### PR TITLE
Set highlight's parent before setting transf

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -145,10 +145,10 @@ namespace VRTK.Highlighters
             }
 
             highlightModel = new GameObject(name + "_HighlightModel");
+            highlightModel.transform.SetParent(transform);
             highlightModel.transform.position = copyModel.transform.position;
             highlightModel.transform.rotation = copyModel.transform.rotation;
             highlightModel.transform.localScale = copyModel.transform.localScale;
-            highlightModel.transform.SetParent(transform);
 
             foreach (var component in copyModel.GetComponents<Component>())
             {


### PR DESCRIPTION
I don't know if there was a specific reason it was being done in the other order, but I just ran into this one - it loses the local scale of the model because Unity will re-calculate scales when you set the parent. So you need to set the parent first.

Case where it was uses: Gameobject with scale of 0.015 holding mesh of scale 1 which was the interactable. When touching it, spawned highlighted mesh was at scale 66x because it would recalculate its scale to match the previous scale of 1x the root, rather than 1x the new mesh.