### PR TITLE
fix(Pointer): ensure ToggleBeam() turns off bezier pointer - fixes #797

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_BezierPointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BezierPointer.cs
@@ -134,13 +134,25 @@ namespace VRTK
         {
             state = (pointerVisibility == pointerVisibilityStates.Always_On ? true : state);
             beamActive = state;
+            if (!beamActive)
+            {
+                ToggleBezierBeam(beamActive);
+            }
         }
 
         protected override void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)
         {
             base.DisablePointerBeam(sender, e);
-            TogglePointerCursor(false);
-            curvedBeam.TogglePoints(false);
+            ToggleBezierBeam(false);
+        }
+
+        private void ToggleBezierBeam(bool state)
+        {
+            if (gameObject.activeInHierarchy)
+            {
+                TogglePointerCursor(state);
+                curvedBeam.TogglePoints(state);
+            }
         }
 
         private GameObject CreateCursor()

--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -116,7 +116,10 @@ namespace VRTK
         public virtual void ToggleState(bool state)
         {
             state = (!enabled ? false : state);
-            playAreaCursor.SetActive(state);
+            if (playAreaCursor)
+            {
+                playAreaCursor.SetActive(state);
+            }
         }
 
         protected virtual void Awake()


### PR DESCRIPTION
The `ToggleBeam` method was not turning off the bezier pointer as it
was only setting the bezier state to inactive but not actually changing
the visibility of the bezier pointer.

This fix ensures that the bezier pointer objects are turned off when
the beam is toggled off.