### PR TITLE
fix(DnapDropZone): fix `ValidSnapObject()` not searching parents for `InteractableObject`

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -281,6 +281,9 @@ namespace VRTK
         private VRTK_InteractableObject ValidSnapObject(GameObject checkObject, bool grabState)
         {
             var ioCheck = checkObject.GetComponent<VRTK_InteractableObject>();
+            if (ioCheck == null) {
+                ioCheck = checkObject.GetComponentInParent<VRTK_InteractableObject>();
+            }
             return (ioCheck && ioCheck.IsGrabbed() == grabState && !Utilities.TagOrScriptCheck(checkObject, validObjectTagOrScriptListPolicy, validObjectWithTagOrClass, true) ? ioCheck : null);
         }
 


### PR DESCRIPTION
Right now the snap to drop zone functionality only works if the `Collider`
generating the event is on the same object that has the `InteractableObject`
script. If your Colliders are only on the children things won't work.
This fix makes sure that the `ValidSnapObject()` method also looks in the
parent objects.