### PR TITLE
chore(velocity_tracking): move velocity tracking to device finder

### DIFF
--- a/Assets/VRTK/Examples/Resources/Scripts/Sword.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/Sword.cs
@@ -5,7 +5,6 @@
     public class Sword : VRTK_InteractableObject
     {
         private VRTK_ControllerActions controllerActions;
-        private VRTK_ControllerEvents controllerEvents;
         private float impactMagnifier = 120f;
         private float collisionForce = 0f;
         private float maxCollisionForce = 4000f;
@@ -19,7 +18,6 @@
         {
             base.Grabbed(grabbingObject);
             controllerActions = grabbingObject.GetComponent<VRTK_ControllerActions>();
-            controllerEvents = grabbingObject.GetComponent<VRTK_ControllerEvents>();
         }
 
         protected override void Awake()
@@ -30,9 +28,9 @@
 
         private void OnCollisionEnter(Collision collision)
         {
-            if (controllerActions && controllerEvents && IsGrabbed())
+            if (controllerActions && IsGrabbed())
             {
-                collisionForce = controllerEvents.GetVelocity().magnitude * impactMagnifier;
+                collisionForce = VRTK_DeviceFinder.GetControllerVelocity(controllerActions.gameObject).magnitude * impactMagnifier;
                 var hapticStrength = collisionForce / maxCollisionForce;
                 controllerActions.TriggerHapticPulse(hapticStrength, 0.5f, 0.01f);
             }

--- a/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System.Collections.Generic;
 
     /// <summary>
     /// The Base Headset SDK script provides a bridge to SDK methods that deal with the VR Headset.
@@ -13,6 +14,12 @@ namespace VRTK
     {
         protected Transform cachedHeadset;
         protected Transform cachedHeadsetCamera;
+
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public abstract void ProcessUpdate(Dictionary<string, object> options);
 
         /// <summary>
         /// The GetHeadset method returns the Transform of the object that is used to represent the headset in the scene.

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackHeadset.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackHeadset.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System.Collections.Generic;
 
     /// <summary>
     /// The Fallback System SDK script provides a fallback collection of methods that return null or default Headset values.
@@ -11,6 +12,14 @@ namespace VRTK
     /// </remarks>
     public class SDK_FallbackHeadset : SDK_BaseHeadset
     {
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public override void ProcessUpdate(Dictionary<string, object> options)
+        {
+        }
+
         /// <summary>
         /// The GetHeadset method returns the Transform of the object that is used to represent the headset in the scene.
         /// </summary>

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
@@ -3,12 +3,21 @@ namespace VRTK
 {
 #if VRTK_SDK_OCULUSVR
     using UnityEngine;
+    using System.Collections.Generic;
 
     /// <summary>
     /// The OculusVR Headset SDK script provides a bridge to the OculusVR SDK.
     /// </summary>
     public class SDK_OculusVRHeadset : SDK_BaseHeadset
     {
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public override void ProcessUpdate(Dictionary<string, object> options)
+        {
+        }
+
         /// <summary>
         /// The GetHeadset method returns the Transform of the object that is used to represent the headset in the scene.
         /// </summary>

--- a/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
@@ -3,6 +3,7 @@ namespace VRTK
 {
 #if VRTK_SDK_SIM
     using UnityEngine;
+    using System.Collections.Generic;
 
     /// <summary>
     /// The Sim Headset SDK script  provides dummy functions for the headset.
@@ -10,6 +11,14 @@ namespace VRTK
     public class SDK_SimHeadset : SDK_BaseHeadset
     {
         private Transform camera;
+
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public override void ProcessUpdate(Dictionary<string, object> options)
+        {
+        }
 
         /// <summary>
         /// The GetHeadset method returns the Transform of the object that is used to represent the headset in the scene.

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -3,12 +3,21 @@ namespace VRTK
 {
 #if VRTK_SDK_STEAMVR
     using UnityEngine;
+    using System.Collections.Generic;
 
     /// <summary>
     /// The SteamVR Headset SDK script provides a bridge to the SteamVR SDK.
     /// </summary>
     public class SDK_SteamVRHeadset : SDK_BaseHeadset
     {
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public override void ProcessUpdate(Dictionary<string, object> options)
+        {
+        }
+
         /// <summary>
         /// The GetHeadset method returns the Transform of the object that is used to represent the headset in the scene.
         /// </summary>

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -10,6 +10,11 @@
         private static SDK_BaseController controllerSDK = null;
         private static SDK_BaseBoundaries boundariesSDK = null;
 
+        public static void HeadsetProcessUpdate(Dictionary<string, object> options = null)
+        {
+            GetHeadsetSDK().ProcessUpdate(options);
+        }
+
         public static void ControllerProcessUpdate(uint index, Dictionary<string, object> options = null)
         {
             GetControllerSDK().ProcessUpdate(index, options);

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseGrabAttach.cs
@@ -202,14 +202,13 @@ namespace VRTK.GrabAttachMechanics
                 if (grabbingObject)
                 {
                     var grabbingObjectScript = grabbingObject.GetComponent<VRTK_InteractGrab>();
-                    var controllerEvents = grabbingObject.GetComponent<VRTK_ControllerEvents>();
 
                     var grabbingObjectThrowMultiplier = grabbingObjectScript.throwMultiplier;
 
                     var origin = VRTK_DeviceFinder.GetControllerOrigin(grabbingObject);
 
-                    var velocity = (controllerEvents ? controllerEvents.GetVelocity() : Vector3.zero);
-                    var angularVelocity = (controllerEvents ? controllerEvents.GetAngularVelocity() : Vector3.zero);
+                    var velocity = VRTK_DeviceFinder.GetControllerVelocity(grabbingObject);
+                    var angularVelocity = VRTK_DeviceFinder.GetControllerAngularVelocity(grabbingObject);
 
                     if (origin != null)
                     {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -424,9 +424,6 @@ namespace VRTK
         private float hairTriggerDelta;
         private float hairGripDelta;
 
-        private Vector3 controllerVelocity = Vector3.zero;
-        private Vector3 controllerAngularVelocity = Vector3.zero;
-
         public virtual void OnTriggerPressed(ControllerInteractionEventArgs e)
         {
             if (TriggerPressed != null)
@@ -791,20 +788,20 @@ namespace VRTK
         /// The GetVelocity method is useful for getting the current velocity of the physical game controller. This can be useful to determine the speed at which the controller is being swung or the direction it is being moved in.
         /// </summary>
         /// <returns>A 3 dimensional vector containing the current real world physical controller velocity.</returns>
+        [Obsolete("`VRTK_ControllerEvents.GetVelocity()` has been replaced with `VRTK_DeviceFinder.GetControllerVelocity(givenController)`. This method will be removed in a future version of VRTK.")]
         public Vector3 GetVelocity()
         {
-            SetVelocity();
-            return controllerVelocity;
+            return VRTK_DeviceFinder.GetControllerVelocity(gameObject);
         }
 
         /// <summary>
         /// The GetAngularVelocity method is useful for getting the current rotational velocity of the physical game controller. This can be useful for determining which way the controller is being rotated and at what speed the rotation is occurring.
         /// </summary>
         /// <returns>A 3 dimensional vector containing the current real world physical controller angular (rotational) velocity.</returns>
+        [Obsolete("`VRTK_ControllerEvents.GetAngularVelocity()` has been replaced with `VRTK_DeviceFinder.GetControllerAngularVelocity(givenController)`. This method will be removed in a future version of VRTK.")]
         public Vector3 GetAngularVelocity()
         {
-            SetVelocity();
-            return controllerAngularVelocity;
+            return VRTK_DeviceFinder.GetControllerAngularVelocity(gameObject);
         }
 
         /// <summary>
@@ -1188,8 +1185,6 @@ namespace VRTK
                 return;
             }
 
-            VRTK_SDK_Bridge.ControllerProcessUpdate(controllerIndex);
-
             Vector2 currentTriggerAxis = VRTK_SDK_Bridge.GetTriggerAxisOnIndex(controllerIndex);
             Vector2 currentGripAxis = VRTK_SDK_Bridge.GetGripAxisOnIndex(controllerIndex);
             Vector2 currentTouchpadAxis = VRTK_SDK_Bridge.GetTouchpadAxisOnIndex(controllerIndex);
@@ -1398,13 +1393,6 @@ namespace VRTK
 
             hairTriggerDelta = VRTK_SDK_Bridge.GetTriggerHairlineDeltaOnIndex(controllerIndex);
             hairGripDelta = VRTK_SDK_Bridge.GetGripHairlineDeltaOnIndex(controllerIndex);
-        }
-
-        private void SetVelocity()
-        {
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
-            controllerVelocity = VRTK_SDK_Bridge.GetVelocityOnIndex(controllerIndex);
-            controllerAngularVelocity = VRTK_SDK_Bridge.GetAngularVelocityOnIndex(controllerIndex);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
@@ -104,6 +104,8 @@
                 OnControllerIndexChanged(SetEventPayload(previousIndex));
             }
 
+            VRTK_SDK_Bridge.ControllerProcessUpdate(currentIndex);
+
             if (aliasController && gameObject.activeInHierarchy && !aliasController.activeSelf)
             {
                 aliasController.SetActive(true);

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedHeadset.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedHeadset.cs
@@ -1,0 +1,12 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public class VRTK_TrackedHeadset : MonoBehaviour
+    {
+        private void Update()
+        {
+            VRTK_SDK_Bridge.HeadsetProcessUpdate();
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedHeadset.cs.meta
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedHeadset.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b7fae572fcbf1ec43807eab8aa208da5
+timeCreated: 1484131391
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
@@ -185,7 +185,7 @@ namespace VRTK
 
                 if (device)
                 {
-                    velocity = -device.GetComponent<VRTK_ControllerEvents>().GetVelocity();
+                    velocity = -VRTK_DeviceFinder.GetControllerVelocity(device);
                     if (usePlayerScale)
                     {
                         velocity = Vector3.Scale(velocity, playArea.localScale);

--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -230,6 +230,28 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetControllerVelocity method is used for getting the current velocity of the physical game controller. This can be useful to determine the speed at which the controller is being swung or the direction it is being moved in.
+        /// </summary>
+        /// <param name="givenController">The GameObject of the controller.</param>
+        /// <returns>A 3 dimensional vector containing the current real world physical controller velocity.</returns>
+        public static Vector3 GetControllerVelocity(GameObject givenController)
+        {
+            var controllerIndex = GetControllerIndex(givenController);
+            return VRTK_SDK_Bridge.GetVelocityOnIndex(controllerIndex);
+        }
+
+        /// <summary>
+        /// The GetControllerAngularVelocity method is used for getting the current rotational velocity of the physical game controller. This can be useful for determining which way the controller is being rotated and at what speed the rotation is occurring.
+        /// </summary>
+        /// <param name="givenController">The GameObject of the controller.</param>
+        /// <returns>A 3 dimensional vector containing the current real world physical controller angular (rotational) velocity.</returns>
+        public static Vector3 GetControllerAngularVelocity(GameObject givenController)
+        {
+            var controllerIndex = GetControllerIndex(givenController);
+            return VRTK_SDK_Bridge.GetAngularVelocityOnIndex(controllerIndex);
+        }
+
+        /// <summary>
         /// The HeadsetTransform method is used to retrieve the transform for the VR Headset in the scene. It can be useful to determine the position of the user's head in the game world.
         /// </summary>
         /// <returns>The transform of the VR Headset component.</returns>

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -182,8 +182,17 @@ namespace VRTK
             CreateInstance();
             if (!VRTK_SharedMethods.IsEditTime())
             {
+                SetupHeadset();
                 SetupControllers();
                 GetBoundariesSDK().InitBoundaries();
+            }
+        }
+
+        private void SetupHeadset()
+        {
+            if (!actualHeadset.GetComponent<VRTK_TrackedHeadset>())
+            {
+                actualHeadset.AddComponent<VRTK_TrackedHeadset>();
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1302,28 +1302,6 @@ Adding the `VRTK_ControllerEvents_UnityEvents` component to `VRTK_ControllerEven
 
 ### Class Methods
 
-#### GetVelocity/0
-
-  > `public Vector3 GetVelocity()`
-
-  * Parameters
-   * _none_
-  * Returns
-   * `Vector3` - A 3 dimensional vector containing the current real world physical controller velocity.
-
-The GetVelocity method is useful for getting the current velocity of the physical game controller. This can be useful to determine the speed at which the controller is being swung or the direction it is being moved in.
-
-#### GetAngularVelocity/0
-
-  > `public Vector3 GetAngularVelocity()`
-
-  * Parameters
-   * _none_
-  * Returns
-   * `Vector3` - A 3 dimensional vector containing the current real world physical controller angular (rotational) velocity.
-
-The GetAngularVelocity method is useful for getting the current rotational velocity of the physical game controller. This can be useful for determining which way the controller is being rotated and at what speed the rotation is occurring.
-
 #### GetTouchpadAxis/0
 
   > `public Vector2 GetTouchpadAxis()`
@@ -4673,6 +4651,28 @@ The GetScriptAliasController method will attempt to get the object that contains
 
 The GetModelAliasController method will attempt to get the object that contains the model for the controller.
 
+#### GetControllerVelocity/1
+
+  > `public static Vector3 GetControllerVelocity(GameObject givenController)`
+
+  * Parameters
+   * `GameObject givenController` - The GameObject of the controller.
+  * Returns
+   * `Vector3` - A 3 dimensional vector containing the current real world physical controller velocity.
+
+The GetControllerVelocity method is used for getting the current velocity of the physical game controller. This can be useful to determine the speed at which the controller is being swung or the direction it is being moved in.
+
+#### GetControllerAngularVelocity/1
+
+  > `public static Vector3 GetControllerAngularVelocity(GameObject givenController)`
+
+  * Parameters
+   * `GameObject givenController` - The GameObject of the controller.
+  * Returns
+   * `Vector3` - A 3 dimensional vector containing the current real world physical controller angular (rotational) velocity.
+
+The GetControllerAngularVelocity method is used for getting the current rotational velocity of the physical game controller. This can be useful for determining which way the controller is being rotated and at what speed the rotation is occurring.
+
 #### HeadsetTransform/0
 
   > `public static Transform HeadsetTransform()`
@@ -5069,6 +5069,17 @@ The Base Headset SDK script provides a bridge to SDK methods that deal with the 
 This is an abstract class to implement the interface required by all implemented SDKs.
 
 ### Class Methods
+
+#### ProcessUpdate/1
+
+  > `public abstract void ProcessUpdate(Dictionary<string, object> options);`
+
+  * Parameters
+   * `Dictionary<string, object> options` - A dictionary of generic options that can be used to within the update.
+  * Returns
+   * _none_
+
+The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 #### GetHeadset/0
 
@@ -5970,6 +5981,17 @@ This is the fallback class that will just return default values.
 
 ### Class Methods
 
+#### ProcessUpdate/1
+
+  > `public override void ProcessUpdate(Dictionary<string, object> options)`
+
+  * Parameters
+   * `Dictionary<string, object> options` - A dictionary of generic options that can be used to within the update.
+  * Returns
+   * _none_
+
+The ProcessUpdate method enables an SDK to run logic for every Unity Update
+
 #### GetHeadset/0
 
   > `public override Transform GetHeadset()`
@@ -6842,6 +6864,17 @@ The Sim Headset SDK script  provides dummy functions for the headset.
 
 ### Class Methods
 
+#### ProcessUpdate/1
+
+  > `public override void ProcessUpdate(Dictionary<string, object> options)`
+
+  * Parameters
+   * `Dictionary<string, object> options` - A dictionary of generic options that can be used to within the update.
+  * Returns
+   * _none_
+
+The ProcessUpdate method enables an SDK to run logic for every Unity Update
+
 #### GetHeadset/0
 
   > `public override Transform GetHeadset()`
@@ -7710,6 +7743,17 @@ The SteamVR Headset SDK script provides a bridge to the SteamVR SDK.
 
 ### Class Methods
 
+#### ProcessUpdate/1
+
+  > `public override void ProcessUpdate(Dictionary<string, object> options)`
+
+  * Parameters
+   * `Dictionary<string, object> options` - A dictionary of generic options that can be used to within the update.
+  * Returns
+   * _none_
+
+The ProcessUpdate method enables an SDK to run logic for every Unity Update
+
 #### GetHeadset/0
 
   > `public override Transform GetHeadset()`
@@ -8577,6 +8621,17 @@ The ForceInterleavedReprojectionOn method determines whether Interleaved Reproje
 The OculusVR Headset SDK script provides a bridge to the OculusVR SDK.
 
 ### Class Methods
+
+#### ProcessUpdate/1
+
+  > `public override void ProcessUpdate(Dictionary<string, object> options)`
+
+  * Parameters
+   * `Dictionary<string, object> options` - A dictionary of generic options that can be used to within the update.
+  * Returns
+   * _none_
+
+The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 #### GetHeadset/0
 


### PR DESCRIPTION
The Velocity tracking on the controllers was originally done in
Controller Events, but this is not the best place for it as velocity
retrieval is not really an event. The Velocity and Angular Velocity
retrieval methods have now been moved to the Device Finder script.

The Controller SDK Update routine has also been moved out of
Controller Events and into the Tracked Controller script as this script
is always available in the scene.

An addition of a Tracked Headset script has also been added that runs
an Update routine for the headset within the SDK mimicking the
functionality of the Tracked Controller update.

The methods in the Controller Events script are still in place but have
been deprecated (and removed from the documentation) and now all they
do is pass through the call to the Device Finder.