### PR TITLE
fix(Pointer): ensure pointer interaction collider is sized correctly - fixes #836

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_SimplePointer.cs
@@ -154,10 +154,7 @@ namespace VRTK
 
             base.InitPointer();
 
-            if (showPointerTip && objectInteractor)
-            {
-                objectInteractor.transform.localScale = pointerTip.transform.localScale * 1.05f;
-            }
+            ResizeObjectInteractor();
 
             SetPointerTransform(pointerLength, pointerThickness);
             TogglePointer(false);
@@ -200,6 +197,16 @@ namespace VRTK
 
                 pointerBeam.GetComponentInChildren<Renderer>().enabled = false;
                 pointerTip.GetComponentInChildren<Renderer>().enabled = false;
+            }
+
+            ResizeObjectInteractor();
+        }
+
+        private void ResizeObjectInteractor()
+        {
+            if (showPointerTip && pointerTip && objectInteractor)
+            {
+                objectInteractor.transform.localScale = pointerTip.transform.localScale * 1.05f;
             }
         }
 


### PR DESCRIPTION
There was an issue where the pointer interaction collider would not be
set to the correct size if the pointer had been initialised too early
before the pointer tip size had been set.

This fix ensures the interaction collider is always resized every time
the pointer is toggled.