### PR TITLE
fix(SimplePointer): set pointer transform correctly

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -182,6 +182,11 @@ namespace VRTK
             return (pointerOriginTransform ? pointerOriginTransform.forward : transform.forward);
         }
 
+        protected virtual Quaternion GetOriginRotation()
+        {
+            return (pointerOriginTransform ? pointerOriginTransform.rotation : transform.rotation);
+        }
+
         protected virtual Quaternion GetOriginLocalRotation()
         {
             return (pointerOriginTransform ? pointerOriginTransform.localRotation : Quaternion.identity);

--- a/Assets/VRTK/Scripts/Pointers/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_SimplePointer.cs
@@ -212,10 +212,8 @@ namespace VRTK
             pointerBeam.transform.localPosition = new Vector3(0f, 0f, beamPosition);
             pointerTip.transform.localPosition = new Vector3(0f, 0f, setLength - (pointerTip.transform.localScale.z / 2));
 
-            pointerHolder.transform.localPosition = GetOriginLocalPosition();
-            pointerHolder.transform.localRotation = GetOriginLocalRotation();
-            pointerHolder.transform.position = transform.position;
-            pointerHolder.transform.rotation = transform.rotation;
+            pointerHolder.transform.position = GetOriginPosition();
+            pointerHolder.transform.rotation = GetOriginRotation();
             base.UpdateDependencies(pointerTip.transform.position);
         }
 


### PR DESCRIPTION
It doesn't make sense to first set the local space values of a
transform and immediately overriding them by setting the world space
values.