### PR TITLE
Fix Panel Orientation on all platforms

### DIFF
--- a/Assets/VRTK/Scripts/Controls/2D/PanelMenu/PanelMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/PanelMenu/PanelMenuController.cs
@@ -1,4 +1,4 @@
-// Panel Menu Controller|Prefabs|0070
+﻿// Panel Menu Controller|Prefabs|0070
 namespace VRTK
 {
     using System.Collections;
@@ -106,7 +106,7 @@ namespace VRTK
             {
                 if (rotateTowards == null)
                 {
-                    rotateTowards = GameObject.Find("Camera (eye)");
+                    rotateTowards = VRTK_DeviceFinder.HeadsetCamera().gameObject;
                     if (rotateTowards == null)
                     {
                         Debug.LogWarning("The PanelMenuController could not automatically find an object to rotate towards.");


### PR DESCRIPTION
Fxies an issue where the PanelMenuController would only work for the SteamVR platform.

Instead of searching for hardcoded objects, use the SDK Manager to find the correct gameobject.