### PR TITLE
fix(Highlighter): defensive code to prevent nullref

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -405,7 +405,7 @@ namespace VRTK
         /// <param name="globalHighlightColor">The colour to use when highlighting the object.</param>
         public virtual void ToggleHighlight(bool toggle, Color globalHighlightColor)
         {
-            if (highlightOnTouch)
+            if (objectHighlighter && highlightOnTouch)
             {
                 if (toggle && !IsGrabbed())
                 {


### PR DESCRIPTION
Fixes bug with InteractableObject where MissingReferenceException is thrown 
if gameObject is inactive and Highlight is toggled