### PR TITLE
feat(UIPointer): allow for auto click after pointer hover timer - resolves #819

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_EventSystemVRInput.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_EventSystemVRInput.cs
@@ -16,8 +16,9 @@
 
         public override void Process()
         {
-            foreach (var pointer in pointers)
+            for (int i = 0; i < pointers.Count; i++)
             {
+                VRTK_UIPointer pointer = pointers[i];
                 if (pointer.gameObject.activeInHierarchy && pointer.enabled)
                 {
                     List<RaycastResult> results = new List<RaycastResult>();
@@ -86,10 +87,25 @@
             return (canvasCheck && canvasCheck.enabled ? true : false);
         }
 
+        private void CheckPointerHoverClick(VRTK_UIPointer pointer, List<RaycastResult> results)
+        {
+            if (pointer.hoverDurationTimer > 0f)
+            {
+                pointer.hoverDurationTimer -= Time.deltaTime;
+            }
+
+            if (pointer.canClickOnHover && pointer.hoverDurationTimer <= 0f)
+            {
+                pointer.canClickOnHover = false;
+                ClickOnDown(pointer, results, true);
+            }
+        }
+
         private void Hover(VRTK_UIPointer pointer, List<RaycastResult> results)
         {
             if (pointer.pointerEventData.pointerEnter)
             {
+                CheckPointerHoverClick(pointer, results);
                 if (!ValidElement(pointer.pointerEventData.pointerEnter))
                 {
                     return;
@@ -170,9 +186,9 @@
             }
         }
 
-        private void ClickOnDown(VRTK_UIPointer pointer, List<RaycastResult> results)
+        private void ClickOnDown(VRTK_UIPointer pointer, List<RaycastResult> results, bool forceClick = false)
         {
-            pointer.pointerEventData.eligibleForClick = pointer.ValidClick(true);
+            pointer.pointerEventData.eligibleForClick = (forceClick ? true : pointer.ValidClick(true));
 
             if (IsEligibleClick(pointer, results))
             {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3933,6 +3933,7 @@ The UI pointer is activated via the `Pointer` alias on the `Controller Events` a
  * **Activation Mode:** Determines when the UI pointer should be active.
  * **Click Method:** Determines when the UI Click event action should happen.
  * **Attempt Click On Deactivate:** Determines whether the UI click action should be triggered when the pointer is deactivated. If the pointer is hovering over a clickable element then it will invoke the click action on that element. Note: Only works with `Click Method =  Click_On_Button_Up`
+ * **Click After Hover Duration:** The amount of time the pointer can be over the same UI element before it automatically attempts to click it. 0f means no click attempt will be made.
 
 ### Class Variables
 


### PR DESCRIPTION
A new `Click After Hover Duration` inspector parameter has been added
that means when the pointer is hovering over a UI element and has been
hovering over the same elemenet for the duration given in the param
then the UI Click will be triggered allowing for auto clicking items
which is useful for head gaze UI solutions.