### PR TITLE
fix(Interaction): parent of the outline highlighter cloned object

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -145,10 +145,10 @@ namespace VRTK.Highlighters
             }
 
             highlightModel = new GameObject(name + "_HighlightModel");
-            highlightModel.transform.SetParent(transform);
-            highlightModel.transform.position = copyModel.transform.position;
-            highlightModel.transform.rotation = copyModel.transform.rotation;
-            highlightModel.transform.localScale = Vector3.one;
+            highlightModel.transform.SetParent(copyModel.transform.parent, false);
+            highlightModel.transform.localPosition = copyModel.transform.localPosition;
+            highlightModel.transform.localRotation = copyModel.transform.localRotation;
+            highlightModel.transform.localScale = copyModel.transform.localScale;
 
             foreach (var component in copyModel.GetComponents<Component>())
             {


### PR DESCRIPTION
Change the parent of the OutlineObjectCopyHighlighter cloned object to
the same parent as the original object.

Change the parent setting to not re-compute world position.

Change the transform assignments from world to local (faster), because
now the parent is the same.

The OutlineObjectCopyHighlighter cloned object needs to have the
parent set to the same parent of the customOutlineModel to exactly
match its shape. Even the PR #828 still causes problems with a hierarchy
of game objects with different scaling (e.g customOutlineModel with its
own scaling as child of the game object with its own scaling, holding
the OutlineObjectCopyHighlighter component).