### PR TITLE
fix(UIPointer): ensure event input pointers list is managed correctly

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_EventSystemVRInput.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_EventSystemVRInput.cs
@@ -7,11 +7,11 @@
 
     public class VRTK_EventSystemVRInput : PointerInputModule
     {
-        public List<VRTK_UIPointer> pointers;
+        public List<VRTK_UIPointer> pointers = new List<VRTK_UIPointer>();
 
         public void Initialise()
         {
-            pointers = new List<VRTK_UIPointer>();
+            pointers.Clear();
         }
 
         public override void Process()


### PR DESCRIPTION
Previously, whenever a UIPointer was initialised it would get added to
the Event Input pointers list, but it could end up being added multiple
times to the same list as no checking was done to see if it already
existed within the list and it was also not removed from the list when
the UIPointer was disabled.

This fix ensures the list is correctly managed and also caches the
event system and event system input to prevent them from being re-found
each time a pointer is enabled.