### PR TITLE
docs(contributing and examples): minor spelling corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ defined in the same file.
 Where possible, the structure of the code should also flow with the
 accessibility level of the method or parameters. So all `public`
 parameters and methods should be defined first, followed by `protected`
-paramters and methods with `private` parameters and methods being
+parameters and methods with `private` parameters and methods being
 defined last.
 
 Blocks of code such as conditional statements and loops must always
@@ -80,7 +80,7 @@ it's not necessary.
 
 e.g.
 
-  * `this.transform.rotation` is simplfied to `transform.rotation`
+  * `this.transform.rotation` is simplified to `transform.rotation`
   * `GameObject.FindObjectsOfType` is simplified to `FindObjectsOfType`
 
 ## Documentation
@@ -142,7 +142,7 @@ be entered in the following format:
 
 ### Type
 
-The type must be one of the folowing:
+The type must be one of the following:
 
   * feat: A new feature
   * fix: A bug fix
@@ -155,7 +155,7 @@ The type must be one of the folowing:
 
 ### Scope
 
-The scope could be anything specifiyng the place of the commit change,
+The scope could be anything specifying the place of the commit change,
 such as, `Controller`, `Interaction`, `Locomotion`, etc...
 
 ### Subject

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -234,7 +234,7 @@ A scene that uses the `VRTK_SnapDropZone` prefab to set up pre-determined snap z
 
 ### 042_CameraRig_MoveInPlace
 
-A scene that demonstrates how the user can move and traverse colliders by either swinging the controllers in a walking fashion or by running on the spot utilisng the head bob for movement.
+A scene that demonstrates how the user can move and traverse colliders by either swinging the controllers in a walking fashion or by running on the spot utilising the head bob for movement.
 
 ### 043_Controller_SecondaryControllerActions
 


### PR DESCRIPTION
Noticed a couple of spelling errors when reading contribution doc. Fixed
these along with some other I found when running them through and editor.