### PR TITLE
feat(headset_velocity): add methods to get velocities for headset

### DIFF
--- a/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
@@ -34,6 +34,18 @@ namespace VRTK
         public abstract Transform GetHeadsetCamera();
 
         /// <summary>
+        /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current velocity of the headset.</returns>
+        public abstract Vector3 GetHeadsetVelocity();
+
+        /// <summary>
+        /// The GetHeadsetAngularVelocity method is used to determine the current angular velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current angular velocity of the headset.</returns>
+        public abstract Vector3 GetHeadsetAngularVelocity();
+
+        /// <summary>
         /// The HeadsetFade method is used to apply a fade to the headset camera to progressively change the colour.
         /// </summary>
         /// <param name="color">The colour to fade to.</param>

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackHeadset.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackHeadset.cs
@@ -39,6 +39,24 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current velocity of the headset.</returns>
+        public override Vector3 GetHeadsetVelocity()
+        {
+            return Vector3.zero;
+        }
+
+        /// <summary>
+        /// The GetHeadsetAngularVelocity method is used to determine the current angular velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current angular velocity of the headset.</returns>
+        public override Vector3 GetHeadsetAngularVelocity()
+        {
+            return Vector3.zero;
+        }
+
+        /// <summary>
         /// The HeadsetFade method is used to apply a fade to the headset camera to progressively change the colour.
         /// </summary>
         /// <param name="color">The colour to fade to.</param>

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
@@ -10,12 +10,18 @@ namespace VRTK
     /// </summary>
     public class SDK_OculusVRHeadset : SDK_BaseHeadset
     {
+        private Quaternion previousHeadsetRotation;
+        private Quaternion currentHeadsetRotation;
+
         /// <summary>
         /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
         /// </summary>
         /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
         public override void ProcessUpdate(Dictionary<string, object> options)
         {
+            var device = GetHeadset();
+            previousHeadsetRotation = currentHeadsetRotation;
+            currentHeadsetRotation = device.transform.rotation;
         }
 
         /// <summary>
@@ -48,6 +54,25 @@ namespace VRTK
                 cachedHeadsetCamera = GetHeadset();
             }
             return cachedHeadsetCamera;
+        }
+
+        /// <summary>
+        /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current velocity of the headset.</returns>
+        public override Vector3 GetHeadsetVelocity()
+        {
+            return OVRManager.isHmdPresent ? OVRPlugin.GetEyeVelocity(OVRPlugin.Eye.Left).ToOVRPose().position : Vector3.zero;
+        }
+
+        /// <summary>
+        /// The GetHeadsetAngularVelocity method is used to determine the current angular velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current angular velocity of the headset.</returns>
+        public override Vector3 GetHeadsetAngularVelocity()
+        {
+            var deltaRotation = currentHeadsetRotation * Quaternion.Inverse(previousHeadsetRotation);
+            return new Vector3(Mathf.DeltaAngle(0, deltaRotation.eulerAngles.x), Mathf.DeltaAngle(0, deltaRotation.eulerAngles.y), Mathf.DeltaAngle(0, deltaRotation.eulerAngles.z));
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -290,7 +290,7 @@ namespace VRTK
         /// <returns>A Vector3 containing the current velocity of the tracked object.</returns>
         public override Vector3 GetVelocityOnIndex(uint index)
         {
-            if (index >= OpenVR.k_unTrackedDeviceIndexInvalid)
+            if (index <= (uint)SteamVR_TrackedObject.EIndex.Hmd || index >= OpenVR.k_unTrackedDeviceIndexInvalid)
             {
                 return Vector3.zero;
             }
@@ -305,7 +305,7 @@ namespace VRTK
         /// <returns>A Vector3 containing the current angular velocity of the tracked object.</returns>
         public override Vector3 GetAngularVelocityOnIndex(uint index)
         {
-            if (index >= OpenVR.k_unTrackedDeviceIndexInvalid)
+            if (index <= (uint)SteamVR_TrackedObject.EIndex.Hmd || index >= OpenVR.k_unTrackedDeviceIndexInvalid)
             {
                 return Vector3.zero;
             }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -59,6 +59,24 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current velocity of the headset.</returns>
+        public override Vector3 GetHeadsetVelocity()
+        {
+            return SteamVR_Controller.Input((int)SteamVR_TrackedObject.EIndex.Hmd).velocity;
+        }
+
+        /// <summary>
+        /// The GetHeadsetAngularVelocity method is used to determine the current angular velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current angular velocity of the headset.</returns>
+        public override Vector3 GetHeadsetAngularVelocity()
+        {
+            return SteamVR_Controller.Input((int)SteamVR_TrackedObject.EIndex.Hmd).angularVelocity;
+        }
+
+        /// <summary>
         /// The HeadsetFade method is used to apply a fade to the headset camera to progressively change the colour.
         /// </summary>
         /// <param name="color">The colour to fade to.</param>

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -120,6 +120,16 @@
             return GetControllerSDK().GetAngularVelocityOnIndex(index);
         }
 
+        public static Vector3 GetHeadsetVelocity()
+        {
+            return GetHeadsetSDK().GetHeadsetVelocity();
+        }
+
+        public static Vector3 GetHeadsetAngularVelocity()
+        {
+            return GetHeadsetSDK().GetHeadsetAngularVelocity();
+        }
+
         public static Vector2 GetTouchpadAxisOnIndex(uint index)
         {
             return GetControllerSDK().GetTouchpadAxisOnIndex(index);

--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -252,6 +252,24 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current velocity of the headset.</returns>
+        public static Vector3 GetHeadsetVelocity()
+        {
+            return VRTK_SDK_Bridge.GetHeadsetVelocity();
+        }
+
+        /// <summary>
+        /// The GetHeadsetAngularVelocity method is used to determine the current angular velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current angular velocity of the headset.</returns>
+        public static Vector3 GetHeadsetAngularVelocity()
+        {
+            return VRTK_SDK_Bridge.GetHeadsetAngularVelocity();
+        }
+
+        /// <summary>
         /// The HeadsetTransform method is used to retrieve the transform for the VR Headset in the scene. It can be useful to determine the position of the user's head in the game world.
         /// </summary>
         /// <returns>The transform of the VR Headset component.</returns>


### PR DESCRIPTION
The DeviceFinder and SDK classes provide methods to receive the
velocity and angular velocity of controllers. This change adds methods
to retrieve those velocities of the headset. The controller velocity
methods of the VRTK SteamVR SDK have been updated to only return
velocities of controllers, not the headset, because SteamVR uses
indexes for all the tracked objects.