### PR TITLE
fix(Examples): added error checking if no gameobject named Bullet exi…

### DIFF
--- a/Assets/VRTK/Examples/Resources/Scripts/Gun.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/Gun.cs
@@ -16,16 +16,25 @@ public class Gun : VRTK_InteractableObject
     protected override void Start()
     {
         base.Start();
+		Transform bulletTransform = transform.Find ("Bullet");
+		if (!bulletTransform) {
+			Debug.LogError ("VRTK Gun.cs: Unable to find a GameObject named 'Bullet'", gameObject);
+			return;
+		}
         bullet = transform.Find("Bullet").gameObject;
         bullet.SetActive(false);
     }
 
     private void FireBullet()
     {
-        GameObject bulletClone = Instantiate(bullet, bullet.transform.position, bullet.transform.rotation) as GameObject;
-        bulletClone.SetActive(true);
-        Rigidbody rb = bulletClone.GetComponent<Rigidbody>();
-        rb.AddForce(-bullet.transform.forward * bulletSpeed);
-        Destroy(bulletClone, bulletLife);
+		if (bullet) {
+	        GameObject bulletClone = Instantiate(bullet, bullet.transform.position, bullet.transform.rotation) as GameObject;
+	        bulletClone.SetActive(true);
+	        Rigidbody rb = bulletClone.GetComponent<Rigidbody>();
+	        rb.AddForce(-bullet.transform.forward * bulletSpeed);
+	        Destroy(bulletClone, bulletLife);
+		} else {
+			Debug.LogError ("VRTK Gun.cs: Unable to fire bullet since bullet gameobject is not assigned", gameObject);
+		}
     }
 }


### PR DESCRIPTION
…sts as child

When there is no gameobject named Bullet which is referenced by this script
the instantiation fails. Added a simple Debug.LogError() to notify user about this.
