### PR TITLE
fix(Highlighters): Use local scale of 1,1,1 to match parent size

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -148,7 +148,7 @@ namespace VRTK.Highlighters
             highlightModel.transform.SetParent(transform);
             highlightModel.transform.position = copyModel.transform.position;
             highlightModel.transform.rotation = copyModel.transform.rotation;
-            highlightModel.transform.localScale = copyModel.transform.localScale;
+            highlightModel.transform.localScale = Vector3.one;
 
             foreach (var component in copyModel.GetComponents<Component>())
             {


### PR DESCRIPTION
The copy highlighter needs a scale of 1,1,1 to match the size of the parent, otherwise if the parent doesn't have a scale of 1,1,1 it'll be smaller/bigger than the parent.