### PR TITLE
fix(SDK): controller retrieval and touch events in simulator

### DIFF
--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -21,6 +21,9 @@ namespace VRTK
             {"StartMenu", KeyCode.F }
         };
 
+        protected const string RIGHT_HAND_CONTROLLER_NAME = "RightHand";
+        protected const string LEFT_HAND_CONTROLLER_NAME = "LeftHand";
+
         /// <summary>
         /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
         /// </summary>
@@ -141,11 +144,12 @@ namespace VRTK
         /// <returns>The GameObject containing the left hand controller.</returns>
         public override GameObject GetControllerLeftHand(bool actual = false)
         {
-            GameObject controller = null;
-            GameObject simPlayer = SDK_InputSimulator.FindInScene();
-            if (simPlayer != null)
+            // use the basic base functionality to find the left hand controller
+            var controller = GetSDKManagerControllerLeftHand(actual);
+            // if the controller cannot be found with default settings, try finding it below the InputSimulator by name
+            if (!controller && actual)
             {
-                controller = simPlayer.transform.FindChild("LeftHand").gameObject;
+                controller = GetActualController(ControllerHand.Left);
             }
 
             return controller;
@@ -158,12 +162,40 @@ namespace VRTK
         /// <returns>The GameObject containing the right hand controller.</returns>
         public override GameObject GetControllerRightHand(bool actual = false)
         {
-            GameObject controller = null;
+            // use the basic base functionality to find the right hand controller
+            var controller = GetSDKManagerControllerRightHand(actual);
+            // if the controller cannot be found with default settings, try finding it below the InputSimulator by name
+            if (!controller && actual)
+            {
+                controller = GetActualController(ControllerHand.Right);
+            }
+
+            return controller;
+        }
+
+        /// <summary>
+        /// finds the actual controller for the specified hand (identified by name) and returns it
+        /// </summary>
+        /// <param name="hand">the for which to find the respective controller gameobject</param>
+        /// <returns>the gameobject of the actual controller corresponding to the specified hand</returns>
+        private static GameObject GetActualController(ControllerHand hand)
+        {
             GameObject simPlayer = SDK_InputSimulator.FindInScene();
+            GameObject controller = null;
 
             if (simPlayer != null)
             {
-                controller = simPlayer.transform.FindChild("RightHand").gameObject;
+                switch (hand)
+                {
+                    case ControllerHand.Right:
+                        controller = simPlayer.transform.FindChild(RIGHT_HAND_CONTROLLER_NAME).gameObject;
+                        break;
+                    case ControllerHand.Left:
+                        controller = simPlayer.transform.FindChild(LEFT_HAND_CONTROLLER_NAME).gameObject;
+                        break;
+                    default:
+                        break;
+                }
             }
 
             return controller;
@@ -235,10 +267,10 @@ namespace VRTK
                 switch (hand)
                 {
                     case ControllerHand.Left:
-                        model = simPlayer.transform.FindChild("LeftHand/Hand").gameObject;
+                        model = simPlayer.transform.FindChild(string.Format("{0}/Hand", LEFT_HAND_CONTROLLER_NAME)).gameObject;
                         break;
                     case ControllerHand.Right:
-                        model = simPlayer.transform.FindChild("RightHand/Hand").gameObject;
+                        model = simPlayer.transform.FindChild(string.Format("{0}/Hand", RIGHT_HAND_CONTROLLER_NAME)).gameObject;
                         break;
                 }
             }
@@ -825,8 +857,8 @@ namespace VRTK
                 GameObject simPlayer = SDK_InputSimulator.FindInScene();
                 if (simPlayer)
                 {
-                    rightHand = simPlayer.transform.FindChild("RightHand");
-                    leftHand = simPlayer.transform.FindChild("LeftHand");
+                    rightHand = simPlayer.transform.FindChild(RIGHT_HAND_CONTROLLER_NAME);
+                    leftHand = simPlayer.transform.FindChild(LEFT_HAND_CONTROLLER_NAME);
                     rightController = rightHand.GetComponent<SDK_ControllerSim>();
                     leftController = leftHand.GetComponent<SDK_ControllerSim>();
                 }

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -18,7 +18,9 @@ namespace VRTK
             {"TouchpadPress", KeyCode.Q },
             {"ButtonOne", KeyCode.E },
             {"ButtonTwo", KeyCode.R },
-            {"StartMenu", KeyCode.F }
+            {"StartMenu", KeyCode.F },
+            {"TouchModifier", KeyCode.T},
+            {"HairTouchModifier", KeyCode.H}
         };
 
         protected const string RIGHT_HAND_CONTROLLER_NAME = "RightHand";
@@ -409,7 +411,8 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsTriggerPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["Trigger"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsTriggerTouchedOnIndex(index);
         }
 
         /// <summary>
@@ -419,7 +422,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsTriggerPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["Trigger"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsTriggerTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -429,7 +433,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsTriggerPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["Trigger"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsTriggerTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -439,7 +444,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being touched.</returns>
         public override bool IsTriggerTouchedOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["Trigger"]);
         }
 
         /// <summary>
@@ -449,7 +454,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been touched down.</returns>
         public override bool IsTriggerTouchedDownOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["Trigger"]);
         }
 
         /// <summary>
@@ -459,7 +464,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsTriggerTouchedUpOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["Trigger"]);
         }
 
         /// <summary>
@@ -469,7 +474,8 @@ namespace VRTK
         /// <returns>Returns true if the button has passed it's press threshold.</returns>
         public override bool IsHairTriggerDownOnIndex(uint index)
         {
-            return false;
+            // button hair touches shall be ignored if the only the touch modifier is used
+            return !IsButtonHairTouchIgnored() && IsTriggerTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -479,7 +485,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released from it's press threshold.</returns>
         public override bool IsHairTriggerUpOnIndex(uint index)
         {
-            return false;
+            // button hair touches shall be ignored if the only the touch modifier is used
+            return !IsButtonHairTouchIgnored() && IsTriggerTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -489,7 +496,8 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsGripPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["Grip"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsGripTouchedOnIndex(index);
         }
 
         /// <summary>
@@ -499,7 +507,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsGripPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["Grip"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsGripTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -509,7 +518,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsGripPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["Grip"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsGripTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -519,7 +529,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being touched.</returns>
         public override bool IsGripTouchedOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["Grip"]);
         }
 
         /// <summary>
@@ -529,7 +539,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been touched down.</returns>
         public override bool IsGripTouchedDownOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["Grip"]);
         }
 
         /// <summary>
@@ -539,7 +549,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsGripTouchedUpOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["Grip"]);
         }
 
         /// <summary>
@@ -549,7 +559,8 @@ namespace VRTK
         /// <returns>Returns true if the button has passed it's press threshold.</returns>
         public override bool IsHairGripDownOnIndex(uint index)
         {
-            return false;
+            // button hair touches shall be ignored if the hair touch modifier is used
+            return !IsButtonHairTouchIgnored() && IsGripTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -559,7 +570,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released from it's press threshold.</returns>
         public override bool IsHairGripUpOnIndex(uint index)
         {
-            return false;
+            // button hair touches shall be ignored if the hair touch modifier is used
+            return !IsButtonHairTouchIgnored() && IsGripTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -569,7 +581,8 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsTouchpadPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["TouchpadPress"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsTouchpadTouchedOnIndex(index);
         }
 
         /// <summary>
@@ -579,7 +592,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsTouchpadPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["TouchpadPress"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsTouchpadTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -589,7 +603,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsTouchpadPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["TouchpadPress"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsTouchpadTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -599,7 +614,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being touched.</returns>
         public override bool IsTouchpadTouchedOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["TouchpadPress"]);
         }
 
         /// <summary>
@@ -609,7 +624,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been touched down.</returns>
         public override bool IsTouchpadTouchedDownOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["TouchpadPress"]);
         }
 
         /// <summary>
@@ -619,7 +634,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsTouchpadTouchedUpOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["TouchpadPress"]);
         }
 
         /// <summary>
@@ -629,7 +644,8 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsButtonOnePressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["ButtonOne"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsButtonOneTouchedOnIndex(index);
         }
 
         /// <summary>
@@ -639,7 +655,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsButtonOnePressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["ButtonOne"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsButtonOneTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -649,7 +666,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonOnePressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["ButtonOne"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsButtonOneTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -659,7 +677,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being touched.</returns>
         public override bool IsButtonOneTouchedOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["ButtonOne"]);
         }
 
         /// <summary>
@@ -669,7 +687,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been touched down.</returns>
         public override bool IsButtonOneTouchedDownOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["ButtonOne"]);
         }
 
         /// <summary>
@@ -679,7 +697,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonOneTouchedUpOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["ButtonOne"]);
         }
 
         /// <summary>
@@ -689,7 +707,8 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsButtonTwoPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["ButtonTwo"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsButtonTwoTouchedOnIndex(index);
         }
 
         /// <summary>
@@ -699,7 +718,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsButtonTwoPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["ButtonTwo"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsButtonTwoTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -709,7 +729,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonTwoPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["ButtonTwo"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsButtonTwoTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -719,7 +740,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being touched.</returns>
         public override bool IsButtonTwoTouchedOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["ButtonTwo"]);
         }
 
         /// <summary>
@@ -729,7 +750,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been touched down.</returns>
         public override bool IsButtonTwoTouchedDownOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["ButtonTwo"]);
         }
 
         /// <summary>
@@ -739,7 +760,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsButtonTwoTouchedUpOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["ButtonTwo"]);
         }
 
         /// <summary>
@@ -749,7 +770,8 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being pressed.</returns>
         public override bool IsStartMenuPressedOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["StartMenu"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsStartMenuTouchedOnIndex(index);
         }
 
         /// <summary>
@@ -759,7 +781,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been pressed down.</returns>
         public override bool IsStartMenuPressedDownOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["StartMenu"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsStartMenuTouchedDownOnIndex(index);
         }
 
         /// <summary>
@@ -769,7 +792,8 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsStartMenuPressedUpOnIndex(uint index)
         {
-            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["StartMenu"]);
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return !IsButtonPressIgnored() && IsStartMenuTouchedUpOnIndex(index);
         }
 
         /// <summary>
@@ -779,7 +803,7 @@ namespace VRTK
         /// <returns>Returns true if the button is continually being touched.</returns>
         public override bool IsStartMenuTouchedOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings["StartMenu"]);
         }
 
         /// <summary>
@@ -789,7 +813,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been touched down.</returns>
         public override bool IsStartMenuTouchedDownOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings["StartMenu"]);
         }
 
         /// <summary>
@@ -799,7 +823,7 @@ namespace VRTK
         /// <returns>Returns true if the button has just been released.</returns>
         public override bool IsStartMenuTouchedUpOnIndex(uint index)
         {
-            return false;
+            return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings["StartMenu"]);
         }
 
         private void OnEnable()
@@ -807,6 +831,58 @@ namespace VRTK
             controllers = new SimControllers();
         }
 
+        /// <summary>
+        /// whether or not the touch modifier is currently pressed
+        /// if so, pressing a key on the keyboard will only emit touch events,
+        /// but not a real press (or hair touch events).
+        /// </summary>
+        /// <returns>whether or not the TouchModifier is active</returns>
+        protected bool IsTouchModifierPressed()
+        {
+            return Input.GetKey(keyMappings["TouchModifier"]);
+        }
+
+        /// <summary>
+        /// whether or not the hair touch modifier is currently pressed
+        /// if so, pressing a key on the keyboard will only emit touch and hair touch events,
+        /// but not a real press.
+        /// </summary>
+        /// <returns>whether or not the HairTouchModifier is active</returns>
+        protected bool IsHairTouchModifierPressed()
+        {
+            return Input.GetKey(keyMappings["HairTouchModifier"]);
+        }
+
+        /// <summary>
+        /// whether or not a button press shall be ignored, e.g. because of the
+        /// use of the touch or hair touch modifier
+        /// </summary>
+        /// <returns></returns>
+        protected bool IsButtonPressIgnored()
+        {
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return IsHairTouchModifierPressed() || IsTouchModifierPressed();
+        }
+
+        /// <summary>
+        /// whether or not a button press shall be ignored, e.g. because of the
+        /// use of the touch or hair touch modifier
+        /// </summary>
+        /// <returns></returns>
+        protected bool IsButtonHairTouchIgnored()
+        {
+            // button presses shall be ignored if the hair touch or touch modifiers are used
+            return IsTouchModifierPressed() && !IsHairTouchModifierPressed();
+        }
+
+        /// <summary>
+        /// checks if the given button (KeyCode) is currently in a specific pressed state (ButtonPressTypes) on the keyboard
+        /// also asserts that button presses are only handled for the currently active controller by comparing the controller indices
+        /// </summary>
+        /// <param name="index">unique index of the controller for which the button press is to be checked</param>
+        /// <param name="type">the type of press (up, down, hold)</param>
+        /// <param name="button">the button on the keyboard</param>
+        /// <returns></returns>
         private bool IsButtonPressed(uint index, ButtonPressTypes type, KeyCode button)
         {
             if (index >= uint.MaxValue)

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -1232,28 +1232,11 @@ namespace VRTK
             Vector2 currentGripAxis = VRTK_SDK_Bridge.GetGripAxisOnIndex(controllerIndex);
             Vector2 currentTouchpadAxis = VRTK_SDK_Bridge.GetTouchpadAxisOnIndex(controllerIndex);
 
-            //Trigger Pressed
-            if (VRTK_SDK_Bridge.IsTriggerPressedDownOnIndex(controllerIndex))
-            {
-                OnTriggerPressed(SetButtonEvent(ref triggerPressed, true, currentTriggerAxis.x));
-                EmitAlias(ButtonAlias.Trigger_Press, true, currentTriggerAxis.x, ref triggerPressed);
-            }
-            else if (VRTK_SDK_Bridge.IsTriggerPressedUpOnIndex(controllerIndex))
-            {
-                OnTriggerReleased(SetButtonEvent(ref triggerPressed, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Press, false, 0f, ref triggerPressed);
-            }
-
             //Trigger Touched
             if (VRTK_SDK_Bridge.IsTriggerTouchedDownOnIndex(controllerIndex))
             {
                 OnTriggerTouchStart(SetButtonEvent(ref triggerTouched, true, currentTriggerAxis.x));
                 EmitAlias(ButtonAlias.Trigger_Touch, true, currentTriggerAxis.x, ref triggerTouched);
-            }
-            else if (VRTK_SDK_Bridge.IsTriggerTouchedUpOnIndex(controllerIndex))
-            {
-                OnTriggerTouchEnd(SetButtonEvent(ref triggerTouched, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Touch, false, 0f, ref triggerTouched);
             }
 
             //Trigger Hairline
@@ -1262,10 +1245,12 @@ namespace VRTK
                 OnTriggerHairlineStart(SetButtonEvent(ref triggerHairlinePressed, true, currentTriggerAxis.x));
                 EmitAlias(ButtonAlias.Trigger_Hairline, true, currentTriggerAxis.x, ref triggerHairlinePressed);
             }
-            else if (VRTK_SDK_Bridge.IsHairTriggerUpOnIndex(controllerIndex))
+
+            //Trigger Pressed
+            if (VRTK_SDK_Bridge.IsTriggerPressedDownOnIndex(controllerIndex))
             {
-                OnTriggerHairlineEnd(SetButtonEvent(ref triggerHairlinePressed, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Hairline, false, 0f, ref triggerHairlinePressed);
+                OnTriggerPressed(SetButtonEvent(ref triggerPressed, true, currentTriggerAxis.x));
+                EmitAlias(ButtonAlias.Trigger_Press, true, currentTriggerAxis.x, ref triggerPressed);
             }
 
             //Trigger Clicked
@@ -1280,6 +1265,27 @@ namespace VRTK
                 EmitAlias(ButtonAlias.Trigger_Click, false, 0f, ref triggerClicked);
             }
 
+            // Trigger Pressed end
+            if (VRTK_SDK_Bridge.IsTriggerPressedUpOnIndex(controllerIndex))
+            {
+                OnTriggerReleased(SetButtonEvent(ref triggerPressed, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Press, false, 0f, ref triggerPressed);
+            }
+
+            //Trigger Hairline End
+            if (VRTK_SDK_Bridge.IsHairTriggerUpOnIndex(controllerIndex))
+            {
+                OnTriggerHairlineEnd(SetButtonEvent(ref triggerHairlinePressed, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Hairline, false, 0f, ref triggerHairlinePressed);
+            }
+
+            //Trigger Touch End
+            if (VRTK_SDK_Bridge.IsTriggerTouchedUpOnIndex(controllerIndex))
+            {
+                OnTriggerTouchEnd(SetButtonEvent(ref triggerTouched, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Touch, false, 0f, ref triggerTouched);
+            }
+
             //Trigger Axis
             if (Vector2ShallowEquals(triggerAxis, currentTriggerAxis))
             {
@@ -1290,28 +1296,12 @@ namespace VRTK
                 OnTriggerAxisChanged(SetButtonEvent(ref triggerAxisChanged, true, currentTriggerAxis.x));
             }
 
-            //Grip Pressed
-            if (VRTK_SDK_Bridge.IsGripPressedDownOnIndex(controllerIndex))
-            {
-                OnGripPressed(SetButtonEvent(ref gripPressed, true, currentGripAxis.x));
-                EmitAlias(ButtonAlias.Grip_Press, true, currentGripAxis.x, ref gripPressed);
-            }
-            else if (VRTK_SDK_Bridge.IsGripPressedUpOnIndex(controllerIndex))
-            {
-                OnGripReleased(SetButtonEvent(ref gripPressed, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Press, false, 0f, ref gripPressed);
-            }
 
             //Grip Touched
             if (VRTK_SDK_Bridge.IsGripTouchedDownOnIndex(controllerIndex))
             {
                 OnGripTouchStart(SetButtonEvent(ref gripTouched, true, currentGripAxis.x));
                 EmitAlias(ButtonAlias.Grip_Touch, true, currentGripAxis.x, ref gripTouched);
-            }
-            else if (VRTK_SDK_Bridge.IsGripTouchedUpOnIndex(controllerIndex))
-            {
-                OnGripTouchEnd(SetButtonEvent(ref gripTouched, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Touch, false, 0f, ref gripTouched);
             }
 
             //Grip Hairline
@@ -1320,10 +1310,12 @@ namespace VRTK
                 OnGripHairlineStart(SetButtonEvent(ref gripHairlinePressed, true, currentGripAxis.x));
                 EmitAlias(ButtonAlias.Grip_Hairline, true, currentGripAxis.x, ref gripHairlinePressed);
             }
-            else if (VRTK_SDK_Bridge.IsHairGripUpOnIndex(controllerIndex))
+
+            //Grip Pressed
+            if (VRTK_SDK_Bridge.IsGripPressedDownOnIndex(controllerIndex))
             {
-                OnGripHairlineEnd(SetButtonEvent(ref gripHairlinePressed, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Hairline, false, 0f, ref gripHairlinePressed);
+                OnGripPressed(SetButtonEvent(ref gripPressed, true, currentGripAxis.x));
+                EmitAlias(ButtonAlias.Grip_Press, true, currentGripAxis.x, ref gripPressed);
             }
 
             //Grip Clicked
@@ -1338,6 +1330,27 @@ namespace VRTK
                 EmitAlias(ButtonAlias.Grip_Click, false, 0f, ref gripClicked);
             }
 
+            // Grip Pressed End
+            if (VRTK_SDK_Bridge.IsGripPressedUpOnIndex(controllerIndex))
+            {
+                OnGripReleased(SetButtonEvent(ref gripPressed, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Press, false, 0f, ref gripPressed);
+            }
+
+            //Grip Hairline End
+            if (VRTK_SDK_Bridge.IsHairGripUpOnIndex(controllerIndex))
+            {
+                OnGripHairlineEnd(SetButtonEvent(ref gripHairlinePressed, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Hairline, false, 0f, ref gripHairlinePressed);
+            }
+
+            // Grip Touch End
+            if (VRTK_SDK_Bridge.IsGripTouchedUpOnIndex(controllerIndex))
+            {
+                OnGripTouchEnd(SetButtonEvent(ref gripTouched, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Touch, false, 0f, ref gripTouched);
+            }
+
             //Grip Axis
             if (Vector2ShallowEquals(gripAxis, currentGripAxis))
             {
@@ -1346,6 +1359,13 @@ namespace VRTK
             else
             {
                 OnGripAxisChanged(SetButtonEvent(ref gripAxisChanged, true, currentGripAxis.x));
+            }
+
+            //Touchpad Touched
+            if (VRTK_SDK_Bridge.IsTouchpadTouchedDownOnIndex(controllerIndex))
+            {
+                OnTouchpadTouchStart(SetButtonEvent(ref touchpadTouched, true, 1f));
+                EmitAlias(ButtonAlias.Touchpad_Touch, true, 1f, ref touchpadTouched);
             }
 
             //Touchpad Pressed
@@ -1360,13 +1380,8 @@ namespace VRTK
                 EmitAlias(ButtonAlias.Touchpad_Press, false, 0f, ref touchpadPressed);
             }
 
-            //Touchpad Touched
-            if (VRTK_SDK_Bridge.IsTouchpadTouchedDownOnIndex(controllerIndex))
-            {
-                OnTouchpadTouchStart(SetButtonEvent(ref touchpadTouched, true, 1f));
-                EmitAlias(ButtonAlias.Touchpad_Touch, true, 1f, ref touchpadTouched);
-            }
-            else if (VRTK_SDK_Bridge.IsTouchpadTouchedUpOnIndex(controllerIndex))
+            //Touchpad Untouched
+            if (VRTK_SDK_Bridge.IsTouchpadTouchedUpOnIndex(controllerIndex))
             {
                 OnTouchpadTouchEnd(SetButtonEvent(ref touchpadTouched, false, 0f));
                 EmitAlias(ButtonAlias.Touchpad_Touch, false, 0f, ref touchpadTouched);
@@ -1381,6 +1396,13 @@ namespace VRTK
                 OnTouchpadAxisChanged(SetButtonEvent(ref touchpadAxisChanged, true, 1f));
             }
 
+            //ButtonOne Touched
+            if (VRTK_SDK_Bridge.IsButtonOneTouchedDownOnIndex(controllerIndex))
+            {
+                OnButtonOneTouchStart(SetButtonEvent(ref buttonOneTouched, true, 1f));
+                EmitAlias(ButtonAlias.Button_One_Touch, true, 1f, ref buttonOneTouched);
+            }
+
             //ButtonOne Pressed
             if (VRTK_SDK_Bridge.IsButtonOnePressedDownOnIndex(controllerIndex))
             {
@@ -1393,16 +1415,18 @@ namespace VRTK
                 EmitAlias(ButtonAlias.Button_One_Press, false, 0f, ref buttonOnePressed);
             }
 
-            //ButtonOne Touched
-            if (VRTK_SDK_Bridge.IsButtonOneTouchedDownOnIndex(controllerIndex))
-            {
-                OnButtonOneTouchStart(SetButtonEvent(ref buttonOneTouched, true, 1f));
-                EmitAlias(ButtonAlias.Button_One_Touch, true, 1f, ref buttonOneTouched);
-            }
-            else if (VRTK_SDK_Bridge.IsButtonOneTouchedUpOnIndex(controllerIndex))
+            //ButtonOne Touched End
+            if (VRTK_SDK_Bridge.IsButtonOneTouchedUpOnIndex(controllerIndex))
             {
                 OnButtonOneTouchEnd(SetButtonEvent(ref buttonOneTouched, false, 0f));
                 EmitAlias(ButtonAlias.Button_One_Touch, false, 0f, ref buttonOneTouched);
+            }
+
+            //ButtonTwo Touched
+            if (VRTK_SDK_Bridge.IsButtonTwoTouchedDownOnIndex(controllerIndex))
+            {
+                OnButtonTwoTouchStart(SetButtonEvent(ref buttonTwoTouched, true, 1f));
+                EmitAlias(ButtonAlias.Button_Two_Touch, true, 1f, ref buttonTwoTouched);
             }
 
             //ButtonTwo Pressed
@@ -1417,13 +1441,8 @@ namespace VRTK
                 EmitAlias(ButtonAlias.Button_Two_Press, false, 0f, ref buttonTwoPressed);
             }
 
-            //ButtonTwo Touched
-            if (VRTK_SDK_Bridge.IsButtonTwoTouchedDownOnIndex(controllerIndex))
-            {
-                OnButtonTwoTouchStart(SetButtonEvent(ref buttonTwoTouched, true, 1f));
-                EmitAlias(ButtonAlias.Button_Two_Touch, true, 1f, ref buttonTwoTouched);
-            }
-            else if (VRTK_SDK_Bridge.IsButtonTwoTouchedUpOnIndex(controllerIndex))
+            //ButtonTwo Touched End
+            if (VRTK_SDK_Bridge.IsButtonTwoTouchedUpOnIndex(controllerIndex))
             {
                 OnButtonTwoTouchEnd(SetButtonEvent(ref buttonTwoTouched, false, 0f));
                 EmitAlias(ButtonAlias.Button_Two_Touch, false, 0f, ref buttonTwoTouched);


### PR DESCRIPTION
When trying to develop without any VR-Hardware, the simulator comes in really handy. However, I noticed that some events on the simulator (e.g. touchdown, touchup, touched on any buttons) are never fired. While it makes sense to not fire those events from a technical perspective (since we cannot distinguish between press and touch on a keyboard) it makes developing a whole lot harder, since a developer potentially has to use different types of events during development (Simulator) and in production (HMD). 

Furthermore, the Simulator SDK right now does not allow for finding script alias controllers. Whenever the calls to get a controller (e.g. `GetControllerLeftHand` or `GetControllerByIndex`) are used, the boolean `actual` parameter is simply ignored and the actual controllers are always returned. This is not in line with the base implementation or the implementation for SteamVR.

This PR mitigates both the above problems.

- Touch Events are now always fired alongside with pressed / released events
- Controller Retrieval / Finding logic has been reworked to be more consistent with other implementations