### PR TITLE
chore(README): reformat readme and split out things made with vrtk list

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,7 +2,11 @@
 
 This directory contains Unity3d scenes that demonstrate the scripts and prefabs being used in the game world to create desired functionality.
 
+The examples have all been built to work with the SteamVR Plugin by default, but they can be converted over to using the Oculus Utilities package by following the instructions for using the Oculus Utilities package in the README.md.
+
 There is also a `/Resources/Scripts` directory within the `VRTK/Examples` directory that contains helper scripts utilised by the example scenes to highlight certain functionality (such as event listeners). These example scripts are not required for real world usage.
+
+> *If the examples are not working on first load, click the `[VRTK]` GameObject in the scene hierarchy to ensure the SDK Manager editor script successfully sets up the project and scene.*
 
 ## Current Examples
 

--- a/MADEWITHVRTK.md
+++ b/MADEWITHVRTK.md
@@ -1,0 +1,41 @@
+# Made With VRTK
+
+A collection of titles that have been made with VRTK.
+
+| Name | Link |
+|-------------------------------------------------|-------------------------------------------------------------------------------------------|
+| QuiVR | [Steam Store Page](http://store.steampowered.com/app/489380) |
+| Left-Hand Path | [Steam Store Page](http://store.steampowered.com/app/488760) |
+| Holodaze | [Steam Store Page](http://store.steampowered.com/app/475520) |
+| ViveSpray | [Steam Store Page](http://store.steampowered.com/app/494830) |
+| VeeR Pong | [Steam Store Page](http://store.steampowered.com/app/494850) |
+| Emergence Fractal Universe | [Steam Store Page](http://store.steampowered.com/app/500470) |
+| Ocarina of Vive | [Itch.io Store Page](https://tomcat94.itch.io/ocarina-of-vive-shooting-gallery) |
+| Danc<R | [Itch.io Store Page](https://tomcat94.itch.io/dancr-alpha) |
+| Tower Island: Explore, Discover and Disassemble | [Steam Store Page](http://store.steampowered.com/app/487740) |
+| Virtual Warfighter | [Steam Store Page](http://store.steampowered.com/app/517020) |
+| VR Regatta | [Steam Store Page](http://store.steampowered.com/app/468240) |
+| Car Car Crash Hands | [Steam Store Page](http://store.steampowered.com/app/472720) |
+| MegaPolice | [Youtube Trailer](https://www.youtube.com/watch?v=d6hCgfMxldY) |
+| The Crystal Nebula | [Steam Store Page](http://store.steampowered.com/app/505660) |
+| Drone Training VR | [Youtube Trailer](https://www.youtube.com/watch?v=A5MFT2JsySc) |
+| Cogs and Cowboys | [Steam Store Page](http://store.steampowered.com/app/510410) |
+| Frantic Freighter | [Steam Store Page](http://store.steampowered.com/app/503150) |
+| Redswood VR | [Steam Store Page](http://store.steampowered.com/app/499760) |
+| Wrath Of The Fire God | [Steam Store Page](http://store.steampowered.com/app/511370) |
+| Coinvault | [Itch.io Store Page](https://ldvr.itch.io/ldvrs-coinvault-for-the-vive) |
+| VR Explosive Kitten Toss | [Itch.io Store Page](https://ldvr.itch.io/ldvrs-kitten-toss) |
+| Zika VR | [Itch.io Store Page](https://ldvr.itch.io/ldvr-presents-zika-vr) |
+| Domino VR | [Steam Store Page](http://store.steampowered.com/app/508680) |
+| One Of The Last | [Steam Store Page](http://store.steampowered.com/app/550360) |
+| The Days After | [Game website](http://www.fivefingerstudios.com/thedaysafter) |
+| Quantized | [Steam Greenlight Page](https://steamcommunity.com/sharedfiles/filedetails/?id=195344075) |
+| Caketomino | [Steam Store Page](http://store.steampowered.com/app/517770) |
+| Escape Station | [Steam Store Page](http://store.steampowered.com/app/527360) |
+| Outrageous Grounds: The Maze | [Steam Store Page](http://store.steampowered.com/app/513050) |
+| Draco Dux | [Steam Store Page](http://store.steampowered.com/app/460730) |
+| Deisim | [Steam Store Page](http://store.steampowered.com/app/525680) |
+| Potioneer: The VR Gardening Simulator | [Steam Store Page](http://store.steampowered.com/app/544410) |
+| Manastorm: Champions of G'nar | [Steam Store Page](http://store.steampowered.com/app/548560) |
+| Keep Defending | [Steam Store Page](http://store.steampowered.com/app/527720) |
+| Stage Presence | [Steam Store Page](http://store.steampowered.com/app/391640) |

--- a/README.md
+++ b/README.md
@@ -1,153 +1,134 @@
 ![vrtk logo](https://raw.githubusercontent.com/thestonefox/VRTK/master/Assets/VRTK/Examples/Resources/Images/logos/vrtk-capsule-clear.png)
 > ### VRTK - Virtual Reality Toolkit
-> A collection of useful scripts and prefabs for building VR titles in Unity 5.
+> A productive VR Toolkit for rapidly building VR solutions in Unity3d.
 
 [![Slack](http://sysdia2.co.uk/badge.svg)](http://invite.vrtk.io)
 [![Waffle](https://img.shields.io/badge/waffle-tracker-blue.svg)](http://tracker.vrtk.io)
 
-**This Toolkit requires a compatible VR SDK to be imported into your Unity Project**
-
-  * Compatible SDKs
-   * [SteamVR Plugin]
-   * [Oculus Utilities]
-
-## Quick Start
-
-  * Clone this repository `git clone https://github.com/thestonefox/VRTK.git`.
-  * Open `VRTK` within Unity3d.
-  * Add the `VRTK_SDKManager` script to a GameObject in the scene.
-
-### SteamVR
-
-  * Import the [SteamVR Plugin] from the Unity Asset Store.
-  * Drag the `[CameraRig]` prefab from the SteamVR plugin into the
-  scene.
-  * Check that `Virtual Reality Supported` is ticked in the
-  `Edit -> Project Settings -> Player` menu.
-  * Ensure that `OpenVR` is added in the `Virtual Reality SDKs` list
-  in the `Edit -> Project Settings -> Player` menu.
-  * Select the GameObject with the `VRTK_SDKManager` script attached
-  to it.
-   * Select `Steam VR` for each of the SDK Choices.
-   * Click the `Auto Populate Linked Objects` button to find the
-   relevant Linked Objects.
-  * Optionally, browse the `Examples` scenes for example usage of the
-  scripts.
-
-### Oculus Utilities
-
-  * Download the [Oculus Utilities] from the Oculus developer website.
-  * Import the `OculusUtilities.unitypackage` into the project.
-  * Drag the `OVRCameraRig` prefab from the Oculus package into the
-  scene.
-  * Check that `Virtual Reality Supported` is ticked in the
-  `Edit -> Project Settings -> Player` menu.
-  * Ensure that `Oculus` is added in the `Virtual Reality SDKs` list
-  in the `Edit -> Project Settings -> Player` menu.
-  * Select the GameObject with the `VRTK_SDKManager` script attached
-  to it.
-   * Select `Oculus VR` for each of the SDK Choices.
-   * Click the `Auto Populate Linked Objects` button to find the
-   relevant Linked Objects.
-
-## Summary
-
-This toolkit provides many common VR functionality within Unity3d such
-as (but not limited to):
-
-  * Controller button events with common aliases
-  * Controller world pointers (e.g. laser pointers)
-  * Player Locomotion
-  * Grabbing/holding objects using the controllers
-  * Interacting with objects using the controllers
-  * Transforming game objects into interactive UI elements
-
-The toolkit is heavily inspired by the [SteamVR Plugin for Unity3d Github Repo].
-
-## What's In The Box
-
-This toolkit project is split into three main sections:
-
-  * Prefabs - `VRTK/Prefabs/`
-  * Scripts - `VRTK/Scripts/`
-  * Examples - `VRTK/Examples/`
-  * SDK - `VRTK/SDK`
-
-The `VRTK` directory is where all of the relevant files are kept
-and this directory can be simply copied over to an existing project.
-The `Examples` directory contains useful scenes showing the VR Toolkit
-in action.
+| Supported SDK | Download Link |
+|---------------|---------------|
+| SteamVR Unity Asset | [SteamVR Plugin] |
+| Oculus Utilities Unity Package | [Oculus Utilities] |
 
 ## Documentation
 
 The documentation for the project can be found within this
 repository in [DOCUMENTATION.md] which includes the up to date
-documentation for this GitHub repository. Alternatively, the
-stable versions of the documentation can be viewed online at
-[http://docs.vrtk.io](http://docs.vrtk.io).
+documentation for this GitHub repository.
+
+Alternatively, the stable versions of the documentation can be viewed
+online at [http://docs.vrtk.io](http://docs.vrtk.io).
+
+## Getting Started
+
+> *VRTK requires a supported VR SDK to be imported into your Unity3d Project.*
+
+ * Clone this repository `git clone https://github.com/thestonefox/VRTK.git`.
+ * Open `VRTK` within Unity3d.
+ * Add the `VRTK_SDKManager` script to a GameObject in the scene.
+
+<details><summary>**Instructions for using the SteamVR Unity3d asset**</summary>
+
+ * Import the [SteamVR Plugin] from the Unity Asset Store.
+ * Drag the `[CameraRig]` prefab from the SteamVR plugin into the
+ scene.
+ * Check that `Virtual Reality Supported` is ticked in the
+ `Edit -> Project Settings -> Player` menu.
+ * Ensure that `OpenVR` is added in the `Virtual Reality SDKs` list
+ in the `Edit -> Project Settings -> Player` menu.
+ * Select the GameObject with the `VRTK_SDKManager` script attached
+ to it.
+  * Select `Steam VR` for each of the SDK Choices.
+  * Click the `Auto Populate Linked Objects` button to find the
+  relevant Linked Objects.
+ * Optionally, browse the `Examples` scenes for example usage of the
+ scripts.
+
+</details>
+
+<details><summary>**Instructions for using the Oculus Utilities Unity3d package**</summary>
+
+ * Download the [Oculus Utilities] from the Oculus developer website.
+ * Import the `OculusUtilities.unitypackage` into the project.
+ * Drag the `OVRCameraRig` prefab from the Oculus package into the
+ scene.
+ * Check that `Virtual Reality Supported` is ticked in the
+ `Edit -> Project Settings -> Player` menu.
+ * Ensure that `Oculus` is added in the `Virtual Reality SDKs` list
+ in the `Edit -> Project Settings -> Player` menu.
+ * Select the GameObject with the `VRTK_SDKManager` script attached
+ to it.
+  * Select `Oculus VR` for each of the SDK Choices.
+  * Click the `Auto Populate Linked Objects` button to find the
+  relevant Linked Objects.
+
+</details>
+   
+## What's In The Box
+
+VRTK is a collection of useful scripts and concepts to aid building VR
+solutions rapidly and easily in Unity3d 5+.
+
+It covers a number of common solutions such as:
+
+ * Locomotion within virtual space.
+ * Interactions like touching, grabbing and using objects
+ * Interacting with Unity3d UI elements through pointers or touch.
+ * Body physics within virtual space.
+ * 2D and 3D controls like buttons, levers, doors, drawers, etc.
+ * And much more...
+
+VRTK is split into four main sections:
+
+ * Prefabs - `VRTK/Prefabs/`
+ * Scripts - `VRTK/Scripts/`
+ * Examples - `VRTK/Examples/`
+ * SDK - `VRTK/SDK`
+
+The `VRTK` directory is where all of the relevant files are kept
+and this directory can be simply copied over to an existing project.
+
+*VRTK is heavily inspired by the [SteamVR Plugin for Unity3d Github Repo].*
 
 ## Examples
 
 A collection of example scenes have been created to aid with
-understanding the different aspects of the toolkit. A list
-of the examples can be viewed within this repository in
-[EXAMPLES.md] which includes an up to date list of examples.
+understanding the different aspects of VRTK.
 
-## Games, Apps and Experiences that use this Toolkit
+A list of the examples can be viewed in [EXAMPLES.md] which includes
+an up to date list of examples showcasing the features of VRTK.
 
-| Name | Link |
-|-------------------------------------------------|-------------------------------------------------------------------------------------------|
-| QuiVR | [Steam Store Page](http://store.steampowered.com/app/489380) |
-| Left-Hand Path | [Steam Store Page](http://store.steampowered.com/app/488760) |
-| Holodaze | [Steam Store Page](http://store.steampowered.com/app/475520) |
-| ViveSpray | [Steam Store Page](http://store.steampowered.com/app/494830) |
-| VeeR Pong | [Steam Store Page](http://store.steampowered.com/app/494850) |
-| Emergence Fractal Universe | [Steam Store Page](http://store.steampowered.com/app/500470) |
-| Ocarina of Vive | [Itch.io Store Page](https://tomcat94.itch.io/ocarina-of-vive-shooting-gallery) |
-| Danc<R | [Itch.io Store Page](https://tomcat94.itch.io/dancr-alpha) |
-| Tower Island: Explore, Discover and Disassemble | [Steam Store Page](http://store.steampowered.com/app/487740) |
-| Virtual Warfighter | [Steam Store Page](http://store.steampowered.com/app/517020) |
-| VR Regatta | [Steam Store Page](http://store.steampowered.com/app/468240) |
-| Car Car Crash Hands | [Steam Store Page](http://store.steampowered.com/app/472720) |
-| MegaPolice | [Youtube Trailer](https://www.youtube.com/watch?v=d6hCgfMxldY) |
-| The Crystal Nebula | [Steam Store Page](http://store.steampowered.com/app/505660) |
-| Drone Training VR | [Youtube Trailer](https://www.youtube.com/watch?v=A5MFT2JsySc) |
-| Cogs and Cowboys | [Steam Store Page](http://store.steampowered.com/app/510410) |
-| Frantic Freighter | [Steam Store Page](http://store.steampowered.com/app/503150) |
-| Redswood VR | [Steam Store Page](http://store.steampowered.com/app/499760) |
-| Wrath Of The Fire God | [Steam Store Page](http://store.steampowered.com/app/511370) |
-| Coinvault | [Itch.io Store Page](https://ldvr.itch.io/ldvrs-coinvault-for-the-vive) |
-| VR Explosive Kitten Toss | [Itch.io Store Page](https://ldvr.itch.io/ldvrs-kitten-toss) |
-| Zika VR | [Itch.io Store Page](https://ldvr.itch.io/ldvr-presents-zika-vr) |
-| Domino VR | [Steam Store Page](http://store.steampowered.com/app/508680) |
-| One Of The Last | [Steam Store Page](http://store.steampowered.com/app/550360) |
-| The Days After | [Game website](http://www.fivefingerstudios.com/thedaysafter) |
-| Quantized | [Steam Greenlight Page](https://steamcommunity.com/sharedfiles/filedetails/?id=195344075) |
-| Caketomino | [Steam Store Page](http://store.steampowered.com/app/517770) |
-| Escape Station | [Steam Store Page](http://store.steampowered.com/app/527360) |
-| Outrageous Grounds: The Maze | [Steam Store Page](http://store.steampowered.com/app/513050) |
-| Draco Dux | [Steam Store Page](http://store.steampowered.com/app/460730) |
-| Deisim | [Steam Store Page](http://store.steampowered.com/app/525680) |
-| Potioneer: The VR Gardening Simulator | [Steam Store Page](http://store.steampowered.com/app/544410) |
-| Manastorm: Champions of G'nar | [Steam Store Page](http://store.steampowered.com/app/548560) |
-| Keep Defending | [Steam Store Page](http://store.steampowered.com/app/527720) |
-| Stage Presence | [Steam Store Page](http://store.steampowered.com/app/391640) |
+The examples have all been built to work with the [SteamVR Plugin] by
+default, but they can be converted over to using the [Oculus Utilities]
+package by following the instructions for using the Oculus Utilities
+package above.
+
+> *If the examples are not working on first load, click the `[VRTK]`
+> GameObject in the scene hierarchy to ensure the SDK Manager editor
+> script successfully sets up the project and scene.*
+
+## Made With VRTK
+
+Many games and experiences have already been made with VRTK.
+
+Check out the [Made With VRTK Document] to see the full list.
 
 ## Contributing
 
 I would love to get contributions from you! Follow the instructions
-below on how to make pull requests. For the full contribution
-guidelines see the [Contribution Document].
+below on how to make pull requests.
+
+For the full contribution guidelines see the [Contribution Document].
 
 ## Pull requests
 
-  1. [Fork] the project, clone your fork, and configure the remotes.
-  2. Create a new topic branch (from `master`) to contain your feature,
-  chore, or fix.
-  3. Commit your changes in logical units.
-  4. Make sure all the example scenes are still working.
-  5. Push your topic branch up to your fork.
-  6. [Open a Pull Request] with a clear title and description.
+ 1. [Fork] the project, clone your fork, and configure the remotes.
+ 2. Create a new topic branch (from `master`) to contain your feature,
+ chore, or fix.
+ 3. Commit your changes in logical units.
+ 4. Make sure all the example scenes are still working.
+ 5. Push your topic branch up to your fork.
+ 6. [Open a Pull Request] with a clear title and description.
 
 ## License
 
@@ -156,9 +137,9 @@ Code released under the [MIT License].
 [SteamVR Plugin]: https://www.assetstore.unity3d.com/en/#!/content/32647
 [SteamVR Plugin for Unity3d Github Repo]: https://github.com/ValveSoftware/openvr/tree/master/unity_package/Assets/SteamVR
 [Oculus Utilities]: https://developer3.oculus.com/downloads/game-engines/1.10.0/Oculus_Utilities_for_Unity_5/
-[Catlike Coding]: http://catlikecoding.com/unity/tutorials/curves-and-splines/
 [MIT License]: https://github.com/thestonefox/SteamVR_Unity_Toolkit/blob/master/LICENSE
 [Contribution Document]: https://github.com/thestonefox/SteamVR_Unity_Toolkit/blob/master/CONTRIBUTING.md
+[Made With VRTK Document]: https://github.com/thestonefox/SteamVR_Unity_Toolkit/blob/master/MADEWITHVRTK.md
 [DOCUMENTATION.md]: https://github.com/thestonefox/SteamVR_Unity_Toolkit/blob/master/DOCUMENTATION.md
 [EXAMPLES.md]: https://github.com/thestonefox/SteamVR_Unity_Toolkit/blob/master/EXAMPLES.md
 [Fork]: http://help.github.com/fork-a-repo/


### PR DESCRIPTION
The README has been reformatted to read in a better flow, and the list
of games made with VRTK has been split out into it's own file as it was
getting too long for the README file.