### PR TITLE
fix(Throwing): calc throw velocity from center of collision

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -345,7 +345,8 @@ namespace VRTK
                 rb.angularVelocity = angularVelocity;
             }
 
-            rb.velocity = rb.GetPointVelocity(rb.position + (rb.position - transform.position));
+            Vector3 collisionCenter = rb.GetComponent<Collider>().bounds.center;
+            rb.velocity = rb.GetPointVelocity(collisionCenter + (collisionCenter - transform.position));
         }
 
         private bool GrabInteractedObject()


### PR DESCRIPTION
Throwing objects with a non-centered pivot would cause undesired results for objects like spheres with their pivot at the bottom. Suggesting using the center of the collider instead.

This is a proposed fix from #684 
