### PR TITLE
NavMesh areas selectable in editor

### DIFF
--- a/Assets/VRTK/Editor/VRTK_BasicTeleportEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_BasicTeleportEditor.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+using UnityEditor;
+using VRTK;
+
+[CustomEditor(typeof(VRTK_BasicTeleport), true)]
+public class VRTK_BasicTeleportEditor : Editor
+{
+    public new VRTK_BasicTeleport target { get { return base.target as VRTK_BasicTeleport; } }
+
+    private bool _showLayers;
+
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        _showLayers = EditorGUILayout.Foldout(_showLayers, "NavMesh Layers");
+
+        if (_showLayers)
+        {
+            var currentAreas = this.target.NavMeshLayerMask;
+            var areas = GameObjectUtility.GetNavMeshAreaNames();
+            for (int i = 0; i < areas.Length; i++)
+            {
+                var selected = (currentAreas & (1 << i)) != 0;
+                if (EditorGUILayout.Toggle(areas[i], selected))
+                    this.target.NavMeshLayerMask |= (1 << i);
+                else
+                    this.target.NavMeshLayerMask &= ~(1 << i);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_WorldPointerEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_WorldPointerEditor.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+using UnityEditor;
+using VRTK;
+
+[CustomEditor(typeof(VRTK_WorldPointer), true)]
+public class VRTK_WorldPointerEditor : Editor
+{
+    public new VRTK_WorldPointer target { get { return base.target as VRTK_WorldPointer; } }
+
+    private bool _showLayers;
+
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        _showLayers = EditorGUILayout.Foldout(_showLayers, "NavMesh Layers");
+
+        if (_showLayers)
+        {
+            var currentAreas = this.target.NavMeshLayerMask;
+            var areas = GameObjectUtility.GetNavMeshAreaNames();
+            for (int i = 0; i < areas.Length; i++)
+            {
+                var selected = (currentAreas & (1 << i)) != 0;
+                if (EditorGUILayout.Toggle(areas[i], selected))
+                    this.target.NavMeshLayerMask |= (1 << i);
+                else
+                    this.target.NavMeshLayerMask &= ~(1 << i);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -36,6 +36,13 @@ namespace VRTK
 
         protected bool playAreaCursorCollided = false;
 
+        protected int _navMeshLayerMask = -1;
+        public int NavMeshLayerMask
+        {
+            get { return _navMeshLayerMask; }
+            set { _navMeshLayerMask = value; }
+        }
+
         private Transform playArea;
         private GameObject playAreaCursor;
         private GameObject[] playAreaCursorBoundaries;
@@ -263,15 +270,19 @@ namespace VRTK
         protected virtual bool ValidDestination(Transform target, Vector3 destinationPosition)
         {
             bool validNavMeshLocation = false;
-            if (target)
-            {
-                NavMeshHit hit;
-                validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, 0.1f, NavMesh.AllAreas);
-            }
             if (navMeshCheckDistance == 0f)
             {
                 validNavMeshLocation = true;
             }
+            else
+            {
+                if (target)
+                {
+                    NavMeshHit hit;
+                    validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, navMeshCheckDistance, NavMeshLayerMask);
+                }
+            }
+
             return (validNavMeshLocation && target && target.tag != invalidTargetWithTagOrClass && target.GetComponent(invalidTargetWithTagOrClass) == null);
         }
 

--- a/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
@@ -31,6 +31,13 @@ namespace VRTK
         protected Transform eyeCamera;
         protected bool adjustYForTerrain = false;
         protected bool enableTeleport = true;
+        protected int _navMeshLayerMask = -1;
+        public int NavMeshLayerMask
+        {
+            get { return _navMeshLayerMask; }
+            set { _navMeshLayerMask = value; }
+        }
+
 
         private float blinkPause = 0f;
         private float fadeInTime = 0f;
@@ -110,14 +117,17 @@ namespace VRTK
             }
 
             bool validNavMeshLocation = false;
-            if (target)
-            {
-                NavMeshHit hit;
-                validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, 0.1f, NavMesh.AllAreas);
-            }
             if (navMeshLimitDistance == 0f)
             {
                 validNavMeshLocation = true;
+            }
+            else
+            { 
+                if (target)
+                {
+                    NavMeshHit hit;
+                    validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, navMeshLimitDistance, NavMeshLayerMask);
+                }
             }
 
             return (validNavMeshLocation && target && target.tag != ignoreTargetWithTagOrClass && target.GetComponent(ignoreTargetWithTagOrClass) == null);


### PR DESCRIPTION
Custom editor and property for WorldPointer and BasicTeleport so the user can choose NavMesh areas to check for. Used existing variable for distance check.

The previous check with NavMesh.AllAreas allowed pointer and teleport to not walkable points in some circumstances. This way the user can select areas manually.
