### PR TITLE
fix(Examples): fix a warning on Unity 5.5 and above

### DIFF
--- a/Assets/VRTK/Examples/Resources/Scripts/FireExtinguisher_Sprayer.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/FireExtinguisher_Sprayer.cs
@@ -24,7 +24,13 @@
                 {
                     particles.Play();
                 }
+
+#if UNITY_5_5_OR_NEWER
+                var mainModule = particles.main;
+                mainModule.startSpeedMultiplier = maxSprayPower * power;
+#else
                 particles.startSpeed = maxSprayPower * power;
+#endif
             }
         }
 


### PR DESCRIPTION
The used properties of a `ParticleSystem` are now on its `MainModule`.