### PR TITLE
fix(Interaction): set error if helper script not on interactable object - fixes #848

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
@@ -4,7 +4,7 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
-    /// The Interact Controller Appearance script is used to determine whether the controller model should be visible or hidden on touch, grab or use.
+    /// The Interact Controller Appearance script is attached on the same GameObject as an Interactable Object script and is used to determine whether the controller model should be visible or hidden on touch, grab or use.
     /// </summary>
     /// <example>
     /// `VRTK/Examples/008_Controller_UsingAGrabbedObject` shows that the controller can be hidden when touching, grabbing and using an object.
@@ -89,6 +89,14 @@ namespace VRTK
                     return;
                 }
                 ToggleController(showController, controllerActions, obj.gameObject, hideDelayOnUse);
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            if (!GetComponent<VRTK_InteractableObject>())
+            {
+                Debug.LogError("The `VRTK_InteractControllerAppearance` script is required to be attached to a GameObject that has the `VRTK_InteractableObject` script also attached to it.");
             }
         }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -4,7 +4,7 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
-    /// The Interact Haptics script is attached along side the Interactable Object script and provides controller haptics on touch, grab and use of the object.
+    /// The Interact Haptics script is attached on the same GameObject as an Interactable Object script and provides controller haptics on touch, grab and use of the object.
     /// </summary>
     public class VRTK_InteractHaptics : MonoBehaviour
     {
@@ -70,6 +70,14 @@ namespace VRTK
             if (strengthOnUse > 0 && durationOnUse > 0f)
             {
                 TriggerHapticPulse(controllerActions, strengthOnUse, durationOnUse, intervalOnUse);
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            if (!GetComponent<VRTK_InteractableObject>())
+            {
+                Debug.LogError("The `VRTK_InteractHaptics` script is required to be attached to a GameObject that has the `VRTK_InteractableObject` script also attached to it.");
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2472,7 +2472,7 @@ The ForceResetUsing will force the controller to stop using the currently touche
 
 ### Overview
 
-The Interact Haptics script is attached along side the Interactable Object script and provides controller haptics on touch, grab and use of the object.
+The Interact Haptics script is attached on the same GameObject as an Interactable Object script and provides controller haptics on touch, grab and use of the object.
 
 ### Inspector Parameters
 
@@ -2527,7 +2527,7 @@ The HapticsOnUse method triggers the haptic feedback on the given controller for
 
 ### Overview
 
-The Interact Controller Appearance script is used to determine whether the controller model should be visible or hidden on touch, grab or use.
+The Interact Controller Appearance script is attached on the same GameObject as an Interactable Object script and is used to determine whether the controller model should be visible or hidden on touch, grab or use.
 
 ### Inspector Parameters
 


### PR DESCRIPTION
The Interactable Object script has a couple of helper scripts such as
Interact Haptics and Controller Appearance that need to be on the same
GameObject as the Interactable Object.

This fix throws a Log Error if they are attached to anything other than
an Interactable Object.