### PR TITLE
fix(Caching): get specific ControllerManager for left/right controller

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVR.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVR.cs
@@ -470,7 +470,14 @@ namespace VRTK
         {
             if (cachedControllerManager == null)
             {
-                cachedControllerManager = FindObjectOfType<SteamVR_ControllerManager>();
+                SteamVR_ControllerManager[] controllerManagers = FindObjectsOfType<SteamVR_ControllerManager>();
+                foreach (SteamVR_ControllerManager cm in controllerManagers)
+                {
+                    if (cm.left && cm.right) 
+                    {
+                        cachedControllerManager = cm;
+                    }
+                }
             }
             return cachedControllerManager;
         }


### PR DESCRIPTION
Adding mixed reality support (externalcamera.cfg in root directory) would throw an error since the SteamVR_ControllerManager assignment was grabbing the MR controller manager (mixed reality requires 2 ControllerManagers). Checking to make sure the left and right hand objects are assigned ensures the proper controller manager is selected.