### PR TITLE
fix(Interaction): AttemptHaptics now checks usingObject is valid.

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -144,13 +144,16 @@ namespace VRTK
             }
         }
 
-        private void AttemptHaptics()
-        {
-            var doHaptics = usingObject.GetComponentInParent<VRTK_InteractHaptics>();
-            if (doHaptics)
-            {
-                doHaptics.HapticsOnUse(controllerActions);
-            }
+		private void AttemptHaptics()
+		{
+			if (usingObject) 
+			{ 
+				var doHaptics = usingObject.GetComponentInParent<VRTK_InteractHaptics>();
+				if (doHaptics)
+				{
+					doHaptics.HapticsOnUse(controllerActions);
+				}
+			}
         }
 
         private void ToggleControllerVisibility(bool visible)


### PR DESCRIPTION
Brings it in line to the other AttemptHaptic functions (i.e on grab). Stops the object reference null error that can occur.