### PR TITLE
feat(Interaction): add grab to pointer tip - resolves #683

### DIFF
--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -41,6 +41,8 @@ namespace VRTK
         public bool holdButtonToActivate = true;
         [Tooltip("If this is checked then the pointer will be an extension of the controller and able to interact with Interactable Objects.")]
         public bool interactWithObjects = false;
+        [Tooltip("If `Interact With Objects` is checked and this is checked then when an object is grabbed with the pointer touching it, the object will attach to the pointer tip and not snap to the controller.")]
+        public bool grabToPointerTip = false;
         [Tooltip("The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.")]
         public float activateDelay = 0f;
         [Tooltip("Determines when the pointer beam should be displayed.")]
@@ -56,12 +58,17 @@ namespace VRTK
         protected VRTK_PlayAreaCursor playAreaCursor;
         protected Color currentPointerColor;
         protected GameObject objectInteractor;
+        protected GameObject objectInteractorAttachPoint;
 
         private bool isActive;
         private bool destinationSetActive;
         private float activateDelayTimer = 0f;
         private int beamEnabledState = 0;
         private VRTK_InteractableObject interactableObject = null;
+        private Rigidbody savedAttachPoint;
+        private bool attachedToInteractorAttachPoint = false;
+        private float savedBeamLength = 0f;
+        private VRTK_InteractGrab controllerGrabScript;
 
         /// <summary>
         /// The IsActive method is used to determine if the pointer currently active.
@@ -119,6 +126,8 @@ namespace VRTK
             controller.AliasPointerOff += new ControllerInteractionEventHandler(DisablePointerBeam);
             controller.AliasPointerSet += new ControllerInteractionEventHandler(SetPointerDestination);
 
+            controllerGrabScript = controller.GetComponent<VRTK_InteractGrab>();
+
             var tmpMaterial = Resources.Load("WorldPointer") as Material;
             if (pointerMaterial != null)
             {
@@ -149,6 +158,7 @@ namespace VRTK
             controller.AliasPointerOn -= new ControllerInteractionEventHandler(EnablePointerBeam);
             controller.AliasPointerOff -= new ControllerInteractionEventHandler(DisablePointerBeam);
             controller.AliasPointerSet -= new ControllerInteractionEventHandler(SetPointerDestination);
+            controllerGrabScript = null;
         }
 
         protected virtual void Update()
@@ -268,10 +278,7 @@ namespace VRTK
 
         protected virtual void TogglePointer(bool state)
         {
-            if (interactWithObjects)
-            {
-                objectInteractor.SetActive(state);
-            }
+            ToggleObjectInteraction(state);
 
             if (playAreaCursor)
             {
@@ -282,6 +289,33 @@ namespace VRTK
             if (!state && PointerActivatesUseAction(interactableObject) && interactableObject.holdButtonToUse && interactableObject.IsUsing())
             {
                 interactableObject.StopUsing(gameObject);
+            }
+        }
+
+        protected virtual void ToggleObjectInteraction(bool state)
+        {
+            if (interactWithObjects)
+            {
+                if (state && grabToPointerTip && controllerGrabScript)
+                {
+                    savedAttachPoint = controllerGrabScript.controllerAttachPoint;
+                    controllerGrabScript.controllerAttachPoint = objectInteractorAttachPoint.GetComponent<Rigidbody>();
+                    attachedToInteractorAttachPoint = true;
+                }
+
+                if (!state && grabToPointerTip && controllerGrabScript)
+                {
+                    if (attachedToInteractorAttachPoint)
+                    {
+                        controllerGrabScript.ForceRelease(true);
+                    }
+                    controllerGrabScript.controllerAttachPoint = savedAttachPoint;
+                    savedAttachPoint = null;
+                    attachedToInteractorAttachPoint = false;
+                    savedBeamLength = 0f;
+                }
+
+                objectInteractor.SetActive(state);
             }
         }
 
@@ -355,9 +389,32 @@ namespace VRTK
             tmpCollider.isTrigger = true;
             Utilities.SetPlayerObject(objectInteractorCollider, VRTK_PlayerObject.ObjectTypes.Pointer);
 
+            if (grabToPointerTip)
+            {
+                objectInteractorAttachPoint = new GameObject(string.Format("[{0}]WorldPointer_ObjectInteractor_AttachPoint", gameObject.name));
+                objectInteractorAttachPoint.transform.SetParent(objectInteractor.transform);
+                objectInteractorAttachPoint.transform.localPosition = Vector3.zero;
+                objectInteractorAttachPoint.layer = LayerMask.NameToLayer("Ignore Raycast");
+                var objectInteratorRigidBody = objectInteractorAttachPoint.AddComponent<Rigidbody>();
+                objectInteratorRigidBody.isKinematic = true;
+                objectInteratorRigidBody.freezeRotation = true;
+                objectInteratorRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+                Utilities.SetPlayerObject(objectInteractorAttachPoint, VRTK_PlayerObject.ObjectTypes.Pointer);
+            }
+
             var objectInteractorScale = 0.025f;
             objectInteractor.transform.localScale = new Vector3(objectInteractorScale, objectInteractorScale, objectInteractorScale);
             objectInteractor.SetActive(false);
+        }
+
+        protected virtual float OverrideBeamLength(float currentLength)
+        {
+            if (interactWithObjects && grabToPointerTip && attachedToInteractorAttachPoint && controllerGrabScript && controllerGrabScript.GetGrabbedObject())
+            {
+                savedBeamLength = (savedBeamLength == 0 ? currentLength : savedBeamLength);
+                return savedBeamLength;
+            }
+            return currentLength;
         }
 
         private bool InvalidConstantBeam()

--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -80,7 +80,8 @@ namespace VRTK
         /// <summary>
         /// The ForceRelease method will force the controller to stop grabbing the currently grabbed object.
         /// </summary>
-        public void ForceRelease()
+        /// <param name="applyGrabbingObjectVelocity">If this is true then upon releasing the object any velocity on the grabbing object will be applied to the object to essentiall throw it. Defaults to `false`.</param>
+        public void ForceRelease(bool applyGrabbingObjectVelocity = false)
         {
             if (grabbedObject != null && grabbedObject.GetComponent<VRTK_InteractableObject>() && grabbedObject.GetComponent<VRTK_InteractableObject>().AttachIsUnthrowableObject())
             {
@@ -88,7 +89,7 @@ namespace VRTK
             }
             else
             {
-                UngrabInteractedObject(false);
+                UngrabInteractedObject(applyGrabbingObjectVelocity);
             }
         }
 

--- a/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
@@ -88,6 +88,16 @@ namespace VRTK
             }
         }
 
+        protected override void UpdateObjectInteractor()
+        {
+            base.UpdateObjectInteractor();
+            //if the object interactor is too far from the pointer tip then set it to the pointer tip position to prevent glitching.
+            if (Vector3.Distance(objectInteractor.transform.position, pointerTip.transform.position) > 0)
+            {
+                objectInteractor.transform.position = pointerTip.transform.position;
+            }
+        }
+
         protected override void InitPointer()
         {
             pointerHolder = new GameObject(string.Format("[{0}]WorldPointer_SimplePointer_Holder", gameObject.name));
@@ -219,7 +229,7 @@ namespace VRTK
                 actualLength = pointerContactDistance;
             }
 
-            return actualLength;
+            return OverrideBeamLength(actualLength);
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -545,6 +545,7 @@ The play area collider does not work well with terrains as they are uneven and c
  * **Pointer Material:** The material to use on the rendered version of the pointer. If no material is selected then the default `WorldPointer` material will be used.
  * **Hold Button To Activate:** If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.
  * **Interact With Objects:** If this is checked then the pointer will be an extension of the controller and able to interact with Interactable Objects.
+ * **Grab To Pointer Tip:** If `Interact With Objects` is checked and this is checked then when an object is grabbed with the pointer touching it, the object will attach to the pointer tip and not snap to the controller.
  * **Activate Delay:** The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.
  * **Pointer Visibility:** Determines when the pointer beam should be displayed.
  * **Layers To Ignore:** The layers to ignore when raycasting.
@@ -3358,12 +3359,12 @@ Adding the `VRTK_InteractGrab_UnityEvents` component to `VRTK_InteractGrab` obje
 
 ### Class Methods
 
-#### ForceRelease/0
+#### ForceRelease/1
 
-  > `public void ForceRelease()`
+  > `public void ForceRelease(bool applyGrabbingObjectVelocity = false)`
 
   * Parameters
-   * _none_
+   * `bool applyGrabbingObjectVelocity` - If this is true then upon releasing the object any velocity on the grabbing object will be applied to the object to essentiall throw it. Defaults to `false`.
   * Returns
    * _none_
 


### PR DESCRIPTION
A new parameter on the World Pointer can now be set that when a
pointer is set to `Interact With Objects = true` rather than on grab
snapping the object to the controller, it now uses the pointer tip
as the attach point.

The length of the pointer is locked at the point of grabbing so it's
not possible to bring the objects closer or move them further away
but a potential feature in the future could be custom public methods
on the pointer scripts that allow the manual entry of a pointer length
so it could be controller via an input of a controller.