### PR TITLE
feat(Headset): add headset controller glance events - resolves #241

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/DeviceFinder.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/DeviceFinder.cs
@@ -79,5 +79,10 @@
         {
             return GameObject.FindObjectOfType<SteamVR_Camera>().GetComponent<Transform>();
         }
+
+        public static SteamVR_ControllerManager ControllerManager()
+        {
+            return GameObject.FindObjectOfType<SteamVR_ControllerManager>();
+        }
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_PlayerObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_PlayerObject.cs
@@ -15,7 +15,8 @@ namespace VRTK
             CameraRig,
             Headset,
             Controller,
-            Pointer
+            Pointer,
+            ControllerTracker
         }
 
         public ObjectTypes objectType;

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerTooltips.cs
@@ -27,10 +27,7 @@
 
         public void ShowTips(bool state)
         {
-            foreach (var tooltip in this.GetComponentsInChildren<VRTK_ObjectTooltip>())
-            {
-                tooltip.gameObject.SetActive(state);
-            }
+            this.gameObject.SetActive(state);
         }
 
         private void Start()
@@ -40,6 +37,29 @@
             touchpadInitialised = false;
             appMenuInitialised = false;
             InitialiseTips();
+
+            var controllerGlance = GameObject.FindObjectOfType<VRTK_HeadsetControllerGlance>();
+            if (controllerGlance)
+            {
+                controllerGlance.ControllerGlanceEnter += new ControllerGlanceEventHandler(ShowTooltips);
+                controllerGlance.ControllerGlanceExit += new ControllerGlanceEventHandler(HideTooltips);
+            }
+        }
+
+        private void ShowTooltips(object sender, ControllerGlanceEventArgs e)
+        {
+            if (e.controller == this.transform.parent.gameObject)
+            {
+                ShowTips(true);
+            }
+        }
+
+        private void HideTooltips(object sender, ControllerGlanceEventArgs e)
+        {
+            if (e.controller == this.transform.parent.gameObject)
+            {
+                ShowTips(false);
+            }
         }
 
         private void InitialiseTips()
@@ -94,6 +114,7 @@
 
                 tooltip.Reset();
             }
+            ShowTips(false);
         }
 
         private bool TipsInitialised()

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetControllerGlance.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetControllerGlance.cs
@@ -1,0 +1,88 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections;
+
+    public struct ControllerGlanceEventArgs
+    {
+        public float distance;
+        public GameObject controller;
+    }
+
+    public delegate void ControllerGlanceEventHandler(object sender, ControllerGlanceEventArgs e);
+
+    public class VRTK_HeadsetControllerGlance : MonoBehaviour
+    {
+        public float colliderRadius = 0.12f;
+        public event ControllerGlanceEventHandler ControllerGlanceEnter;
+        public event ControllerGlanceEventHandler ControllerGlanceExit;
+
+        private GameObject controllerHit = null;
+
+        public virtual void OnControllerGlanceEnter(ControllerGlanceEventArgs e)
+        {
+            if (ControllerGlanceEnter != null)
+                ControllerGlanceEnter(this, e);
+        }
+
+        public virtual void OnControllerGlanceExit(ControllerGlanceEventArgs e)
+        {
+            if (ControllerGlanceExit != null)
+                ControllerGlanceExit(this, e);
+        }
+
+        private void Start()
+        {
+            var controllerManager = DeviceFinder.ControllerManager();
+            CreateControllerTracker(controllerManager.left);
+            CreateControllerTracker(controllerManager.right);
+        }
+
+        private void Update()
+        {
+            var ray = new Ray(this.transform.position, this.transform.forward);
+            RaycastHit hit;
+            var hasHit = Physics.Raycast(ray, out hit, 10f);
+            if (!hasHit && controllerHit != null)
+            {
+                OnControllerGlanceExit(SetControllerGlanceEvent(0f, controllerHit));
+                controllerHit = null;
+            }
+
+            if (hasHit && hit.collider.GetComponent<VRTK_PlayerObject>() && hit.collider.GetComponent<VRTK_PlayerObject>().objectType == VRTK_PlayerObject.ObjectTypes.ControllerTracker)
+            {
+                if(controllerHit != hit.collider.transform.parent.gameObject)
+                {
+                    if (controllerHit != null)
+                    {
+                        OnControllerGlanceExit(SetControllerGlanceEvent(0f, controllerHit));
+                        controllerHit = null;
+                    }
+
+                    controllerHit = hit.collider.transform.parent.gameObject;
+                    OnControllerGlanceEnter(SetControllerGlanceEvent(hit.distance, controllerHit));
+                }
+            }
+        }
+
+        private ControllerGlanceEventArgs SetControllerGlanceEvent(float distance, GameObject controller)
+        {
+            ControllerGlanceEventArgs e;
+            e.distance = distance;
+            e.controller = controller;
+            return e;
+        }
+
+        private void CreateControllerTracker(GameObject controller)
+        {
+            var tracker = new GameObject("HeadsetRay_Tracker");
+            tracker.transform.parent = controller.transform;
+            tracker.transform.localPosition = new Vector3(0f, 0f, 0f);
+            var collider = tracker.AddComponent<SphereCollider>();
+            collider.radius = colliderRadius;
+            collider.center = new Vector3(0f, 0f, -0.04f);
+            collider.isTrigger = true;
+            tracker.AddComponent<VRTK_PlayerObject>().objectType = VRTK_PlayerObject.ObjectTypes.ControllerTracker;
+        }
+    }
+}

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetControllerGlance.cs.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetControllerGlance.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0a444fa1f89117d41a0cd9528c16c7ec
+timeCreated: 1467921675
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Headset Controller Glance script allows for an event to be emitted
when the headset is looking at either of the controllers.