### PR TITLE
fix(Interaction): prevent pointer use constantly calling start using - resolves #833

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -362,6 +362,7 @@ namespace VRTK
         {
             OnInteractableObjectUnused(SetInteractableObjectEvent(previousUsingObject));
             ResetUsingObject();
+            usingState = 0;
             usingObject = null;
         }
 

--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -477,7 +477,7 @@ namespace VRTK
             interactableObject = target.GetComponent<VRTK_InteractableObject>();
             bool cannotUseBecauseNotGrabbed = (interactableObject && interactableObject.useOnlyIfGrabbed && !interactableObject.IsGrabbed());
 
-            if (PointerActivatesUseAction(interactableObject) && interactableObject.holdButtonToUse && !cannotUseBecauseNotGrabbed)
+            if (PointerActivatesUseAction(interactableObject) && interactableObject.holdButtonToUse && !cannotUseBecauseNotGrabbed && interactableObject.usingState == 0)
             {
                 interactableObject.StartUsing(controller.gameObject);
                 interactableObject.usingState++;


### PR DESCRIPTION
The pointer activates use action would cause the `StartUsing` method
on the interactable object to continually execute.

This fix only runs the StartUsing method if it's not already being
used.