### PR TITLE
fix(SnapDropZone): save interactable object state before force snap - Resolves #855

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -175,6 +175,7 @@ namespace VRTK
             var ioCheck = objectToSnap.GetComponentInParent<VRTK_InteractableObject>();
             if (ioCheck)
             {
+                ioCheck.SaveCurrentState();
                 StopCoroutine("AttemptForceSnapAtEndOfFrame");
                 if (ioCheck.IsGrabbed())
                 {


### PR DESCRIPTION
Upon force snapping to a snap drop zone, the interactable object state
needs to be set, because if it is snapped then the SaveCurrentState
method won't be run and the previous parent will not be saved causing
it to lose it's parent when it is unsnapped and dropped.

Calling SaveCurrentState before the force snap takes place means the
previous parent will be adhered to when it is dropped.