### PR TITLE
fix(AdaptiveQuality): prevent flickering on Unity 5.4.3

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -337,7 +337,7 @@ namespace VRTK
             timing.SaveCurrentFrameTiming();
         }
 
-#if UNITY_5_4_1 || UNITY_5_4_2 || UNITY_5_5_OR_NEWER
+#if UNITY_5_4_1 || UNITY_5_4_2 || UNITY_5_4_3 || UNITY_5_5_OR_NEWER
         private void LateUpdate()
         {
             UpdateRenderScale();
@@ -351,7 +351,7 @@ namespace VRTK
                 return;
             }
 
-#if !(UNITY_5_4_1 || UNITY_5_4_2 || UNITY_5_5_OR_NEWER)
+#if !(UNITY_5_4_1 || UNITY_5_4_2 || UNITY_5_4_3 || UNITY_5_5_OR_NEWER)
             UpdateRenderScale();
 #endif
             UpdateMSAALevel();


### PR DESCRIPTION
Whenever the render scale is changed the old frame is visible for some
time, looking like flickering when `AdaptiveQuality` is enabled. The
fix is to change the render scale in `LateUpdate` on Unity 5.4.3, too.