### PR TITLE
feat(Interaction): change velocity of thrown object

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -331,6 +331,8 @@ namespace VRTK
                 rb.velocity = velocity * (throwMultiplier * objectThrowMultiplier);
                 rb.angularVelocity = angularVelocity;
             }
+
+            rb.velocity = rb.GetPointVelocity(rb.position + (rb.position - transform.position));
         }
 
         private bool GrabInteractedObject()


### PR DESCRIPTION
…ce from controller

Based on article at http://www.normalvr.com/blog/throwing-throw-down/

Currently when throwing grabbed object, the velocity is based on center of steam controller.
Change to increase velocity based on distance object is attached to controller.
Example: Ball at end of stick will move at greater speed, compared to where stick is being held.