### PR TITLE
fix(SDK): run controller init code using Awake

### DIFF
--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
@@ -810,12 +810,6 @@ namespace VRTK
             return IsButtonPressed(index, ButtonPressTypes.TouchUp, OVRInput.Touch.Two);
         }
 
-        [RuntimeInitializeOnLoadMethod]
-        private void Initialise()
-        {
-            SetTrackedControllerCaches(true);
-        }
-
         private void SetTrackedControllerCaches(bool forceRefresh = false)
         {
             if (forceRefresh)

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -728,8 +728,7 @@ namespace VRTK
             return false;
         }
 
-        [RuntimeInitializeOnLoadMethod]
-        private void Initialise()
+        private void Awake()
         {
             Assembly executingAssembly = Assembly.GetExecutingAssembly();
             Type eventClass = executingAssembly.GetType("SteamVR_Utils").GetNestedType("Event");


### PR DESCRIPTION
The `Awake()` method is supported in the ScriptableObject so it's
more appropriate to use this and `[RuntimeInitializeOnLoadMethod]`
only works on static methods meaning the `Initialise()` method was
never being run.

The Oculus SDK doesn't need an Awake method as the controllers
are not ready to be cached at that time anyway and the cache setup
will be run the first time they are called, which is a more
appropriate time to set the cache up as the other dependencies will
be available.