### PR TITLE
fix(Interaction): use local rotation when inverting tracked snap handle

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseGrabAttach.cs
@@ -268,7 +268,7 @@ namespace VRTK.GrabAttachMechanics
         {
             if (snapHandle)
             {
-                snapHandle.rotation = Quaternion.Inverse(snapHandle.rotation);
+                snapHandle.localRotation = Quaternion.Inverse(snapHandle.localRotation);
             }
         }
     }


### PR DESCRIPTION
The snap handle rotation is inverted when using a tracked object grab
mechanic. However, it was using the rotation to invert which caused
issues if the object had been rotated in the scene. Rotating the
local rotation of the snap handle is enough to fix the inversion issue
and this does not affect the object if it's world rotation has been
changed.