### PR TITLE
fix(SDK): replace call to SteamVR_Util.Event as no longer in 1.2.0

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -729,11 +729,20 @@ namespace VRTK
         [RuntimeInitializeOnLoadMethod]
         private void Initialise()
         {
+#if STEAMVR_1_1_0_OR_OLDER
             SteamVR_Utils.Event.Listen("TrackedDeviceRoleChanged", OnTrackedDeviceRoleChanged);
+#else
+            SteamVR_Events.SystemAction("TrackedDeviceRoleChanged", OnTrackedDeviceRoleChanged);
+#endif
             SetTrackedControllerCaches(true);
         }
 
         private void OnTrackedDeviceRoleChanged(params object[] args)
+        {
+            SetTrackedControllerCaches(true);
+        }
+
+        private void OnTrackedDeviceRoleChanged(VREvent_t vrEvent)
         {
             SetTrackedControllerCaches(true);
         }


### PR DESCRIPTION
The SteamVR Plugin has been updated to version 1.2.0 and the method
`SteamVR_Util.Event` is no longer present and has not been deprecated
which causes errors to be thrown in VRTK as this method was used within
the SteamVR Controller SDK.

This fix updates the code to use the `SteamVR_Events.SystemAction` to
process the logic.

However, this method is not backward compatible with the SteamVR 1.1.0
plugin. To resolve this, the old code has been left in and wrapped in
a custom scripting define symbol of `STEAMVR_1_1_0_OR_OLDER` and if
a developer is still using an older version of the SteamVR plugin
such as 1.1.0 or earlier then they will need to add this custom
scripting define symbol in the `Edit -> Project Settings -> Player`
menu within the `Scripting Define Symbol` text box.