### PR TITLE
fix(Interaction): ensure collision checks are done in physics loop

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -280,6 +280,7 @@ namespace VRTK
                 CancelInvoke("ResetTriggerRumble");
                 ResetTriggerRumble();
                 ForceStopTouching();
+                triggerIsColliding = true;
             }
         }
 
@@ -296,6 +297,7 @@ namespace VRTK
             var colliderInteractableObject = TriggerStart(collider);
             if (touchedObject == null && colliderInteractableObject && IsObjectInteractable(collider.gameObject))
             {
+                triggerIsColliding = true;
                 touchedObject = colliderInteractableObject;
                 var touchedObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
                 var touchingObject = gameObject;
@@ -318,9 +320,27 @@ namespace VRTK
             }
         }
 
+        private void FixedUpdate()
+        {
+            if (!triggerIsColliding && !triggerWasColliding)
+            {
+                CheckStopTouching();
+            }
+            triggerWasColliding = triggerIsColliding;
+            triggerIsColliding = false;
+        }
+
         private void LateUpdate()
         {
-            if (touchedObject != null && (touchedObjectActiveColliders.Count == 0 || (!triggerIsColliding && !triggerWasColliding)))
+            if (touchedObjectActiveColliders.Count == 0)
+            {
+                CheckStopTouching();
+            }
+        }
+
+        private void CheckStopTouching()
+        {
+            if (touchedObject != null)
             {
                 var touchedObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
                 var touchingObject = gameObject;
@@ -331,9 +351,6 @@ namespace VRTK
                     StopTouching(touchedObject);
                 }
             }
-
-            triggerWasColliding = triggerIsColliding;
-            triggerIsColliding = false;
         }
 
         private GameObject TriggerStart(Collider collider)
@@ -343,7 +360,6 @@ namespace VRTK
                 return null;
             }
 
-            triggerIsColliding = true;
             AddActiveCollider(collider);
 
             return GetColliderInteractableObject(collider);


### PR DESCRIPTION
Previously, there was a check to see if a collider on the controller
had been disabled by checking in the `LateUpdate` method which worked
but only because SteamVR locked the physics time step meaning the
physics routine (running the OnTrigger stuff) was in sync with the
Update/LateUpdate routines.

However, if the physics time step was not locked (e.g. if using the
simulator) then it would be possible to get the LateUpdate routine
to run during the physics loop and cause objects to constantly be
touched and untouched.

As FixedUpdate is a physics routine, it's best to do some of the
checks in there then the different time steps won't cause any
issues.