### PR TITLE
feat(SDK): add support for start button - resolves #816

### DIFF
--- a/Assets/VRTK/Examples/029_Controller_Tooltips.unity
+++ b/Assets/VRTK/Examples/029_Controller_Tooltips.unity
@@ -135,7 +135,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22412712, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16.5
       objectReference: {fileID: 0}
     - target: {fileID: 22482598, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_SizeDelta.x
@@ -143,7 +143,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22482598, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16.5
       objectReference: {fileID: 0}
     - target: {fileID: 441652, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_LocalScale.x
@@ -388,7 +388,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22412712, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16.5
       objectReference: {fileID: 0}
     - target: {fileID: 22482598, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_SizeDelta.x
@@ -396,7 +396,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22482598, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16.5
       objectReference: {fileID: 0}
     - target: {fileID: 441652, guid: 9ab61c80dfd411f4c86b8553b0c42cf1, type: 2}
       propertyPath: m_LocalScale.x
@@ -709,74 +709,6 @@ Prefab:
       value: R-Touchpad
       objectReference: {fileID: 0}
     - target: {fileID: 11415184, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: appMenuText
-      value: R-App Menu
-      objectReference: {fileID: 0}
-    - target: {fileID: 22476268, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22476268, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22422736, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22422736, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22465506, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22465506, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22481940, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22481940, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22442990, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22442990, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22432698, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22432698, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22482542, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22482542, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22454212, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22454212, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 11415184, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
       propertyPath: buttonOneText
       value: R-ButtonOne
       objectReference: {fileID: 0}
@@ -784,25 +716,9 @@ Prefab:
       propertyPath: buttonTwoText
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 224000011018885128, guid: 910be6460ba00dc4bb13725c3ff972cb,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 224000011018885128, guid: 910be6460ba00dc4bb13725c3ff972cb,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224000014259110642, guid: 910be6460ba00dc4bb13725c3ff972cb,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 62.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 224000014259110642, guid: 910be6460ba00dc4bb13725c3ff972cb,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
+    - target: {fileID: 11415184, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
+      propertyPath: startMenuText
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
@@ -864,6 +780,7 @@ MonoBehaviour:
   boundariesSDK: 1
   headsetSDK: 1
   controllerSDK: 1
+  autoManageScriptDefines: 1
   actualBoundaries: {fileID: 1188569438}
   actualHeadset: {fileID: 1589250222}
   actualLeftController: {fileID: 697789100}
@@ -1126,6 +1043,7 @@ MonoBehaviour:
   left: {fileID: 697789100}
   right: {fileID: 1996941625}
   objects: []
+  assignAllBeforeIdentified: 0
 --- !u!4 &1188569444
 Transform:
   m_ObjectHideFlags: 0
@@ -1151,7 +1069,6 @@ GameObject:
   m_Component:
   - 4: {fileID: 1282067424}
   - 20: {fileID: 1282067428}
-  - 114: {fileID: 1282067427}
   - 114: {fileID: 1282067426}
   - 92: {fileID: 1282067425}
   m_Layer: 0
@@ -1199,18 +1116,6 @@ MonoBehaviour:
   index: 0
   origin: {fileID: 0}
   isValid: 0
---- !u!114 &1282067427
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 11420968, guid: 4d293c8e162f3874b982baadd71153d2,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1282067423}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: be96d45fe21847a4a805d408a8015c84, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!20 &1282067428
 Camera:
   m_ObjectHideFlags: 0
@@ -1296,6 +1201,7 @@ MonoBehaviour:
     buttonOneModelPath: 
     buttonTwoModelPath: 
     systemMenuModelPath: 
+    startMenuModelPath: 
   elementHighlighterOverrides:
     body: {fileID: 0}
     trigger: {fileID: 0}
@@ -1305,6 +1211,7 @@ MonoBehaviour:
     buttonOne: {fileID: 0}
     buttonTwo: {fileID: 0}
     systemMenu: {fileID: 0}
+    startMenu: {fileID: 0}
 --- !u!1 &1355444891
 GameObject:
   m_ObjectHideFlags: 0
@@ -1533,6 +1440,10 @@ Prefab:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 11415184, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
+      propertyPath: startMenuText
+      value: 
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 910be6460ba00dc4bb13725c3ff972cb, type: 2}
   m_IsPrefabParent: 0
@@ -1732,6 +1643,7 @@ MonoBehaviour:
     buttonOneModelPath: 
     buttonTwoModelPath: 
     systemMenuModelPath: 
+    startMenuModelPath: 
   elementHighlighterOverrides:
     body: {fileID: 0}
     trigger: {fileID: 0}
@@ -1741,6 +1653,7 @@ MonoBehaviour:
     buttonOne: {fileID: 0}
     buttonTwo: {fileID: 0}
     systemMenu: {fileID: 0}
+    startMenu: {fileID: 0}
 --- !u!1 &1589250222
 GameObject:
   m_ObjectHideFlags: 0
@@ -1787,7 +1700,6 @@ MonoBehaviour:
   _head: {fileID: 1282067424}
   _ears: {fileID: 71119717}
   wireframe: 0
-  flip: {fileID: 0}
 --- !u!124 &1589250225
 Behaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/Resources/Scripts/VRTK_ControllerAppearance_Example.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/VRTK_ControllerAppearance_Example.cs
@@ -29,6 +29,12 @@
             events.ButtonOnePressed += new ControllerInteractionEventHandler(DoButtonOnePressed);
             events.ButtonOneReleased += new ControllerInteractionEventHandler(DoButtonOneReleased);
 
+            events.ButtonTwoPressed += new ControllerInteractionEventHandler(DoButtonTwoPressed);
+            events.ButtonTwoReleased += new ControllerInteractionEventHandler(DoButtonTwoReleased);
+
+            events.StartMenuPressed += new ControllerInteractionEventHandler(DoStartMenuPressed);
+            events.StartMenuReleased += new ControllerInteractionEventHandler(DoStartMenuReleased);
+
             events.GripPressed += new ControllerInteractionEventHandler(DoGripPressed);
             events.GripReleased += new ControllerInteractionEventHandler(DoGripReleased);
 
@@ -66,6 +72,40 @@
         {
             tooltips.ToggleTips(false, VRTK_ControllerTooltips.TooltipButtons.ButtonOneTooltip);
             actions.ToggleHighlightButtonOne(false);
+            if (!events.AnyButtonPressed())
+            {
+                actions.SetControllerOpacity(1f);
+            }
+        }
+
+        private void DoButtonTwoPressed(object sender, ControllerInteractionEventArgs e)
+        {
+            tooltips.ToggleTips(true, VRTK_ControllerTooltips.TooltipButtons.ButtonTwoTooltip);
+            actions.ToggleHighlightButtonTwo(true, Color.yellow, 0.5f);
+            actions.SetControllerOpacity(0.8f);
+        }
+
+        private void DoButtonTwoReleased(object sender, ControllerInteractionEventArgs e)
+        {
+            tooltips.ToggleTips(false, VRTK_ControllerTooltips.TooltipButtons.ButtonTwoTooltip);
+            actions.ToggleHighlightButtonTwo(false);
+            if (!events.AnyButtonPressed())
+            {
+                actions.SetControllerOpacity(1f);
+            }
+        }
+
+        private void DoStartMenuPressed(object sender, ControllerInteractionEventArgs e)
+        {
+            tooltips.ToggleTips(true, VRTK_ControllerTooltips.TooltipButtons.StartMenuTooltip);
+            actions.ToggleHighlightStartMenu(true, Color.yellow, 0.5f);
+            actions.SetControllerOpacity(0.8f);
+        }
+
+        private void DoStartMenuReleased(object sender, ControllerInteractionEventArgs e)
+        {
+            tooltips.ToggleTips(false, VRTK_ControllerTooltips.TooltipButtons.StartMenuTooltip);
+            actions.ToggleHighlightStartMenu(false);
             if (!events.AnyButtonPressed())
             {
                 actions.SetControllerOpacity(1f);

--- a/Assets/VRTK/Examples/Resources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
@@ -61,6 +61,9 @@
             GetComponent<VRTK_ControllerEvents>().ButtonTwoTouchStart += new ControllerInteractionEventHandler(DoButtonTwoTouchStart);
             GetComponent<VRTK_ControllerEvents>().ButtonTwoTouchEnd += new ControllerInteractionEventHandler(DoButtonTwoTouchEnd);
 
+            GetComponent<VRTK_ControllerEvents>().StartMenuPressed += new ControllerInteractionEventHandler(DoStartMenuPressed);
+            GetComponent<VRTK_ControllerEvents>().StartMenuReleased += new ControllerInteractionEventHandler(DoStartMenuReleased);
+
             GetComponent<VRTK_ControllerEvents>().ControllerEnabled += new ControllerInteractionEventHandler(DoControllerEnabled);
             GetComponent<VRTK_ControllerEvents>().ControllerDisabled += new ControllerInteractionEventHandler(DoControllerDisabled);
 
@@ -226,6 +229,16 @@
         private void DoButtonTwoTouchEnd(object sender, ControllerInteractionEventArgs e)
         {
             DebugLogger(e.controllerIndex, "BUTTON TWO", "untouched", e);
+        }
+
+        private void DoStartMenuPressed(object sender, ControllerInteractionEventArgs e)
+        {
+            DebugLogger(e.controllerIndex, "START MENU", "pressed down", e);
+        }
+
+        private void DoStartMenuReleased(object sender, ControllerInteractionEventArgs e)
+        {
+            DebugLogger(e.controllerIndex, "START MENU", "released", e);
         }
 
         private void DoControllerEnabled(object sender, ControllerInteractionEventArgs e)

--- a/Assets/VRTK/Prefabs/ControllerTooltips.prefab
+++ b/Assets/VRTK/Prefabs/ControllerTooltips.prefab
@@ -342,7 +342,7 @@ GameObject:
   - 4: {fileID: 414302}
   - 114: {fileID: 11402720}
   m_Layer: 2
-  m_Name: ButtonTwoTooltip
+  m_Name: StartMenuTooltip
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -517,15 +517,15 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 178472}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: 0.1274, y: 0.0156, z: 0.0434}
-  m_LocalScale: {x: 1, y: 0.99999964, z: 0.99999964}
+  m_LocalPosition: {x: 0.1233, y: 0.0156, z: -0.1569}
+  m_LocalScale: {x: 1, y: 0.9999993, z: 0.9999993}
   m_LocalEulerAnglesHint: {x: 89.980194, y: 0, z: 0}
   m_Children:
   - {fileID: 412680}
   - {fileID: 434770}
   - {fileID: 22498756}
   m_Father: {fileID: 479208}
-  m_RootOrder: 4
+  m_RootOrder: 5
 --- !u!4 &418306
 Transform:
   m_ObjectHideFlags: 1
@@ -651,6 +651,7 @@ Transform:
   - {fileID: 484582}
   - {fileID: 427840}
   - {fileID: 4000012396937550}
+  - {fileID: 4000014175454880}
   - {fileID: 414302}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -778,6 +779,7 @@ MonoBehaviour:
   touchpadText: Touchpad
   buttonOneText: ButtonOne
   buttonTwoText: ButtonTwo
+  startMenuText: StartMenu
   tipBackgroundColor: {r: 0, g: 0, b: 0, a: 1}
   tipTextColor: {r: 1, g: 1, b: 1, a: 1}
   tipLineColor: {r: 0, g: 0, b: 0, a: 1}
@@ -786,6 +788,7 @@ MonoBehaviour:
   touchpad: {fileID: 0}
   buttonOne: {fileID: 0}
   buttonTwo: {fileID: 0}
+  startMenu: {fileID: 0}
 --- !u!114 &11417476
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1961,6 +1964,57 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 151380}
   m_IsPrefabParent: 1
+--- !u!1 &1000011074126690
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000013056628304}
+  - 120: {fileID: 120000011353740912}
+  m_Layer: 2
+  m_Name: Line
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000011116365254
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000012273502934}
+  - 223: {fileID: 223000010039630650}
+  - 114: {fileID: 114000012363958314}
+  m_Layer: 2
+  m_Name: TooltipCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000011366120058
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000013893780094}
+  - 222: {fileID: 222000011982481808}
+  - 114: {fileID: 114000014093169502}
+  - 114: {fileID: 114000013268699548}
+  m_Layer: 2
+  m_Name: UITextReverse
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000011486596710
 GameObject:
   m_ObjectHideFlags: 1
@@ -1969,6 +2023,54 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 4000011546663224}
+  m_Layer: 2
+  m_Name: LineStart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000011740718424
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000013895493572}
+  - 222: {fileID: 222000013241926666}
+  - 114: {fileID: 114000013101879482}
+  m_Layer: 2
+  m_Name: UIContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000011905105796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000014175454880}
+  - 114: {fileID: 114000014163857056}
+  m_Layer: 2
+  m_Name: ButtonTwoTooltip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1000012379195038
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000014165330106}
   m_Layer: 2
   m_Name: LineStart
   m_TagString: Untagged
@@ -2044,6 +2146,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000013362805168
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 224000012153209662}
+  - 222: {fileID: 222000013341157098}
+  - 114: {fileID: 114000011299360962}
+  - 114: {fileID: 114000011045427428}
+  m_Layer: 2
+  m_Name: UITextFront
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000013380415750
 GameObject:
   m_ObjectHideFlags: 1
@@ -2107,6 +2227,19 @@ Transform:
   - {fileID: 224000012279963300}
   m_Father: {fileID: 479208}
   m_RootOrder: 3
+--- !u!4 &4000013056628304
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011074126690}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000014175454880}
+  m_RootOrder: 0
 --- !u!4 &4000013287511056
 Transform:
   m_ObjectHideFlags: 1
@@ -2120,6 +2253,35 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000012396937550}
   m_RootOrder: 0
+--- !u!4 &4000014165330106
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012379195038}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.05, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000014175454880}
+  m_RootOrder: 1
+--- !u!4 &4000014175454880
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011905105796}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: 0.1274, y: 0.0156, z: 0.0434}
+  m_LocalScale: {x: 1, y: 0.99999964, z: 0.99999964}
+  m_LocalEulerAnglesHint: {x: 89.980194, y: 0, z: 0}
+  m_Children:
+  - {fileID: 4000013056628304}
+  - {fileID: 4000014165330106}
+  - {fileID: 224000012273502934}
+  m_Father: {fileID: 479208}
+  m_RootOrder: 4
 --- !u!114 &114000010349668930
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2141,6 +2303,52 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 2
+--- !u!114 &114000011045427428
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013362805168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1741964061, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &114000011299360962
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013362805168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 15
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 300
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: New Text
 --- !u!114 &114000011734848668
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2234,6 +2442,27 @@ MonoBehaviour:
     m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: New Text
+--- !u!114 &114000012363958314
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011116365254}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 1
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 2
 --- !u!114 &114000012444902488
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2254,6 +2483,46 @@ MonoBehaviour:
   fontColor: {r: 1, g: 1, b: 1, a: 1}
   containerColor: {r: 0, g: 0, b: 0, a: 1}
   lineColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!114 &114000013101879482
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011740718424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.36764705, g: 0.5551724, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114000013268699548
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011366120058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1741964061, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
 --- !u!114 &114000013797038712
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2267,6 +2536,59 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
+--- !u!114 &114000014093169502
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011366120058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 15
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 300
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: New Text
+--- !u!114 &114000014163857056
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011905105796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58ed683b89cd94a44bb399806ce5cce6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  displayText: TooltipText
+  fontSize: 14
+  containerSize: {x: 100, y: 30}
+  drawLineFrom: {fileID: 4000014165330106}
+  drawLineTo: {fileID: 0}
+  lineWidth: 0.001
+  fontColor: {r: 1, g: 1, b: 1, a: 1}
+  containerColor: {r: 0, g: 0, b: 0, a: 1}
+  lineColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!114 &114000014261854206
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2280,6 +2602,48 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
+--- !u!120 &120000011353740912
+LineRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011074126690}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}
+  m_Parameters:
+    startWidth: 0.001
+    endWidth: 0.001
+    m_StartColor:
+      serializedVersion: 2
+      rgba: 4278190080
+    m_EndColor:
+      serializedVersion: 2
+      rgba: 4278190080
+  m_UseWorldSpace: 1
 --- !u!120 &120000011431987130
 LineRenderer:
   m_ObjectHideFlags: 1
@@ -2328,18 +2692,55 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000013000720922}
+--- !u!222 &222000011982481808
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011366120058}
 --- !u!222 &222000012114728242
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012694676508}
+--- !u!222 &222000013241926666
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011740718424}
 --- !u!222 &222000013305234862
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000014186441226}
+--- !u!222 &222000013341157098
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013362805168}
+--- !u!223 &223000010039630650
+Canvas:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011116365254}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!223 &223000011099627710
 Canvas:
   m_ObjectHideFlags: 1
@@ -2395,6 +2796,45 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000012153209662
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013362805168}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000012273502934}
+  m_RootOrder: 1
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000012273502934
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011116365254}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 224000013895493572}
+  - {fileID: 224000012153209662}
+  - {fileID: 224000013893780094}
+  m_Father: {fileID: 4000014175454880}
+  m_RootOrder: 2
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.1, y: 0.03}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000012279963300
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2415,6 +2855,42 @@ RectTransform:
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0.1, y: 0.03}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000013893780094
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011366120058}
+  m_LocalRotation: {x: 7.1054274e-15, y: 1, z: 0, w: -0.00000016292068}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000012273502934}
+  m_RootOrder: 2
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224000013895493572
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011740718424}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 224000012273502934}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000014259110642
 RectTransform:

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -20,12 +20,13 @@ namespace VRTK
     {
         public enum TooltipButtons
         {
+            None,
             TriggerTooltip,
             GripTooltip,
             TouchpadTooltip,
             ButtonOneTooltip,
             ButtonTwoTooltip,
-            None
+            StartMenuTooltip
         }
 
         [Tooltip("The text to display for the trigger button action.")]
@@ -38,6 +39,8 @@ namespace VRTK
         public string buttonOneText;
         [Tooltip("The text to display for button two action.")]
         public string buttonTwoText;
+        [Tooltip("The text to display for the start menu action.")]
+        public string startMenuText;
         [Tooltip("The colour to use for the tooltip background container.")]
         public Color tipBackgroundColor = Color.black;
         [Tooltip("The colour to use for the text within the tooltip.")]
@@ -54,12 +57,15 @@ namespace VRTK
         public Transform buttonOne;
         [Tooltip("The transform for the position of button two on the controller.")]
         public Transform buttonTwo;
+        [Tooltip("The transform for the position of the start menu on the controller.")]
+        public Transform startMenu;
 
         private bool triggerInitialised = false;
         private bool gripInitialised = false;
         private bool touchpadInitialised = false;
         private bool buttonOneInitialised = false;
         private bool buttonTwoInitialised = false;
+        private bool startMenuInitialised = false;
         private TooltipButtons[] availableButtons;
         private VRTK_ObjectTooltip[] buttonTooltips;
         private bool[] tooltipStates;
@@ -76,6 +82,7 @@ namespace VRTK
             touchpadInitialised = false;
             buttonOneInitialised = false;
             buttonTwoInitialised = false;
+            startMenuInitialised = false;
         }
 
         /// <summary>
@@ -92,6 +99,9 @@ namespace VRTK
                     break;
                 case TooltipButtons.ButtonTwoTooltip:
                     buttonTwoText = newText;
+                    break;
+                case TooltipButtons.StartMenuTooltip:
+                    startMenuText = newText;
                     break;
                 case TooltipButtons.GripTooltip:
                     gripText = newText;
@@ -140,6 +150,7 @@ namespace VRTK
             touchpadInitialised = false;
             buttonOneInitialised = false;
             buttonTwoInitialised = false;
+            startMenuInitialised = false;
 
             availableButtons = new TooltipButtons[]
             {
@@ -147,7 +158,8 @@ namespace VRTK
                 TooltipButtons.GripTooltip,
                 TooltipButtons.TouchpadTooltip,
                 TooltipButtons.ButtonOneTooltip,
-                TooltipButtons.ButtonTwoTooltip
+                TooltipButtons.ButtonTwoTooltip,
+                TooltipButtons.StartMenuTooltip
             };
 
             buttonTooltips = new VRTK_ObjectTooltip[availableButtons.Length];
@@ -278,6 +290,14 @@ namespace VRTK
                             buttonTwoInitialised = true;
                         }
                         break;
+                    case "startmenu":
+                        tipText = startMenuText;
+                        tipTransform = GetTransform(startMenu, SDK_BaseController.ControllerElements.StartMenu);
+                        if (tipTransform != null)
+                        {
+                            startMenuInitialised = true;
+                        }
+                        break;
                 }
 
                 tooltip.displayText = tipText;
@@ -298,7 +318,7 @@ namespace VRTK
 
         private bool TipsInitialised()
         {
-            return (triggerInitialised && gripInitialised && touchpadInitialised && (buttonOneInitialised || buttonTwoInitialised));
+            return (triggerInitialised && gripInitialised && touchpadInitialised && (buttonOneInitialised || buttonTwoInitialised || startMenuInitialised));
         }
 
         private Transform GetTransform(Transform setTransform, SDK_BaseController.ControllerElements findElement)

--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -43,6 +43,7 @@ namespace VRTK
         /// <param name="ButtonTwo">The second generic button.</param>
         /// <param name="SystemMenu">The system menu button.</param>
         /// <param name="Body">The encompassing mesh of the controller body.</param>
+        /// <param name="StartMenu">The start menu button.</param>
         public enum ControllerElements
         {
             AttachPoint,
@@ -53,7 +54,8 @@ namespace VRTK
             ButtonOne,
             ButtonTwo,
             SystemMenu,
-            Body
+            Body,
+            StartMenu
         }
 
         /// <summary>
@@ -493,6 +495,48 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public abstract bool IsButtonTwoTouchedUpOnIndex(uint index);
 
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public abstract bool IsStartMenuPressedOnIndex(uint index);
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public abstract bool IsStartMenuPressedDownOnIndex(uint index);
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public abstract bool IsStartMenuPressedUpOnIndex(uint index);
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public abstract bool IsStartMenuTouchedOnIndex(uint index);
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public abstract bool IsStartMenuTouchedDownOnIndex(uint index);
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public abstract bool IsStartMenuTouchedUpOnIndex(uint index);
+
         protected GameObject GetSDKManagerControllerLeftHand(bool actual = false)
         {
             var sdkManager = VRTK_SDKManager.instance;
@@ -526,7 +570,7 @@ namespace VRTK
         protected bool CheckControllerLeftHand(GameObject controller, bool actual)
         {
             var sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
+            if (sdkManager != null && controller)
             {
                 return (actual ? controller.Equals(sdkManager.actualLeftController) : controller.Equals(sdkManager.scriptAliasLeftController));
             }
@@ -536,7 +580,7 @@ namespace VRTK
         protected bool CheckControllerRightHand(GameObject controller, bool actual)
         {
             var sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
+            if (sdkManager != null && controller)
             {
                 return (actual ? controller.Equals(sdkManager.actualRightController) : controller.Equals(sdkManager.scriptAliasRightController));
             }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -612,6 +612,66 @@ namespace VRTK
             return false;
         }
 
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
         private void Awake()
         {
             Debug.LogError("Fallback Controller SDK is being used. Have you selected a valid Controller SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Controller SDK from the dropdown.");

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
@@ -40,12 +40,16 @@ namespace VRTK
         /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
         public override void ProcessUpdate(uint index, Dictionary<string, object> options)
         {
-            var device = GetTrackedObject(GetControllerByIndex(index));
-            previousControllerRotations[index] = currentControllerRotations[index];
-            currentControllerRotations[index] = device.transform.rotation;
 
-            UpdateHairValues(index, GetTriggerAxisOnIndex(index).x, GetTriggerHairlineDeltaOnIndex(index), ref previousHairTriggerState[index], ref currentHairTriggerState[index], ref hairTriggerLimit[index]);
-            UpdateHairValues(index, GetGripAxisOnIndex(index).x, GetGripHairlineDeltaOnIndex(index), ref previousHairGripState[index], ref currentHairGripState[index], ref hairGripLimit[index]);
+            if (index < uint.MaxValue)
+            {
+                var device = GetTrackedObject(GetControllerByIndex(index));
+                previousControllerRotations[index] = currentControllerRotations[index];
+                currentControllerRotations[index] = device.transform.rotation;
+
+                UpdateHairValues(index, GetTriggerAxisOnIndex(index).x, GetTriggerHairlineDeltaOnIndex(index), ref previousHairTriggerState[index], ref currentHairTriggerState[index], ref hairTriggerLimit[index]);
+                UpdateHairValues(index, GetGripAxisOnIndex(index).x, GetGripHairlineDeltaOnIndex(index), ref previousHairGripState[index], ref currentHairGripState[index], ref hairGripLimit[index]);
+            }
         }
 
         /// <summary>
@@ -98,6 +102,8 @@ namespace VRTK
                     case ControllerElements.ButtonTwo:
                         return path + "button02" + suffix;
                     case ControllerElements.SystemMenu:
+                        return path + "button03" + suffix;
+                    case ControllerElements.StartMenu:
                         return path + "button03" + suffix;
                     case ControllerElements.Body:
                         return parent;
@@ -808,6 +814,66 @@ namespace VRTK
         public override bool IsButtonTwoTouchedUpOnIndex(uint index)
         {
             return IsButtonPressed(index, ButtonPressTypes.TouchUp, OVRInput.Touch.Two);
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return IsButtonPressed(index, ButtonPressTypes.Press, OVRInput.Button.Start);
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, OVRInput.Button.Start);
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, OVRInput.Button.Start);
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuTouchedUpOnIndex(uint index)
+        {
+            return false;
         }
 
         private void SetTrackedControllerCaches(bool forceRefresh = false)

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -10,7 +10,16 @@ namespace VRTK
     /// </summary>
     public class SDK_SimController : SDK_BaseController
     {
-        SimControllers controllers;
+        private SimControllers controllers;
+        private Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
+        {
+            {"Trigger", KeyCode.Mouse1 },
+            {"Grip", KeyCode.Mouse0 },
+            {"TouchpadPress", KeyCode.Q },
+            {"ButtonOne", KeyCode.E },
+            {"ButtonTwo", KeyCode.R },
+            {"StartMenu", KeyCode.F }
+        };
 
         /// <summary>
         /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
@@ -368,7 +377,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsTriggerPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, KeyCode.Mouse1);
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["Trigger"]);
         }
 
         /// <summary>
@@ -378,7 +387,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsTriggerPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, KeyCode.Mouse1);
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["Trigger"]);
         }
 
         /// <summary>
@@ -388,7 +397,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsTriggerPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, KeyCode.Mouse1);
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["Trigger"]);
         }
 
         /// <summary>
@@ -448,7 +457,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsGripPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, KeyCode.Mouse0);
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["Grip"]);
         }
 
         /// <summary>
@@ -458,7 +467,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsGripPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, KeyCode.Mouse0);
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["Grip"]);
         }
 
         /// <summary>
@@ -468,7 +477,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsGripPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, KeyCode.Mouse0);
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["Grip"]);
         }
 
         /// <summary>
@@ -528,7 +537,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsTouchpadPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, KeyCode.Q);
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["TouchpadPress"]);
         }
 
         /// <summary>
@@ -538,7 +547,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsTouchpadPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, KeyCode.Q);
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["TouchpadPress"]);
         }
 
         /// <summary>
@@ -548,7 +557,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsTouchpadPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, KeyCode.Q);
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["TouchpadPress"]);
         }
 
         /// <summary>
@@ -588,7 +597,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsButtonOnePressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, KeyCode.E);
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["ButtonOne"]);
         }
 
         /// <summary>
@@ -598,7 +607,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsButtonOnePressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, KeyCode.E);
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["ButtonOne"]);
         }
 
         /// <summary>
@@ -608,7 +617,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonOnePressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, KeyCode.E);
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["ButtonOne"]);
         }
 
         /// <summary>
@@ -648,7 +657,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsButtonTwoPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, KeyCode.R);
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["ButtonTwo"]);
         }
 
         /// <summary>
@@ -658,7 +667,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsButtonTwoPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, KeyCode.R);
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["ButtonTwo"]);
         }
 
         /// <summary>
@@ -668,7 +677,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonTwoPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, KeyCode.R);
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["ButtonTwo"]);
         }
 
         /// <summary>
@@ -697,6 +706,66 @@ namespace VRTK
         /// <param name="index">The index of the tracked object to check for.</param>
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonTwoTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["StartMenu"]);
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["StartMenu"]);
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["StartMenu"]);
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuTouchedUpOnIndex(uint index)
         {
             return false;
         }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -728,6 +728,66 @@ namespace VRTK
             return false;
         }
 
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
         private void Awake()
         {
             Assembly executingAssembly = Assembly.GetExecutingAssembly();

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -325,6 +325,38 @@
             return GetControllerSDK().IsButtonTwoTouchedUpOnIndex(index);
         }
 
+        //StartMenu
+
+        public static bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return GetControllerSDK().IsStartMenuPressedOnIndex(index);
+        }
+
+        public static bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return GetControllerSDK().IsStartMenuPressedDownOnIndex(index);
+        }
+
+        public static bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return GetControllerSDK().IsStartMenuPressedUpOnIndex(index);
+        }
+
+        public static bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return GetControllerSDK().IsStartMenuTouchedOnIndex(index);
+        }
+
+        public static bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return GetControllerSDK().IsStartMenuTouchedDownOnIndex(index);
+        }
+
+        public static bool IsStartMenuTouchedUpOnIndex(uint index)
+        {
+            return GetControllerSDK().IsStartMenuTouchedUpOnIndex(index);
+        }
+
         public static Transform GetHeadset()
         {
             return GetHeadsetSDK().GetHeadset();

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerActions.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerActions.cs
@@ -17,6 +17,7 @@ namespace VRTK
         public string buttonOneModelPath = "";
         public string buttonTwoModelPath = "";
         public string systemMenuModelPath = "";
+        public string startMenuModelPath = "";
     }
 
     [System.Serializable]
@@ -30,6 +31,7 @@ namespace VRTK
         public VRTK_BaseHighlighter buttonOne;
         public VRTK_BaseHighlighter buttonTwo;
         public VRTK_BaseHighlighter systemMenu;
+        public VRTK_BaseHighlighter startMenu;
     }
 
     /// <summary>
@@ -303,6 +305,21 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The ToggleHighlightStartMenu method is a shortcut method that makes it easier to toggle the highlight state of the start menu controller element.
+        /// </summary>
+        /// <param name="state">The highlight colour state, `true` will enable the highlight on the start menu and `false` will remove the highlight from the start menu.</param>
+        /// <param name="highlight">The colour to highlight the start menu with.</param>
+        /// <param name="duration">The duration of fade from white to the highlight colour.</param>
+        public void ToggleHighlightStartMenu(bool state, Color? highlight = null, float duration = 0f)
+        {
+            if (!state && controllerHighlighted)
+            {
+                return;
+            }
+            ToggleHighlightAlias(state, modelElementPaths.startMenuModelPath, highlight, duration);
+        }
+
+        /// <summary>
         /// The ToggleHighlighBody method is a shortcut method that makes it easier to toggle the highlight state of the controller body element.
         /// </summary>
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the body and `false` will remove the highlight from the body.</param>
@@ -331,6 +348,7 @@ namespace VRTK
             ToggleHighlightTouchpad(state, highlight, duration);
             ToggleHighlightButtonOne(state, highlight, duration);
             ToggleHighlightButtonTwo(state, highlight, duration);
+            ToggleHighlightStartMenu(state, highlight, duration);
             ToggleHighlightAlias(state, modelElementPaths.systemMenuModelPath, highlight, duration);
             ToggleHighlightAlias(state, modelElementPaths.bodyModelPath, highlight, duration);
         }
@@ -388,6 +406,7 @@ namespace VRTK
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.Body, controllerHand)), objectHighlighter, elementHighlighterOverrides.body);
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.GripLeft, controllerHand)), objectHighlighter, elementHighlighterOverrides.gripLeft);
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.GripRight, controllerHand)), objectHighlighter, elementHighlighterOverrides.gripRight);
+            AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.StartMenu, controllerHand)), objectHighlighter, elementHighlighterOverrides.startMenu);
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.SystemMenu, controllerHand)), objectHighlighter, elementHighlighterOverrides.systemMenu);
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.Touchpad, controllerHand)), objectHighlighter, elementHighlighterOverrides.touchpad);
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.Trigger, controllerHand)), objectHighlighter, elementHighlighterOverrides.trigger);
@@ -430,6 +449,10 @@ namespace VRTK
             if (modelElementPaths.systemMenuModelPath.Trim() == "")
             {
                 modelElementPaths.systemMenuModelPath = VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.SystemMenu, controllerHand);
+            }
+            if (modelElementPaths.startMenuModelPath.Trim() == "")
+            {
+                modelElementPaths.startMenuModelPath = VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.StartMenu, controllerHand);
             }
         }
 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_MoveInPlace.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_MoveInPlace.cs
@@ -518,6 +518,10 @@ namespace VRTK
                             controllerEvent.ButtonTwoTouchStart -= engageButtonPressed;
                             controllerEvent.ButtonTwoTouchEnd -= engageButtonUp;
                             break;
+                        case VRTK_ControllerEvents.ButtonAlias.Start_Menu_Press:
+                            controllerEvent.StartMenuPressed -= engageButtonPressed;
+                            controllerEvent.StartMenuReleased -= engageButtonUp;
+                            break;
                     }
                     subscribed = false;
                 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -141,6 +141,15 @@
         public UnityObjectEvent OnButtonTwoTouchEnd;
 
         /// <summary>
+        /// Emits the StartMenuPressed class event.
+        /// </summary>
+        public UnityObjectEvent OnStartMenuPressed;
+        /// <summary>
+        /// Emits the StartMenuReleased class event.
+        /// </summary>
+        public UnityObjectEvent OnStartMenuReleased;
+
+        /// <summary>
         /// Emits the AliasPointerOn class event.
         /// </summary>
         public UnityObjectEvent OnAliasPointerOn;
@@ -249,6 +258,9 @@
             ce.ButtonTwoReleased += ButtonTwoReleased;
             ce.ButtonTwoTouchStart += ButtonTwoTouchStart;
             ce.ButtonTwoTouchEnd += ButtonTwoTouchEnd;
+
+            ce.StartMenuPressed += StartMenuPressed;
+            ce.StartMenuReleased += StartMenuReleased;
 
             ce.AliasPointerOn += AliasPointerOn;
             ce.AliasPointerOff += AliasPointerOff;
@@ -422,6 +434,16 @@
             OnButtonTwoTouchEnd.Invoke(o, e);
         }
 
+        private void StartMenuPressed(object o, ControllerInteractionEventArgs e)
+        {
+            OnStartMenuPressed.Invoke(o, e);
+        }
+
+        private void StartMenuReleased(object o, ControllerInteractionEventArgs e)
+        {
+            OnStartMenuReleased.Invoke(o, e);
+        }
+
         private void AliasPointerOn(object o, ControllerInteractionEventArgs e)
         {
             OnAliasPointerOn.Invoke(o, e);
@@ -534,6 +556,9 @@
             ce.ButtonTwoReleased -= ButtonTwoReleased;
             ce.ButtonTwoTouchStart -= ButtonTwoTouchStart;
             ce.ButtonTwoTouchEnd -= ButtonTwoTouchEnd;
+
+            ce.StartMenuPressed -= StartMenuPressed;
+            ce.StartMenuReleased -= StartMenuReleased;
 
             ce.AliasPointerOn -= AliasPointerOn;
             ce.AliasPointerOff -= AliasPointerOff;

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -171,6 +171,7 @@ There are a number of parameters that can be set on the Prefab which are provide
  * **Touchpad Text:** The text to display for the touchpad action.
  * **Button One Text:** The text to display for button one action.
  * **Button Two Text:** The text to display for button two action.
+ * **Start Menu Text:** The text to display for the start menu action.
  * **Tip Background Color:** The colour to use for the tooltip background container.
  * **Tip Text Color:** The colour to use for the text within the tooltip.
  * **Tip Line Color:** The colour to use for the line between the tooltip and the relevant controller button.
@@ -179,6 +180,7 @@ There are a number of parameters that can be set on the Prefab which are provide
  * **Touchpad:** The transform for the position of the touchpad button on the controller.
  * **Button One:** The transform for the position of button one on the controller.
  * **Button Two:** The transform for the position of button two on the controller.
+ * **Start Menu:** The transform for the position of the start menu on the controller.
 
 ### Class Methods
 
@@ -1161,6 +1163,7 @@ The script also has a public boolean pressed state for the buttons to allow the 
 ### Class Variables
 
  * `public enum ButtonAlias` - Button types
+  * `Undefined` - No button specified
   * `Trigger_Hairline` - The trigger is squeezed past the current hairline threshold.
   * `Trigger_Touch` - The trigger is squeezed a small amount.
   * `Trigger_Press` - The trigger is squeezed about half way in.
@@ -1173,7 +1176,9 @@ The script also has a public boolean pressed state for the buttons to allow the 
   * `Touchpad_Press` - The touchpad is pressed (to the point of hearing a click).
   * `Button_One_Touch` - The button one is touched.
   * `Button_One_Press` - The button one is pressed.
-  * `Undefined` - No button specified
+  * `Button_Two_Touch` - The button one is touched.
+  * `Button_Two_Press` - The button one is pressed.
+  * `Start_Menu_Press` - The button one is pressed.
  * `public bool triggerPressed` - This will be true if the trigger is squeezed about half way in. Default: `false`
  * `public bool triggerTouched` - This will be true if the trigger is squeezed a small amount. Default: `false`
  * `public bool triggerHairlinePressed` - This will be true if the trigger is squeezed a small amount more from any previous squeeze on the trigger. Default: `false`
@@ -1191,6 +1196,7 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `public bool buttonOneTouched` - This will be true if button one is being touched. Default: `false`
  * `public bool buttonTwoPressed` - This will be true if button two is held down. Default: `false`
  * `public bool buttonTwoTouched` - This will be true if button two is being touched. Default: `false`
+ * `public bool startMenuPressed` - This will be true if start menu is held down. Default: `false`
  * `public bool pointerPressed` - This will be true if the button aliased to the pointer is held down. Default: `false`
  * `public bool grabPressed` - This will be true if the button aliased to the grab is held down. Default: `false`
  * `public bool usePressed` - This will be true if the button aliased to the use is held down. Default: `false`
@@ -1230,6 +1236,8 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `ButtonTwoTouchEnd` - Emitted when button two is no longer being touched.
  * `ButtonTwoPressed` - Emitted when button two is pressed.
  * `ButtonTwoReleased` - Emitted when button two is released.
+ * `StartMenuPressed` - Emitted when start menu is pressed.
+ * `StartMenuReleased` - Emitted when start menu is released.
  * `AliasPointerOn` - Emitted when the pointer toggle alias button is pressed.
  * `AliasPointerOff` - Emitted when the pointer toggle alias button is released.
  * `AliasPointerSet` - Emitted when the pointer set alias button is released.
@@ -1280,6 +1288,8 @@ Adding the `VRTK_ControllerEvents_UnityEvents` component to `VRTK_ControllerEven
  * `OnButtonTwoReleased` - Emits the ButtonTwoReleased class event.
  * `OnButtonTwoTouchStart` - Emits the ButtonTwoTouchStart class event.
  * `OnButtonTwoTouchEnd` - Emits the ButtonTwoTouchEnd class event.
+ * `OnStartMenuPressed` - Emits the StartMenuPressed class event.
+ * `OnStartMenuReleased` - Emits the StartMenuReleased class event.
  * `OnAliasPointerOn` - Emits the AliasPointerOn class event.
  * `OnAliasPointerOff` - Emits the AliasPointerOff class event.
  * `OnAliasPointerSet` - Emits the AliasPointerSet class event.
@@ -1581,6 +1591,19 @@ The ToggleHighlightButtonOne method is a shortcut method that makes it easier to
    * _none_
 
 The ToggleHighlightButtonTwo method is a shortcut method that makes it easier to toggle the highlight state of the button two controller element.
+
+#### ToggleHighlightStartMenu/3
+
+  > `public void ToggleHighlightStartMenu(bool state, Color? highlight = null, float duration = 0f)`
+
+  * Parameters
+   * `bool state` - The highlight colour state, `true` will enable the highlight on the start menu and `false` will remove the highlight from the start menu.
+   * `Color? highlight` - The colour to highlight the start menu with.
+   * `float duration` - The duration of fade from white to the highlight colour.
+  * Returns
+   * _none_
+
+The ToggleHighlightStartMenu method is a shortcut method that makes it easier to toggle the highlight state of the start menu controller element.
 
 #### ToggleHighlighBody/3
 
@@ -5171,6 +5194,7 @@ This is an abstract class to implement the interface required by all implemented
   * `ButtonTwo` - The second generic button.
   * `SystemMenu` - The system menu button.
   * `Body` - The encompassing mesh of the controller body.
+  * `StartMenu` - The start menu button.
  * `public enum ControllerHand` - Controller hand reference.
   * `None` - No hand is assigned.
   * `Left` - The left hand is assigned.
@@ -5845,6 +5869,72 @@ The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller 
    * `bool` - Returns true if the button has just been released.
 
 The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuPressedOnIndex/1
+
+  > `public abstract bool IsStartMenuPressedOnIndex(uint index);`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being pressed.
+
+The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+
+#### IsStartMenuPressedDownOnIndex/1
+
+  > `public abstract bool IsStartMenuPressedDownOnIndex(uint index);`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been pressed down.
+
+The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+
+#### IsStartMenuPressedUpOnIndex/1
+
+  > `public abstract bool IsStartMenuPressedUpOnIndex(uint index);`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuTouchedOnIndex/1
+
+  > `public abstract bool IsStartMenuTouchedOnIndex(uint index);`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being touched.
+
+The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+
+#### IsStartMenuTouchedDownOnIndex/1
+
+  > `public abstract bool IsStartMenuTouchedDownOnIndex(uint index);`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been touched down.
+
+The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+
+#### IsStartMenuTouchedUpOnIndex/1
+
+  > `public abstract bool IsStartMenuTouchedUpOnIndex(uint index);`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
 
 ---
 
@@ -6733,6 +6823,72 @@ The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller 
 
 The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
 
+#### IsStartMenuPressedOnIndex/1
+
+  > `public override bool IsStartMenuPressedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being pressed.
+
+The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+
+#### IsStartMenuPressedDownOnIndex/1
+
+  > `public override bool IsStartMenuPressedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been pressed down.
+
+The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+
+#### IsStartMenuPressedUpOnIndex/1
+
+  > `public override bool IsStartMenuPressedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuTouchedOnIndex/1
+
+  > `public override bool IsStartMenuTouchedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being touched.
+
+The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+
+#### IsStartMenuTouchedDownOnIndex/1
+
+  > `public override bool IsStartMenuTouchedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been touched down.
+
+The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+
+#### IsStartMenuTouchedUpOnIndex/1
+
+  > `public override bool IsStartMenuTouchedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+
 ---
 
 ## Fallback Boundaries (SDK_FallbackBoundaries)
@@ -7614,6 +7770,72 @@ The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller 
 
 The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
 
+#### IsStartMenuPressedOnIndex/1
+
+  > `public override bool IsStartMenuPressedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being pressed.
+
+The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+
+#### IsStartMenuPressedDownOnIndex/1
+
+  > `public override bool IsStartMenuPressedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been pressed down.
+
+The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+
+#### IsStartMenuPressedUpOnIndex/1
+
+  > `public override bool IsStartMenuPressedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuTouchedOnIndex/1
+
+  > `public override bool IsStartMenuTouchedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being touched.
+
+The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+
+#### IsStartMenuTouchedDownOnIndex/1
+
+  > `public override bool IsStartMenuTouchedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been touched down.
+
+The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+
+#### IsStartMenuTouchedUpOnIndex/1
+
+  > `public override bool IsStartMenuTouchedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+
 ---
 
 ## Simulator Boundaries (SDK_SimBoundaries)
@@ -8493,6 +8715,72 @@ The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller 
 
 The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
 
+#### IsStartMenuPressedOnIndex/1
+
+  > `public override bool IsStartMenuPressedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being pressed.
+
+The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+
+#### IsStartMenuPressedDownOnIndex/1
+
+  > `public override bool IsStartMenuPressedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been pressed down.
+
+The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+
+#### IsStartMenuPressedUpOnIndex/1
+
+  > `public override bool IsStartMenuPressedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuTouchedOnIndex/1
+
+  > `public override bool IsStartMenuTouchedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being touched.
+
+The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+
+#### IsStartMenuTouchedDownOnIndex/1
+
+  > `public override bool IsStartMenuTouchedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been touched down.
+
+The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+
+#### IsStartMenuTouchedUpOnIndex/1
+
+  > `public override bool IsStartMenuTouchedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+
 ---
 
 ## SteamVR Boundaries (SDK_SteamVRBoundaries)
@@ -9371,6 +9659,72 @@ The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller 
    * `bool` - Returns true if the button has just been released.
 
 The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuPressedOnIndex/1
+
+  > `public override bool IsStartMenuPressedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being pressed.
+
+The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+
+#### IsStartMenuPressedDownOnIndex/1
+
+  > `public override bool IsStartMenuPressedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been pressed down.
+
+The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+
+#### IsStartMenuPressedUpOnIndex/1
+
+  > `public override bool IsStartMenuPressedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+
+#### IsStartMenuTouchedOnIndex/1
+
+  > `public override bool IsStartMenuTouchedOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button is continually being touched.
+
+The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+
+#### IsStartMenuTouchedDownOnIndex/1
+
+  > `public override bool IsStartMenuTouchedDownOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been touched down.
+
+The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+
+#### IsStartMenuTouchedUpOnIndex/1
+
+  > `public override bool IsStartMenuTouchedUpOnIndex(uint index)`
+
+  * Parameters
+   * `uint index` - The index of the tracked object to check for.
+  * Returns
+   * `bool` - Returns true if the button has just been released.
+
+The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
 
 ---
 


### PR DESCRIPTION
The Oculus SDK supports a start button as the left controller
menu button can be overriden to be used as a start button although
the right controller menu button is reserved for Oculus Home.

This adds the support for the start button to the Oculus SDK and to
any other VRTK classes or prefabs that deal with buttons.