### PR TITLE
fix(Pointer): rescale the pointer cursor also if no collision

### DIFF
--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -319,13 +319,13 @@ namespace VRTK
 
         protected virtual void CreateObjectInteractor()
         {
-            objectInteractor = new GameObject(string.Format("[{0}]WorldPointer_ObjectIneractor_Holder", gameObject.name));
+            objectInteractor = new GameObject(string.Format("[{0}]WorldPointer_ObjectInteractor_Holder", gameObject.name));
             objectInteractor.transform.SetParent(controller.transform);
             objectInteractor.transform.localPosition = Vector3.zero;
             objectInteractor.layer = LayerMask.NameToLayer("Ignore Raycast");
             Utilities.SetPlayerObject(objectInteractor, VRTK_PlayerObject.ObjectTypes.Pointer);
 
-            var objectInteractorCollider = new GameObject(string.Format("[{0}]WorldPointer_ObjectIneractor_Collider", gameObject.name));
+            var objectInteractorCollider = new GameObject(string.Format("[{0}]WorldPointer_ObjectInteractor_Collider", gameObject.name));
             objectInteractorCollider.transform.SetParent(objectInteractor.transform);
             objectInteractorCollider.transform.localPosition = Vector3.zero;
             objectInteractorCollider.layer = LayerMask.NameToLayer("Ignore Raycast");

--- a/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
@@ -80,6 +80,10 @@ namespace VRTK
                     {
                         pointerTip.transform.forward = transform.forward;
                     }
+                    if (pointerCursorRescaledAlongDistance)
+                    {
+                        pointerTip.transform.localScale = pointerCursorOriginalScale * pointerBeamLength;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Rescale the pointer in `VRTK_SimplePointer.Update()`, when the option to
scale the pointer cursor is on (`pointerCursorRescaledAlongDistance
==true`), also without a collision of the pointer.

Fix 2 typos in VRTK_WorldPointer ("Ineractor" changed to "Interactor").