### PR TITLE
feat(Controller): add headset controller awareness - resolves #241

### DIFF
--- a/Assets/VRTK/Examples/029_Controller_Tooltips.unity
+++ b/Assets/VRTK/Examples/029_Controller_Tooltips.unity
@@ -616,134 +616,6 @@ Transform:
   - {fileID: 633279204}
   m_Father: {fileID: 0}
   m_RootOrder: 2
---- !u!43 &395796612
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.2499999, y: 0, z: 0.9000001}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexBuffer: 000001000400010005000400010002000500020006000500020003000600030007000600030000000700000004000700
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: cccc8c3f0ad7233c020040bf000000000000803f0000803f0000803f0000000000000000cccc8cbf0ad7233c020040bf000000000000803f0000803f0000803f0000803f00000000cccc8cbf0ad7233c0200403f000000000000803f0000803f0000803f0000000000000000cccc8c3f0ad7233c0200403f000000000000803f0000803f0000803f0000803f00000000ffff9f3f0ad7233c686666bf000000000000803f0000803f00000000000000000000803fffff9fbf0ad7233c686666bf000000000000803f0000803f000000000000803f0000803fffff9fbf0ad7233c6866663f000000000000803f0000803f00000000000000000000803fffff9f3f0ad7233c6866663f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.2499999, y: 0, z: 0.9000001}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!4 &633279204 stripped
 Transform:
   m_PrefabParentObject: {fileID: 441652, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
@@ -995,7 +867,7 @@ Prefab:
     - target: {fileID: 3380982, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 395796612}
+      objectReference: {fileID: 1685268658}
     - target: {fileID: 11489174, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
       propertyPath: size
       value: 0
@@ -1068,9 +940,33 @@ Prefab:
       propertyPath: drawInGame
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2348914, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 1974926677}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &1188569438 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 146900, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
+  m_PrefabInternal: {fileID: 1188569437}
+--- !u!114 &1188569439
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1188569438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12afd8fe34ccac44e8b37617988222ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trackLeftController: 1
+  trackRightController: 1
+  controllerGlanceRadius: 0.15
+  customRightControllerOrigin: {fileID: 0}
+  customLeftControllerOrigin: {fileID: 0}
 --- !u!1 &1212594898
 GameObject:
   m_ObjectHideFlags: 0
@@ -1115,10 +1011,167 @@ Transform:
 Transform:
   m_PrefabParentObject: {fileID: 458974, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
   m_PrefabInternal: {fileID: 1188569437}
+--- !u!43 &1685268658
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 6766863f0ad7233c696666bf000000000000803f0000803f0000803f0000000000000000676686bf0ad7233c696666bf000000000000803f0000803f0000803f0000803f00000000676686bf0ad7233c6966663f000000000000803f0000803f0000803f00000000000000006766863f0ad7233c6966663f000000000000803f0000803f0000803f0000803f000000009a99993f0ad7233c686686bf000000000000803f0000803f00000000000000000000803f9a9999bf0ad7233c686686bf000000000000803f0000803f000000000000803f0000803f9a9999bf0ad7233c6866863f000000000000803f0000803f00000000000000000000803f9a99993f0ad7233c6866863f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!4 &1950519925 stripped
 Transform:
   m_PrefabParentObject: {fileID: 402434, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
   m_PrefabInternal: {fileID: 1188569437}
+--- !u!21 &1974926677
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: PixelSnap
+      second: 0
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &2123877843
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -56,6 +56,7 @@ namespace VRTK
         private GameObject[] buttonTooltips;
         private VRTK_ControllerActions controllerActions;
         private bool[] tooltipStates;
+        private VRTK_HeadsetControllerAware headsetControllerAware;
 
         /// <summary>
         /// The ToggleTips method will display the controller tooltips if the state is `true` and will hide the controller tooltips if the state is `false`. An optional `element` can be passed to target a specific controller tooltip to toggle otherwise all tooltips are toggled.
@@ -84,7 +85,7 @@ namespace VRTK
             gripInitialised = false;
             touchpadInitialised = false;
             appMenuInitialised = false;
-            InitialiseTips();
+
             availableButtons = new TooltipButtons[]
             {
                 TooltipButtons.TriggerTooltip,
@@ -100,6 +101,8 @@ namespace VRTK
             {
                 buttonTooltips[i] = transform.FindChild(availableButtons[i].ToString()).gameObject;
             }
+
+            InitialiseTips();
         }
 
         private void OnEnable()
@@ -109,6 +112,14 @@ namespace VRTK
                 controllerActions.ControllerModelVisible += new ControllerActionsEventHandler(DoControllerVisible);
                 controllerActions.ControllerModelInvisible += new ControllerActionsEventHandler(DoControllerInvisible);
             }
+
+            headsetControllerAware = FindObjectOfType<VRTK_HeadsetControllerAware>();
+            if (headsetControllerAware)
+            {
+                headsetControllerAware.ControllerGlanceEnter += new HeadsetControllerAwareEventHandler(DoGlanceEnterController);
+                headsetControllerAware.ControllerGlanceExit += new HeadsetControllerAwareEventHandler(DoGlanceExitController);
+                ToggleTips(false);
+            }
         }
 
         private void OnDisable()
@@ -117,6 +128,12 @@ namespace VRTK
             {
                 controllerActions.ControllerModelVisible -= new ControllerActionsEventHandler(DoControllerVisible);
                 controllerActions.ControllerModelInvisible -= new ControllerActionsEventHandler(DoControllerInvisible);
+            }
+
+            if (headsetControllerAware)
+            {
+                headsetControllerAware.ControllerGlanceEnter -= new HeadsetControllerAwareEventHandler(DoGlanceEnterController);
+                headsetControllerAware.ControllerGlanceExit -= new HeadsetControllerAwareEventHandler(DoGlanceExitController);
             }
         }
 
@@ -135,6 +152,23 @@ namespace VRTK
                 tooltipStates[i] = buttonTooltips[i].activeSelf;
             }
             ToggleTips(false);
+        }
+
+
+        private void DoGlanceEnterController(object sender, HeadsetControllerAwareEventArgs e)
+        {
+            if (VRTK_DeviceFinder.GetControllerIndex(transform.parent.gameObject) == e.controllerIndex)
+            {
+                ToggleTips(true);
+            }
+        }
+
+        private void DoGlanceExitController(object sender, HeadsetControllerAwareEventArgs e)
+        {
+            if (VRTK_DeviceFinder.GetControllerIndex(transform.parent.gameObject) == e.controllerIndex)
+            {
+                ToggleTips(false);
+            }
         }
 
         private void InitialiseTips()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
@@ -1,0 +1,88 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+
+    [RequireComponent(typeof(VRTK_HeadsetControllerAware))]
+    public class VRTK_HeadsetControllerAware_UnityEvents : MonoBehaviour
+    {
+        private VRTK_HeadsetControllerAware hca;
+
+        [System.Serializable]
+        public class UnityObjectEvent : UnityEvent<object, HeadsetControllerAwareEventArgs> { };
+
+        /// <summary>
+        /// Emits the ControllerObscured class event.
+        /// </summary>
+        public UnityObjectEvent OnControllerObscured;
+        /// <summary>
+        /// Emits the ControllerUnobscured class event.
+        /// </summary>
+        public UnityObjectEvent OnControllerUnobscured;
+
+        /// <summary>
+        /// Emits the ControllerGlanceEnter class event.
+        /// </summary>
+        public UnityObjectEvent OnControllerGlanceEnter;
+        /// <summary>
+        /// Emits the ControllerGlanceExit class event.
+        /// </summary>
+        public UnityObjectEvent OnControllerGlanceExit;
+
+        private void SetHeadsetControllerAware()
+        {
+            if (hca == null)
+            {
+                hca = GetComponent<VRTK_HeadsetControllerAware>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            SetHeadsetControllerAware();
+            if (hca == null)
+            {
+                Debug.LogError("The VRTK_HeadsetControllerAware_UnityEvents script requires to be attached to a GameObject that contains a VRTK_HeadsetControllerAware script");
+                return;
+            }
+
+            hca.ControllerObscured += ControllerObscured;
+            hca.ControllerUnobscured += ControllerUnobscured;
+            hca.ControllerGlanceEnter += ControllerGlanceEnter;
+            hca.ControllerGlanceExit += ControllerGlanceExit;
+        }
+
+        private void ControllerObscured(object o, HeadsetControllerAwareEventArgs e)
+        {
+            OnControllerObscured.Invoke(o, e);
+        }
+
+        private void ControllerUnobscured(object o, HeadsetControllerAwareEventArgs e)
+        {
+            OnControllerUnobscured.Invoke(o, e);
+        }
+
+        private void ControllerGlanceEnter(object o, HeadsetControllerAwareEventArgs e)
+        {
+            OnControllerGlanceEnter.Invoke(o, e);
+        }
+
+        private void ControllerGlanceExit(object o, HeadsetControllerAwareEventArgs e)
+        {
+            OnControllerGlanceExit.Invoke(o, e);
+        }
+
+        private void OnDisable()
+        {
+            if (hca == null)
+            {
+                return;
+            }
+
+            hca.ControllerObscured -= ControllerObscured;
+            hca.ControllerUnobscured -= ControllerUnobscured;
+            hca.ControllerGlanceEnter -= ControllerGlanceEnter;
+            hca.ControllerGlanceExit -= ControllerGlanceExit;
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e0dc71c2cb29a594c9108c911edec91a
+timeCreated: 1476557431
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_HeadsetControllerAware.cs
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetControllerAware.cs
@@ -1,0 +1,248 @@
+﻿// Headset Controller Aware|Scripts|0112
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="raycastHit">The Raycast Hit struct of item that is obscuring the path to the controller.</param>
+    /// <param name="controllerIndex">The index of the controller that is being or has been obscured or being or has been glanced.</param>
+    public struct HeadsetControllerAwareEventArgs
+    {
+        public RaycastHit raycastHit;
+        public uint controllerIndex;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="HeadsetControllerAwareEventArgs"/></param>
+    public delegate void HeadsetControllerAwareEventHandler(object sender, HeadsetControllerAwareEventArgs e);
+
+    /// <summary>
+    /// The purpose of Headset Controller Aware is to allow the headset to know if something is blocking the path between the headset and controllers and to know if the headset is looking at a controller.
+    /// </summary>
+    /// <example>
+    /// `VRTK/Examples/029_Controller_Tooltips` displays tooltips that have been added to the controllers and are only visible when the controller is being looked at.
+    /// </example>
+    public class VRTK_HeadsetControllerAware : MonoBehaviour
+    {
+        [Tooltip("If this is checked then the left controller will be checked if items obscure it's path from the headset.")]
+        public bool trackLeftController = true;
+        [Tooltip("If this is checked then the right controller will be checked if items obscure it's path from the headset.")]
+        public bool trackRightController = true;
+        [Tooltip("The radius of the accepted distance from the controller origin point to determine if the controller is being looked at.")]
+        public float controllerGlanceRadius = 0.15f;
+        [Tooltip("A custom transform to provide the world space position of the right controller.")]
+        public Transform customRightControllerOrigin;
+        [Tooltip("A custom transform to provide the world space position of the left controller.")]
+        public Transform customLeftControllerOrigin;
+
+        /// <summary>
+        /// Emitted when the controller is obscured by another object.
+        /// </summary>
+        public event HeadsetControllerAwareEventHandler ControllerObscured;
+        /// <summary>
+        /// Emitted when the controller is no longer obscured by an object.
+        /// </summary>
+        public event HeadsetControllerAwareEventHandler ControllerUnobscured;
+
+        /// <summary>
+        /// Emitted when the controller is seen by the headset view.
+        /// </summary>
+        public event HeadsetControllerAwareEventHandler ControllerGlanceEnter;
+        /// <summary>
+        /// Emitted when the controller is no longer seen by the headset view.
+        /// </summary>
+        public event HeadsetControllerAwareEventHandler ControllerGlanceExit;
+
+        private GameObject leftController;
+        private GameObject rightController;
+        private Transform headset;
+
+        private bool leftControllerObscured = false;
+        private bool rightControllerObscured = false;
+        private bool leftControllerLastState = false;
+        private bool rightControllerLastState = false;
+
+        private bool leftControllerGlance = false;
+        private bool rightControllerGlance = false;
+        private bool leftControllerGlanceLastState = false;
+        private bool rightControllerGlanceLastState = false;
+
+        public virtual void OnControllerObscured(HeadsetControllerAwareEventArgs e)
+        {
+            if (ControllerObscured != null)
+            {
+                ControllerObscured(this, e);
+            }
+        }
+
+        public virtual void OnControllerUnobscured(HeadsetControllerAwareEventArgs e)
+        {
+            if (ControllerUnobscured != null)
+            {
+                ControllerUnobscured(this, e);
+            }
+        }
+
+        public virtual void OnControllerGlanceEnter(HeadsetControllerAwareEventArgs e)
+        {
+            if (ControllerGlanceEnter != null)
+            {
+                ControllerGlanceEnter(this, e);
+            }
+        }
+
+        public virtual void OnControllerGlanceExit(HeadsetControllerAwareEventArgs e)
+        {
+            if (ControllerGlanceExit != null)
+            {
+                ControllerGlanceExit(this, e);
+            }
+        }
+
+        /// <summary>
+        /// The LeftControllerObscured method returns the state of if the left controller is being obscured from the path of the headset.
+        /// </summary>
+        /// <returns>Returns true if the path between the headset and the controller is obscured.</returns>
+        public bool LeftControllerObscured()
+        {
+            return leftControllerObscured;
+        }
+
+        /// <summary>
+        /// The RightControllerObscured method returns the state of if the right controller is being obscured from the path of the headset.
+        /// </summary>
+        /// <returns>Returns true if the path between the headset and the controller is obscured.</returns>
+        public bool RightControllerObscured()
+        {
+            return rightControllerObscured;
+        }
+
+        /// <summary>
+        /// the LeftControllerGlanced method returns the state of if the headset is currently looking at the left controller or not.
+        /// </summary>
+        /// <returns>Returns true if the headset can currently see the controller within the given radius threshold.</returns>
+        public bool LeftControllerGlanced()
+        {
+            return leftControllerGlance;
+        }
+
+        /// <summary>
+        /// the RightControllerGlanced method returns the state of if the headset is currently looking at the right controller or not.
+        /// </summary>
+        /// <returns>Returns true if the headset can currently see the controller within the given radius threshold.</returns>
+        public bool RightControllerGlanced()
+        {
+            return rightControllerGlance;
+        }
+
+        private void OnEnable()
+        {
+            headset = VRTK_DeviceFinder.HeadsetTransform();
+            leftController = VRTK_DeviceFinder.GetControllerLeftHand();
+            rightController = VRTK_DeviceFinder.GetControllerRightHand();
+        }
+
+        private void OnDisable()
+        {
+            leftController = null;
+            rightController = null;
+        }
+
+        private void Update()
+        {
+            if (trackLeftController)
+            {
+                RayCastToController(leftController, customLeftControllerOrigin, ref leftControllerObscured, ref leftControllerLastState);
+            }
+            if (trackRightController)
+            {
+                RayCastToController(rightController, customRightControllerOrigin, ref rightControllerObscured, ref rightControllerLastState);
+            }
+
+            CheckHeadsetView(leftController, customLeftControllerOrigin, ref leftControllerGlance, ref leftControllerGlanceLastState);
+            CheckHeadsetView(rightController, customRightControllerOrigin, ref rightControllerGlance, ref rightControllerGlanceLastState);
+        }
+
+        private HeadsetControllerAwareEventArgs SetHeadsetControllerAwareEvent(RaycastHit raycastHit, uint controllerIndex)
+        {
+            HeadsetControllerAwareEventArgs e;
+            e.raycastHit = raycastHit;
+            e.controllerIndex = controllerIndex;
+            return e;
+        }
+
+        private void RayCastToController(GameObject controller, Transform customDestination, ref bool obscured, ref bool lastState)
+        {
+            obscured = false;
+            if (controller && controller.activeInHierarchy)
+            {
+                var destination = (customDestination ? customDestination.position : controller.transform.position);
+                RaycastHit hitInfo;
+                if (Physics.Linecast(headset.position, destination, out hitInfo))
+                {
+                    obscured = true;
+                }
+
+                if (lastState != obscured)
+                {
+                    ObscuredStateChanged(controller, obscured, hitInfo);
+                }
+
+                lastState = obscured;
+            }
+        }
+
+        private void ObscuredStateChanged(GameObject controller, bool obscured, RaycastHit hitInfo)
+        {
+            if (obscured)
+            {
+                OnControllerObscured(SetHeadsetControllerAwareEvent(hitInfo, VRTK_DeviceFinder.GetControllerIndex(controller)));
+            }
+            else
+            {
+                OnControllerUnobscured(SetHeadsetControllerAwareEvent(hitInfo, VRTK_DeviceFinder.GetControllerIndex(controller)));
+            }
+        }
+
+        private void CheckHeadsetView(GameObject controller, Transform customDestination, ref bool controllerGlance, ref bool controllerGlanceLastState)
+        {
+            controllerGlance = false;
+            if (controller && controller.activeInHierarchy)
+            {
+                var controllerPosition = (customDestination ? customDestination.position : controller.transform.position);
+                var distanceFromHeadsetToController = Vector3.Distance(headset.position, controllerPosition);
+                var lookPoint = headset.position + (headset.forward * distanceFromHeadsetToController);
+
+                if (Vector3.Distance(controllerPosition, lookPoint) <= controllerGlanceRadius)
+                {
+                    controllerGlance = true;
+                }
+
+                if (controllerGlanceLastState != controllerGlance)
+                {
+                    GlanceStateChanged(controller, controllerGlance);
+                }
+
+                controllerGlanceLastState = controllerGlance;
+            }
+        }
+
+        private void GlanceStateChanged(GameObject controller, bool glance)
+        {
+            var emptyHit = new RaycastHit();
+            if (glance)
+            {
+                OnControllerGlanceEnter(SetHeadsetControllerAwareEvent(emptyHit, VRTK_DeviceFinder.GetControllerIndex(controller)));
+            }
+            else
+            {
+                OnControllerGlanceExit(SetHeadsetControllerAwareEvent(emptyHit, VRTK_DeviceFinder.GetControllerIndex(controller)));
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/VRTK_HeadsetControllerAware.cs.meta
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetControllerAware.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 12afd8fe34ccac44e8b37617988222ba
+timeCreated: 1475848219
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -692,6 +692,7 @@ This directory contains all of the toolkit scripts that add VR functionality to 
  * [Headset Collision](#headset-collision-vrtk_headsetcollision)
  * [Headset Fade](#headset-fade-vrtk_headsetfade)
  * [Headset Collision Fade](#headset-collision-fade-vrtk_headsetcollisionfade)
+ * [Headset Controller Aware](#headset-controller-aware-vrtk_headsetcontrolleraware)
  * [Teleport Disable On Headset Collision](#teleport-disable-on-headset-collision-vrtk_teleportdisableonheadsetcollision)
  * [Player Presence](#player-presence-vrtk_playerpresence)
  * [Hip Tracking](#hip-tracking-vrtk_hip_tracking)
@@ -1850,6 +1851,93 @@ The Headset Collision Fade uses a composition of the Headset Collision and Heads
 ### Example
 
 `VRTK/Examples/011_Camera_HeadSetCollisionFading` has collidable walls around the play area and if the user puts their head into any of the walls then the headset will fade to black.
+
+---
+
+## Headset Controller Aware (VRTK_HeadsetControllerAware)
+
+### Overview
+
+The purpose of Headset Controller Aware is to allow the headset to know if something is blocking the path between the headset and controllers and to know if the headset is looking at a controller.
+
+### Inspector Parameters
+
+ * **Track Left Controller:** If this is checked then the left controller will be checked if items obscure it's path from the headset.
+ * **Track Right Controller:** If this is checked then the right controller will be checked if items obscure it's path from the headset.
+ * **Controller Glance Radius:** The radius of the accepted distance from the controller origin point to determine if the controller is being looked at.
+ * **Custom Right Controller Origin:** A custom transform to provide the world space position of the right controller.
+ * **Custom Left Controller Origin:** A custom transform to provide the world space position of the left controller.
+
+### Class Events
+
+ * `ControllerObscured` - Emitted when the controller is obscured by another object.
+ * `ControllerUnobscured` - Emitted when the controller is no longer obscured by an object.
+ * `ControllerGlanceEnter` - Emitted when the controller is seen by the headset view.
+ * `ControllerGlanceExit` - Emitted when the controller is no longer seen by the headset view.
+
+### Unity Events
+
+Adding the `VRTK_HeadsetControllerAware_UnityEvents` component to `VRTK_HeadsetControllerAware` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * `OnControllerObscured` - Emits the ControllerObscured class event.
+ * `OnControllerUnobscured` - Emits the ControllerUnobscured class event.
+ * `OnControllerGlanceEnter` - Emits the ControllerGlanceEnter class event.
+ * `OnControllerGlanceExit` - Emits the ControllerGlanceExit class event.
+
+### Event Payload
+
+ * `RaycastHit raycastHit` - The Raycast Hit struct of item that is obscuring the path to the controller.
+ * `uint controllerIndex` - The index of the controller that is being or has been obscured or being or has been glanced.
+
+### Class Methods
+
+#### LeftControllerObscured/0
+
+  > `public bool LeftControllerObscured()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the path between the headset and the controller is obscured.
+
+The LeftControllerObscured method returns the state of if the left controller is being obscured from the path of the headset.
+
+#### RightControllerObscured/0
+
+  > `public bool RightControllerObscured()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the path between the headset and the controller is obscured.
+
+The RightControllerObscured method returns the state of if the right controller is being obscured from the path of the headset.
+
+#### LeftControllerGlanced/0
+
+  > `public bool LeftControllerGlanced()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the headset can currently see the controller within the given radius threshold.
+
+the LeftControllerGlanced method returns the state of if the headset is currently looking at the left controller or not.
+
+#### RightControllerGlanced/0
+
+  > `public bool RightControllerGlanced()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the headset can currently see the controller within the given radius threshold.
+
+the RightControllerGlanced method returns the state of if the headset is currently looking at the right controller or not.
+
+### Example
+
+`VRTK/Examples/029_Controller_Tooltips` displays tooltips that have been added to the controllers and are only visible when the controller is being looked at.
 
 ---
 


### PR DESCRIPTION
The Headset Controller Aware script provides the ability to have the
headset aware of where the controllers are in relation to the headset.

Two key elements are provided:

 * The headset can track if the controllers are being obscured from a
 direct path between the headset and controller.
 * The headset can know when it is looking at a controller.

If a controller is obscured from the headset then an event is emitted
as well as when the controller is no longer obscured.

Also, when the headset looks (glances) at a controller then an event
is emitted.

The Controller Tooltips prefab has been updated to only show the
controller tooltips when the controller is being looked at.