### PR TITLE
fix(AdaptiveQuality): ensure debug visualization moves with headset

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -320,8 +320,6 @@ namespace VRTK
             maximumRenderTargetDimension = Mathf.Max(2, maximumRenderTargetDimension);
             renderScaleFillRateStepSizeInPercent = Mathf.Max(1, renderScaleFillRateStepSizeInPercent);
             msaaLevel = msaaLevel == 1 ? 0 : Mathf.Clamp(Mathf.ClosestPowerOfTwo(msaaLevel), 0, 8);
-
-            CreateOrDestroyDebugVisualization();
         }
 
         private void Update()
@@ -393,7 +391,6 @@ namespace VRTK
                         break;
                     case CommandLineArguments.DrawDebugVisualization:
                         drawDebugVisualization = true;
-                        CreateOrDestroyDebugVisualization();
                         break;
                     case CommandLineArguments.MSAALevel:
                         msaaLevel = int.Parse(nextArgument);
@@ -412,7 +409,6 @@ namespace VRTK
             if (Input.GetKeyDown(KeyboardShortcuts.ToggleDrawDebugVisualization))
             {
                 drawDebugVisualization = !drawDebugVisualization;
-                CreateOrDestroyDebugVisualization();
             }
             else if (Input.GetKeyDown(KeyboardShortcuts.ToggleOverrideRenderScale))
             {


### PR DESCRIPTION
The debug visualization was not correctly parented to the headset. This
change makes sure to only attach at the appropriate moment to fix the
problem.