### PR TITLE
fix(Pointer): prevent bezier pointer clipping - fixes #617

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_CurveGenerator.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_CurveGenerator.cs
@@ -90,18 +90,45 @@ namespace VRTK
 
         public void SetPoints(Vector3[] controlPoints, Material material, Color color)
         {
+            PointsInit(controlPoints);
+            SetObjects(material, color);
+        }
+
+        public Vector3[] GetPoints(Vector3[] controlPoints)
+        {
+            PointsInit(controlPoints);
+
+            Vector3[] calculatedPoints = new Vector3[frequency];
+            float stepSize = frequency * 1;
+            if (Loop || stepSize == 1)
+            {
+                stepSize = 1f / stepSize;
+            }
+            else
+            {
+                stepSize = 1f / (stepSize - 1);
+            }
+
+            for (int f = 0; f < frequency; f++)
+            {
+                calculatedPoints[f] = GetPoint(f * stepSize);
+            }
+            return calculatedPoints;
+        }
+
+        public void TogglePoints(bool state)
+        {
+            gameObject.SetActive(state);
+        }
+
+        private void PointsInit(Vector3[] controlPoints)
+        {
             points = controlPoints;
             modes = new BezierControlPointMode[]
             {
                 BezierControlPointMode.Free,
                 BezierControlPointMode.Free
             };
-            SetObjects(material, color);
-        }
-
-        public void TogglePoints(bool state)
-        {
-            gameObject.SetActive(state);
         }
 
         private GameObject CreateSphere()

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -652,6 +652,7 @@ The laser beam is activated by default by pressing the `Touchpad` on the control
 
  * **Pointer Length:** The length of the projected forward pointer beam, this is basically the distance able to point from the origin position.
  * **Pointer Density:** The number of items to render in the beam bezier curve. A high number here will most likely have a negative impact of game performance due to large number of rendered objects.
+ * **Collision Check Frequency:** The number of points along the bezier curve to check for an early beam collision. Useful if the bezier curve is appearing to clip through teleport locations. 0 won't make any checks and it will be capped at `Pointer Density`. The higher the number, the more CPU intensive the checks become.
  * **Beam Curve Offset:** The amount of height offset to apply to the projected beam to generate a smoother curve even when the beam is pointing straight.
  * **Beam Height Limit Angle:** The maximum angle in degrees of the origin before the beam curve height is restricted. A lower angle setting will prevent the beam being projected high into the sky and curving back down.
  * **Rescale Pointer Tracer:** Rescale each pointer tracer element according to the length of the Bezier curve.


### PR DESCRIPTION
The Bezier Pointer beam can occasionally clip through the floor due
to the way the curve is calculated based on 1 forward point and 1
downward point.

This fix casts additional rays along the curve to check for early
collisions and if a collision is found then the target location
is updated to prevent clipping.