### PR TITLE
feat(Controller): add prefab to auto enable rigidbody on controller

### DIFF
--- a/Assets/VRTK/Prefabs/ControllerRigidbodyActivator.prefab
+++ b/Assets/VRTK/Prefabs/ControllerRigidbodyActivator.prefab
@@ -1,0 +1,82 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1000011401907096}
+  m_IsPrefabParent: 1
+--- !u!1 &1000011401907096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000014230070706}
+  - 135: {fileID: 135000011948786534}
+  - 54: {fileID: 54000011260950592}
+  - 114: {fileID: 114000011069860120}
+  m_Layer: 0
+  m_Name: ControllerRigidbodyActivator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4000014230070706
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011401907096}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!54 &54000011260950592
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011401907096}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 2
+--- !u!114 &114000011069860120
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011401907096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a45ca363358b3cd40872c8608ca3743b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!135 &135000011948786534
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011401907096}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.1
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/VRTK/Prefabs/ControllerRigidbodyActivator.prefab.meta
+++ b/Assets/VRTK/Prefabs/ControllerRigidbodyActivator.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33a096ef14a38e543af97bd67de0db31
+timeCreated: 1476601232
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs
@@ -1,0 +1,39 @@
+﻿// Controller Rigidbody Activator|Prefabs|0033
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// This adds a simple trigger collider volume that when a controller enters will enable the rigidbody on the controller.
+    /// </summary>
+    /// <remarks>
+    /// The prefab game object should be placed in the scene where another interactable game object (such as a button control) is located to turn the controller rigidbody on at the appropriate time for interaction with the control without needing to manually activate by pressing the grab.
+    /// 
+    /// If the prefab is placed as a child of the target interactable game object then the collider volume on the prefab will trigger collisions on the interactable object.
+    ///
+    /// The sphere collider on the prefab can have the radius adjusted to determine how close the controller needs to be to the object before the rigidbody is activated.
+    ///
+    /// It's also possible to replace the sphere trigger collider with an alternative trigger collider for customised collision detection.
+    /// </remarks>
+    public class VRTK_ControllerRigidbodyActivator : MonoBehaviour
+    {
+        private void OnTriggerEnter(Collider collider)
+        {
+            ToggleRigidbody(collider, true);
+        }
+
+        private void OnTriggerExit(Collider collider)
+        {
+            ToggleRigidbody(collider, false);
+        }
+
+        private void ToggleRigidbody(Collider collider, bool state)
+        {
+            var touch = collider.GetComponentInParent<VRTK_InteractTouch>();
+            if (touch)
+            {
+                touch.ToggleControllerRigidBody(state, state);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs.meta
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a45ca363358b3cd40872c8608ca3743b
+timeCreated: 1476598852
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -573,7 +573,7 @@ namespace VRTK
 
             if (createRigidBodyWhenNotTouching && grabbedObject == null)
             {
-                if (interactTouch.IsRigidBodyActive() != controllerEvents.grabPressed)
+                if (!interactTouch.IsRigidBodyForcedActive() && interactTouch.IsRigidBodyActive() != controllerEvents.grabPressed)
                 {
                     interactTouch.ToggleControllerRigidBody(controllerEvents.grabPressed);
                 }

--- a/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
@@ -62,6 +62,7 @@ namespace VRTK
         private bool triggerIsColliding = false;
         private bool triggerWasColliding = false;
         private Rigidbody touchRigidBody;
+        private bool rigidBodyForcedActive = false;
         private Object defaultColliderPrefab;
         private VRTK_ControllerEvents.ButtonAlias originalGrabAlias;
         private VRTK_ControllerEvents.ButtonAlias originalUseAlias;
@@ -145,11 +146,13 @@ namespace VRTK
         /// The ToggleControllerRigidBody method toggles the controller's rigidbody's ability to detect collisions. If it is true then the controller rigidbody will collide with other collidable game objects.
         /// </summary>
         /// <param name="state">The state of whether the rigidbody is on or off. `true` toggles the rigidbody on and `false` turns it off.</param>
-        public void ToggleControllerRigidBody(bool state)
+        /// <param name="forceToggle">Determines if the rigidbody has been forced into it's new state by another script. This can be used to override other non-force settings. Defaults to `false`</param>
+        public void ToggleControllerRigidBody(bool state, bool forceToggle = false)
         {
             if (controllerCollisionDetector && touchRigidBody)
             {
                 touchRigidBody.isKinematic = !state;
+                rigidBodyForcedActive = forceToggle;
                 foreach (var collider in controllerCollisionDetector.GetComponentsInChildren<Collider>())
                 {
                     collider.isTrigger = !state;
@@ -164,6 +167,15 @@ namespace VRTK
         public bool IsRigidBodyActive()
         {
             return !touchRigidBody.isKinematic;
+        }
+
+        /// <summary>
+        /// The IsRigidBodyForcedActive method checks to see if the rigidbody on the controller object has been forced into the active state.
+        /// </summary>
+        /// <returns>Is true if the rigidbody is active and has been forced into the active state.</returns>
+        public bool IsRigidBodyForcedActive()
+        {
+            return (IsRigidBodyActive() && rigidBodyForcedActive);
         }
 
         /// <summary>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -17,6 +17,7 @@ A collection of pre-defined usable prefabs have been included to allow for each 
  * [Frames Per Second Canvas](#frames-per-second-canvas-vrtk_framespersecondviewer)
  * [Object Tooltip](#object-tooltip-vrtk_objecttooltip)
  * [Controller Tooltips](#controller-tooltips-vrtk_controllertooltips)
+ * [Controller Rigidbody Activator](#controller-rigidbody-activator-vrtk_controllerrigidbodyactivator)
  * [Radial Menu](#radial-menu-radialmenu)
  * [Independent Radial Menu Controller](#independent-radial-menu-controller-vrtk_independentradialmenucontroller)
  * [Console Viewer Canvas](#console-viewer-canvas-vrtk_consoleviewer)
@@ -132,6 +133,22 @@ The ToggleTips method will display the controller tooltips if the state is `true
 ### Example
 
 `VRTK/Examples/029_Controller_Tooltips` displays two cubes that have an object tooltip added to them along with tooltips that have been added to the controllers.
+
+---
+
+## Controller Rigidbody Activator (VRTK_ControllerRigidbodyActivator)
+
+### Overview
+
+This adds a simple trigger collider volume that when a controller enters will enable the rigidbody on the controller.
+
+The prefab game object should be placed in the scene where another interactable game object (such as a button control) is located to turn the controller rigidbody on at the appropriate time for interaction with the control without needing to manually activate by pressing the grab.
+
+If the prefab is placed as a child of the target interactable game object then the collider volume on the prefab will trigger collisions on the interactable object.
+
+The sphere collider on the prefab can have the radius adjusted to determine how close the controller needs to be to the object before the rigidbody is activated.
+
+It's also possible to replace the sphere trigger collider with an alternative trigger collider for customised collision detection.
 
 ---
 
@@ -2556,12 +2573,13 @@ The GetTouchedObject method returns the current object being touched by the cont
 
 The IsObjectInteractable method is used to check if a given game object is of type `VRTK_InteractableObject` and whether the object is enabled.
 
-#### ToggleControllerRigidBody/1
+#### ToggleControllerRigidBody/2
 
-  > `public void ToggleControllerRigidBody(bool state)`
+  > `public void ToggleControllerRigidBody(bool state, bool forceToggle = false)`
 
   * Parameters
    * `bool state` - The state of whether the rigidbody is on or off. `true` toggles the rigidbody on and `false` turns it off.
+   * `bool forceToggle` - Determines if the rigidbody has been forced into it's new state by another script. This can be used to override other non-force settings. Defaults to `false`
   * Returns
    * _none_
 
@@ -2577,6 +2595,17 @@ The ToggleControllerRigidBody method toggles the controller's rigidbody's abilit
    * `bool` - Is true if the rigidbody on the controller is currently active and able to affect other scene rigidbodies.
 
 The IsRigidBodyActive method checks to see if the rigidbody on the controller object is active and can affect other rigidbodies in the scene.
+
+#### IsRigidBodyForcedActive/0
+
+  > `public bool IsRigidBodyForcedActive()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Is true if the rigidbody is active and has been forced into the active state.
+
+The IsRigidBodyForcedActive method checks to see if the rigidbody on the controller object has been forced into the active state.
 
 #### ForceStopTouching/0
 


### PR DESCRIPTION
A new Controller Rigidbody Activator prefab has been added that is an
empty game object with a sphere trigger collider and a script that
listens for the controller entering the collider and turns on the
controller rigidbody automatically instead of needing to press the
grab button on the controller to activate it.