### PR TITLE
chore(Structure): ensure MonoBehaviour magic methods are overridable - Resolves #835

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ConsoleViewer.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ConsoleViewer.cs
@@ -57,16 +57,16 @@ namespace VRTK
             lastMessage = "";
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             logTypeColors = new Dictionary<LogType, Color>()
-        {
-            { LogType.Assert, assertMessage },
-            { LogType.Error, errorMessage },
-            { LogType.Exception, exceptionMessage },
-            { LogType.Log, infoMessage },
-            { LogType.Warning, warningMessage }
-        };
+            {
+                { LogType.Assert, assertMessage },
+                { LogType.Error, errorMessage },
+                { LogType.Exception, exceptionMessage },
+                { LogType.Log, infoMessage },
+                { LogType.Warning, warningMessage }
+            };
             scrollWindow = transform.FindChild("Panel/Scroll View").GetComponent<ScrollRect>();
             consoleRect = transform.FindChild("Panel/Scroll View/Viewport/Content").GetComponent<RectTransform>();
             consoleOutput = transform.FindChild("Panel/Scroll View/Viewport/Content/ConsoleOutput").GetComponent<Text>();
@@ -75,12 +75,12 @@ namespace VRTK
             ClearLog();
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             Application.logMessageReceived += HandleLog;
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             Application.logMessageReceived -= HandleLog;
             consoleRect.sizeDelta = Vector2.zero;

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs
@@ -17,12 +17,12 @@ namespace VRTK
     /// </remarks>
     public class VRTK_ControllerRigidbodyActivator : MonoBehaviour
     {
-        private void OnTriggerEnter(Collider collider)
+        protected virtual void OnTriggerEnter(Collider collider)
         {
             ToggleRigidbody(collider, true);
         }
 
-        private void OnTriggerExit(Collider collider)
+        protected virtual void OnTriggerExit(Collider collider)
         {
             ToggleRigidbody(collider, false);
         }

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -142,7 +142,7 @@ namespace VRTK
             }
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             controllerActions = GetComponentInParent<VRTK_ControllerActions>();
             triggerInitialised = false;
@@ -174,7 +174,7 @@ namespace VRTK
             InitialiseTips();
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             if (controllerActions)
             {
@@ -191,7 +191,7 @@ namespace VRTK
             }
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             if (controllerActions)
             {
@@ -203,6 +203,15 @@ namespace VRTK
             {
                 headsetControllerAware.ControllerGlanceEnter -= new HeadsetControllerAwareEventHandler(DoGlanceEnterController);
                 headsetControllerAware.ControllerGlanceExit -= new HeadsetControllerAwareEventHandler(DoGlanceExitController);
+            }
+        }
+
+        protected virtual void Update()
+        {
+            var actualController = VRTK_DeviceFinder.GetActualController(controllerActions.gameObject);
+            if (!TipsInitialised() && actualController && actualController.activeInHierarchy)
+            {
+                InitialiseTips();
             }
         }
 
@@ -342,15 +351,6 @@ namespace VRTK
             }
 
             return returnTransform;
-        }
-
-        private void Update()
-        {
-            var actualController = VRTK_DeviceFinder.GetActualController(controllerActions.gameObject);
-            if (!TipsInitialised() && actualController && actualController.activeInHierarchy)
-            {
-                InitialiseTips();
-            }
         }
     }
 }

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_FramesPerSecondViewer.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_FramesPerSecondViewer.cs
@@ -39,7 +39,7 @@ namespace VRTK
         private float framesTime;
         private Text text;
 
-        private void Start()
+        protected virtual void Start()
         {
             transform.parent.GetComponent<Canvas>().planeDistance = 0.5f;
             text = GetComponent<Text>();
@@ -47,7 +47,7 @@ namespace VRTK
             text.transform.localPosition = position;
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             framesCount++;
             framesTime += Time.unscaledDeltaTime;

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ObjectTooltip.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ObjectTooltip.cs
@@ -61,9 +61,14 @@ namespace VRTK
             ResetTooltip();
         }
 
-        private void Start()
+        protected virtual void Start()
         {
             ResetTooltip();
+        }
+
+        protected virtual void Update()
+        {
+            DrawLine();
         }
 
         private void SetContainer()
@@ -110,11 +115,6 @@ namespace VRTK
                 line.SetPosition(0, drawLineFrom.position);
                 line.SetPosition(1, drawLineTo.position);
             }
-        }
-
-        private void Update()
-        {
-            DrawLine();
         }
     }
 }

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -152,7 +152,7 @@ namespace VRTK
         /// The InitaliseHighlightObject method sets up the highlight object based on the given Highlight Object Prefab.
         /// </summary>
         /// <param name="removeOldObject">If this is set to true then it attempts to delete the old highlight object if it exists. Defaults to `false`</param>
-        public void InitaliseHighlightObject(bool removeOldObject = false)
+        public virtual void InitaliseHighlightObject(bool removeOldObject = false)
         {
             //force delete previous created highlight object
             if (removeOldObject)
@@ -170,7 +170,7 @@ namespace VRTK
         /// the ForceSnap method attempts to automatically attach a valid game object to the snap drop zone.
         /// </summary>
         /// <param name="objectToSnap">The GameObject to attempt to snap.</param>
-        public void ForceSnap(GameObject objectToSnap)
+        public virtual void ForceSnap(GameObject objectToSnap)
         {
             var ioCheck = objectToSnap.GetComponentInParent<VRTK_InteractableObject>();
             if (ioCheck)
@@ -192,7 +192,7 @@ namespace VRTK
         /// <summary>
         /// The ForceUnsnap method attempts to automatically remove the current snapped game object from the snap drop zone.
         /// </summary>
-        public void ForceUnsnap()
+        public virtual void ForceUnsnap()
         {
             if (isSnapped && currentSnappedObject)
             {
@@ -201,7 +201,7 @@ namespace VRTK
             }
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             if (Application.isPlaying)
             {
@@ -209,7 +209,7 @@ namespace VRTK
             }
         }
 
-        private void OnApplicationQuit()
+        protected virtual void OnApplicationQuit()
         {
             if (objectHighlighter)
             {
@@ -217,7 +217,7 @@ namespace VRTK
             }
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             //If the highlightObjectPrefab has changed then delete the highlight object in preparation to create a new one
             if (previousPrefab != null && previousPrefab != highlightObjectPrefab)
@@ -237,7 +237,7 @@ namespace VRTK
             }
         }
 
-        private void OnTriggerEnter(Collider collider)
+        protected virtual void OnTriggerEnter(Collider collider)
         {
             //if there is no current valid snappable object and the zone isn't being snapped then attempt to highlight
             if (!isSnapped && currentValidSnapObject == null)
@@ -246,7 +246,7 @@ namespace VRTK
             }
         }
 
-        private void OnTriggerExit(Collider collider)
+        protected virtual void OnTriggerExit(Collider collider)
         {
             //if the current valid snapped object is the collider leaving the trigger then attempt to turn off the highlighter
             if (currentValidSnapObject == collider.gameObject)
@@ -255,7 +255,7 @@ namespace VRTK
             }
         }
 
-        private void OnTriggerStay(Collider collider)
+        protected virtual void OnTriggerStay(Collider collider)
         {
             //Do sanity check to see if there should be a snappable object
             if (!isSnapped && currentValidSnapObject == null && ValidSnapObject(collider.gameObject, true))

--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenu/RadialMenu.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenu/RadialMenu.cs
@@ -67,7 +67,7 @@ namespace VRTK
 
         #region Unity Methods
 
-        private void Awake()
+        protected virtual void Awake()
         {
             if (Application.isPlaying)
             {
@@ -82,7 +82,7 @@ namespace VRTK
             }
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             //Keep track of pressed button and constantly invoke Hold event
             if (currentPress != -1)

--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenu/UICircle.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenu/UICircle.cs
@@ -107,7 +107,7 @@ namespace VRTK
             }
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             thickness = (int)Mathf.Clamp(thickness, 0, rectTransform.rect.width / 2);
         }

--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenu/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenu/VRTK_IndependentRadialMenuController.cs
@@ -313,7 +313,7 @@ namespace VRTK
             }
         }
 
-        IEnumerator DelayedSetColliderEnabled(bool enabled, float delay, InteractableObjectEventArgs e)
+        private IEnumerator DelayedSetColliderEnabled(bool enabled, float delay, InteractableObjectEventArgs e)
         {
             yield return new WaitForSeconds(delay);
 
@@ -324,17 +324,17 @@ namespace VRTK
         #endregion Helpers
 
         #region Unity Methods
-        private void Awake()
+        protected override void Awake()
         {
             menu = GetComponent<RadialMenu>();
         }
 
-        private void Start()
+        protected virtual void Start()
         {
             Initialize();
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (rotateTowards == null) // Backup
             {
@@ -363,7 +363,7 @@ namespace VRTK
             }
         }
 
-        private void FixedUpdate()
+        protected virtual void FixedUpdate()
         {
             if (waitingToDisableCollider)
             {

--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenuController.cs
@@ -12,7 +12,7 @@ namespace VRTK
         private float currentAngle; //Keep track of angle for when we click
         private bool touchpadTouched;
 
-        private void Awake()
+        protected virtual void Awake()
         {
             menu = GetComponent<RadialMenu>();
 

--- a/Assets/VRTK/Scripts/Controls/3D/Utilities/VRTK_ContentHandler.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/Utilities/VRTK_ContentHandler.cs
@@ -21,7 +21,7 @@ namespace VRTK
         [Tooltip("Any transform that will act as the parent while the object is not inside the control.")]
         public Transform outside;
 
-        private void Start()
+        protected virtual void Start()
         {
             VRTK_InteractableObject io = GetComponent<VRTK_InteractableObject>();
             if (io == null)
@@ -40,7 +40,7 @@ namespace VRTK
             }
         }
 
-        private void OnCollisionEnter(Collision collision)
+        protected virtual void OnCollisionEnter(Collision collision)
         {
             Bounds insideBounds = VRTK_SharedMethods.GetBounds(inside, null, control.GetContent().transform);
             Bounds objBounds = VRTK_SharedMethods.GetBounds(transform);

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Button.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Button.cs
@@ -234,13 +234,24 @@ namespace VRTK
             }
         }
 
-        private void FixedUpdate()
+        protected virtual void FixedUpdate()
         {
             // update reference position if no force is acting on the button to support scenarios where the button is moved at runtime with a connected body
             if (forceCount == 0 && cj.connectedBody)
             {
                 restingPosition = transform.position;
             }
+        }
+
+        protected virtual void OnCollisionExit(Collision collision)
+        {
+            // TODO: this will not always be triggered for some reason, we probably need some "healing"
+            forceCount -= 1;
+        }
+
+        protected virtual void OnCollisionEnter(Collision collision)
+        {
+            forceCount += 1;
         }
 
         private ButtonDirection DetectDirection()
@@ -405,17 +416,6 @@ namespace VRTK
         private Vector3 GetForceVector()
         {
             return -activationDir.normalized * buttonStrength;
-        }
-
-        private void OnCollisionExit(Collision collision)
-        {
-            // TODO: this will not always be triggered for some reason, we probably need some "healing"
-            forceCount -= 1;
-        }
-
-        private void OnCollisionEnter(Collision collision)
-        {
-            forceCount += 1;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseGrabAttach.cs
@@ -189,7 +189,7 @@ namespace VRTK.GrabAttachMechanics
             FlipSnapHandle(leftSnapHandle);
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             Initialise();
         }

--- a/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_SwapControllerGrabAction.cs
+++ b/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_SwapControllerGrabAction.cs
@@ -1,8 +1,6 @@
 ﻿// Swap Controller Grab Action|SecondaryControllerGrabActions|60020
 namespace VRTK.SecondaryControllerGrabActions
 {
-    using UnityEngine;
-
     /// <summary>
     /// The Swap Controller Grab Action provides a mechanism to allow grabbed objects to be swapped between controllers.
     /// </summary>
@@ -11,7 +9,7 @@ namespace VRTK.SecondaryControllerGrabActions
     /// </example>
     public class VRTK_SwapControllerGrabAction : VRTK_BaseGrabAction
     {
-        private void Awake()
+        protected virtual void Awake()
         {
             isActionable = false;
             isSwappable = true;

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerActions.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerActions.cs
@@ -136,7 +136,7 @@ namespace VRTK
         /// </summary>
         /// <param name="state">The visibility state to toggle the controller to, `true` will make the controller visible - `false` will hide the controller model.</param>
         /// <param name="grabbedChildObject">If an object is being held by the controller then this can be passed through to prevent hiding the grabbed game object as well.</param>
-        public void ToggleControllerModel(bool state, GameObject grabbedChildObject)
+        public virtual void ToggleControllerModel(bool state, GameObject grabbedChildObject)
         {
             if (!enabled)
             {
@@ -161,7 +161,7 @@ namespace VRTK
         /// The SetControllerOpacity method allows the opacity of the controller model to be changed to make the controller more transparent. A lower alpha value will make the object more transparent, such as `0.5f` will make the controller partially transparent where as `0f` will make the controller completely transparent.
         /// </summary>
         /// <param name="alpha">The alpha level to apply to opacity of the controller object. `0f` to `1f`.</param>
-        public void SetControllerOpacity(float alpha)
+        public virtual void SetControllerOpacity(float alpha)
         {
             if (!enabled)
             {
@@ -178,7 +178,7 @@ namespace VRTK
         /// <param name="element">The element of the controller to apply the highlight to.</param>
         /// <param name="highlight">The colour of the highlight.</param>
         /// <param name="fadeDuration">The duration of fade from white to the highlight colour. Optional parameter defaults to `0f`.</param>
-        public void HighlightControllerElement(GameObject element, Color? highlight, float fadeDuration = 0f)
+        public virtual void HighlightControllerElement(GameObject element, Color? highlight, float fadeDuration = 0f)
         {
             if (!enabled)
             {
@@ -196,7 +196,7 @@ namespace VRTK
         /// The UnhighlightControllerElement method is the inverse of the HighlightControllerElement method and resets the controller element to its original colour.
         /// </summary>
         /// <param name="element">The element of the controller to remove the highlight from.</param>
-        public void UnhighlightControllerElement(GameObject element)
+        public virtual void UnhighlightControllerElement(GameObject element)
         {
             if (!enabled)
             {
@@ -217,7 +217,7 @@ namespace VRTK
         /// <param name="element">The element of the controller to apply the highlight to.</param>
         /// <param name="highlight">The colour of the highlight.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightControllerElement(bool state, GameObject element, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightControllerElement(bool state, GameObject element, Color? highlight = null, float duration = 0f)
         {
             if (element)
             {
@@ -238,7 +238,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the trigger and `false` will remove the highlight from the trigger.</param>
         /// <param name="highlight">The colour to highlight the trigger with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightTrigger(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightTrigger(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -253,7 +253,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the grip and `false` will remove the highlight from the grip.</param>
         /// <param name="highlight">The colour to highlight the grip with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightGrip(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightGrip(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -269,7 +269,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the touchpad and `false` will remove the highlight from the touchpad.</param>
         /// <param name="highlight">The colour to highlight the touchpad with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightTouchpad(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightTouchpad(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -284,7 +284,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on button one and `false` will remove the highlight from button one.</param>
         /// <param name="highlight">The colour to highlight button one with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightButtonOne(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightButtonOne(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -299,7 +299,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on button two and `false` will remove the highlight from button two.</param>
         /// <param name="highlight">The colour to highlight button two with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightButtonTwo(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightButtonTwo(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -314,7 +314,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the start menu and `false` will remove the highlight from the start menu.</param>
         /// <param name="highlight">The colour to highlight the start menu with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightStartMenu(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightStartMenu(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -329,7 +329,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the body and `false` will remove the highlight from the body.</param>
         /// <param name="highlight">The colour to highlight the body with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlighBody(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlighBody(bool state, Color? highlight = null, float duration = 0f)
         {
             if (!state && controllerHighlighted)
             {
@@ -344,7 +344,7 @@ namespace VRTK
         /// <param name="state">The highlight colour state, `true` will enable the highlight on the entire controller `false` will remove the highlight from the entire controller.</param>
         /// <param name="highlight">The colour to highlight the entire controller with.</param>
         /// <param name="duration">The duration of fade from white to the highlight colour.</param>
-        public void ToggleHighlightController(bool state, Color? highlight = null, float duration = 0f)
+        public virtual void ToggleHighlightController(bool state, Color? highlight = null, float duration = 0f)
         {
             controllerHighlighted = state;
             ToggleHighlightTrigger(state, highlight, duration);
@@ -361,7 +361,7 @@ namespace VRTK
         /// The TriggerHapticPulse/1 method calls a single haptic pulse call on the controller for a single tick.
         /// </summary>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
-        public void TriggerHapticPulse(float strength)
+        public virtual void TriggerHapticPulse(float strength)
         {
             if (enabled)
             {
@@ -377,7 +377,7 @@ namespace VRTK
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
         /// <param name="duration">The length of time the rumble should continue for.</param>
         /// <param name="pulseInterval">The interval to wait between each haptic pulse.</param>
-        public void TriggerHapticPulse(float strength, float duration, float pulseInterval)
+        public virtual void TriggerHapticPulse(float strength, float duration, float pulseInterval)
         {
             if (enabled)
             {
@@ -391,7 +391,7 @@ namespace VRTK
         /// <summary>
         /// The InitaliseHighlighters method sets up the highlighters on the controller model.
         /// </summary>
-        public void InitaliseHighlighters()
+        public virtual void InitaliseHighlighters()
         {
             highlighterOptions = new Dictionary<string, object>();
             highlighterOptions.Add("resetMainTexture", true);
@@ -416,7 +416,7 @@ namespace VRTK
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.Trigger, controllerHand)), objectHighlighter, elementHighlighterOverrides.trigger);
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             cachedElements = new Dictionary<string, Transform>();
 
@@ -460,7 +460,7 @@ namespace VRTK
             }
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             modelContainer = (!modelContainer ? VRTK_DeviceFinder.GetModelAliasController(gameObject) : modelContainer);
             StartCoroutine(WaitForModel());

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -945,19 +945,7 @@ namespace VRTK
             return false;
         }
 
-        private ControllerInteractionEventArgs SetButtonEvent(ref bool buttonBool, bool value, float buttonPressure)
-        {
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
-            buttonBool = value;
-            ControllerInteractionEventArgs e;
-            e.controllerIndex = controllerIndex;
-            e.buttonPressure = buttonPressure;
-            e.touchpadAxis = VRTK_SDK_Bridge.GetTouchpadAxisOnIndex(controllerIndex);
-            e.touchpadAngle = CalculateTouchpadAxisAngle(e.touchpadAxis);
-            return e;
-        }
-
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
             if (actualController)
@@ -972,7 +960,7 @@ namespace VRTK
             }
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             Invoke("DisableEvents", 0f);
             var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
@@ -987,238 +975,7 @@ namespace VRTK
             }
         }
 
-        private void TrackedControllerEnabled(object sender, VRTKTrackedControllerEventArgs e)
-        {
-            var nullBool = false;
-            OnControllerEnabled(SetButtonEvent(ref nullBool, true, 0f));
-        }
-
-        private void TrackedControllerDisabled(object sender, VRTKTrackedControllerEventArgs e)
-        {
-            DisableEvents();
-            var nullBool = false;
-            OnControllerDisabled(SetButtonEvent(ref nullBool, false, 0f));
-        }
-
-        private void TrackedControllerIndexChanged(object sender, VRTKTrackedControllerEventArgs e)
-        {
-            var nullBool = false;
-            OnControllerIndexChanged(SetButtonEvent(ref nullBool, false, 0f));
-        }
-
-        private float CalculateTouchpadAxisAngle(Vector2 axis)
-        {
-            float angle = Mathf.Atan2(axis.y, axis.x) * Mathf.Rad2Deg;
-            angle = 90.0f - angle;
-            if (angle < 0)
-            {
-                angle += 360.0f;
-            }
-            return angle;
-        }
-
-        private void EmitAlias(ButtonAlias type, bool touchDown, float buttonPressure, ref bool buttonBool)
-        {
-            if (pointerToggleButton == type)
-            {
-                if (touchDown)
-                {
-                    pointerPressed = true;
-                    OnAliasPointerOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
-                }
-                else
-                {
-                    pointerPressed = false;
-                    OnAliasPointerOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
-                }
-            }
-
-            if (pointerSetButton == type)
-            {
-                if (!touchDown)
-                {
-                    OnAliasPointerSet(SetButtonEvent(ref buttonBool, false, buttonPressure));
-                }
-            }
-
-            if (grabToggleButton == type)
-            {
-                if (touchDown)
-                {
-                    grabPressed = true;
-                    OnAliasGrabOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
-                }
-                else
-                {
-                    grabPressed = false;
-                    OnAliasGrabOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
-                }
-            }
-
-            if (useToggleButton == type)
-            {
-                if (touchDown)
-                {
-                    usePressed = true;
-                    OnAliasUseOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
-                }
-                else
-                {
-                    usePressed = false;
-                    OnAliasUseOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
-                }
-            }
-
-            if (uiClickButton == type)
-            {
-                if (touchDown)
-                {
-                    uiClickPressed = true;
-                    OnAliasUIClickOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
-                }
-                else
-                {
-                    uiClickPressed = false;
-                    OnAliasUIClickOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
-                }
-            }
-
-            if (menuToggleButton == type)
-            {
-                if (touchDown)
-                {
-                    menuPressed = true;
-                    OnAliasMenuOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
-                }
-                else
-                {
-                    menuPressed = false;
-                    OnAliasMenuOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
-                }
-            }
-        }
-
-        private bool Vector2ShallowEquals(Vector2 vectorA, Vector2 vectorB)
-        {
-            var distanceVector = vectorA - vectorB;
-            return Math.Round(Mathf.Abs(distanceVector.x), axisFidelity, MidpointRounding.AwayFromZero) < float.Epsilon
-                   && Math.Round(Mathf.Abs(distanceVector.y), axisFidelity, MidpointRounding.AwayFromZero) < float.Epsilon;
-        }
-
-        private void DisableEvents()
-        {
-            if (triggerPressed)
-            {
-                OnTriggerReleased(SetButtonEvent(ref triggerPressed, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Press, false, 0f, ref triggerPressed);
-            }
-
-            if (triggerTouched)
-            {
-                OnTriggerTouchEnd(SetButtonEvent(ref triggerTouched, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Touch, false, 0f, ref triggerTouched);
-            }
-
-            if (triggerHairlinePressed)
-            {
-                OnTriggerHairlineEnd(SetButtonEvent(ref triggerHairlinePressed, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Hairline, false, 0f, ref triggerHairlinePressed);
-            }
-
-            if (triggerClicked)
-            {
-                OnTriggerUnclicked(SetButtonEvent(ref triggerClicked, false, 0f));
-                EmitAlias(ButtonAlias.Trigger_Click, false, 0f, ref triggerClicked);
-            }
-
-            if (gripPressed)
-            {
-                OnGripReleased(SetButtonEvent(ref gripPressed, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Press, false, 0f, ref gripPressed);
-            }
-
-            if (gripTouched)
-            {
-                OnGripTouchEnd(SetButtonEvent(ref gripTouched, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Touch, false, 0f, ref gripTouched);
-            }
-
-            if (gripHairlinePressed)
-            {
-                OnGripHairlineEnd(SetButtonEvent(ref gripHairlinePressed, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Hairline, false, 0f, ref gripHairlinePressed);
-            }
-
-            if (gripClicked)
-            {
-                OnGripUnclicked(SetButtonEvent(ref gripClicked, false, 0f));
-                EmitAlias(ButtonAlias.Grip_Click, false, 0f, ref gripClicked);
-            }
-
-            if (touchpadPressed)
-            {
-                OnTouchpadReleased(SetButtonEvent(ref touchpadPressed, false, 0f));
-                EmitAlias(ButtonAlias.Touchpad_Press, false, 0f, ref touchpadPressed);
-            }
-
-            if (touchpadTouched)
-            {
-                OnTouchpadTouchEnd(SetButtonEvent(ref touchpadTouched, false, 0f));
-                EmitAlias(ButtonAlias.Touchpad_Touch, false, 0f, ref touchpadTouched);
-            }
-
-            if (buttonOnePressed)
-            {
-                OnButtonOneReleased(SetButtonEvent(ref buttonOnePressed, false, 0f));
-                EmitAlias(ButtonAlias.Button_One_Press, false, 0f, ref buttonOnePressed);
-            }
-
-            if (buttonOneTouched)
-            {
-                OnButtonOneTouchEnd(SetButtonEvent(ref buttonOneTouched, false, 0f));
-                EmitAlias(ButtonAlias.Button_One_Touch, false, 0f, ref buttonOneTouched);
-            }
-
-            if (buttonTwoPressed)
-            {
-                OnButtonTwoReleased(SetButtonEvent(ref buttonTwoPressed, false, 0f));
-                EmitAlias(ButtonAlias.Button_Two_Press, false, 0f, ref buttonTwoPressed);
-            }
-
-            if (buttonTwoTouched)
-            {
-                OnButtonTwoTouchEnd(SetButtonEvent(ref buttonTwoTouched, false, 0f));
-                EmitAlias(ButtonAlias.Button_Two_Touch, false, 0f, ref buttonTwoTouched);
-            }
-
-            if (startMenuPressed)
-            {
-                OnStartMenuReleased(SetButtonEvent(ref startMenuPressed, false, 0f));
-                EmitAlias(ButtonAlias.Start_Menu_Press, false, 0f, ref startMenuPressed);
-            }
-
-            triggerAxisChanged = false;
-            gripAxisChanged = false;
-            touchpadAxisChanged = false;
-
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
-
-            if (controllerIndex < uint.MaxValue)
-            {
-                Vector2 currentTriggerAxis = VRTK_SDK_Bridge.GetTriggerAxisOnIndex(controllerIndex);
-                Vector2 currentGripAxis = VRTK_SDK_Bridge.GetGripAxisOnIndex(controllerIndex);
-                Vector2 currentTouchpadAxis = VRTK_SDK_Bridge.GetTouchpadAxisOnIndex(controllerIndex);
-
-                // Save current touch and trigger settings to detect next change.
-                touchpadAxis = new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y);
-                triggerAxis = new Vector2(currentTriggerAxis.x, currentTriggerAxis.y);
-                gripAxis = new Vector2(currentGripAxis.x, currentGripAxis.y);
-                hairTriggerDelta = VRTK_SDK_Bridge.GetTriggerHairlineDeltaOnIndex(controllerIndex);
-                hairGripDelta = VRTK_SDK_Bridge.GetGripHairlineDeltaOnIndex(controllerIndex);
-            }
-        }
-
-        private void Update()
+        protected virtual void Update()
         {
             var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
 
@@ -1467,6 +1224,249 @@ namespace VRTK
 
             hairTriggerDelta = VRTK_SDK_Bridge.GetTriggerHairlineDeltaOnIndex(controllerIndex);
             hairGripDelta = VRTK_SDK_Bridge.GetGripHairlineDeltaOnIndex(controllerIndex);
+        }
+
+        private ControllerInteractionEventArgs SetButtonEvent(ref bool buttonBool, bool value, float buttonPressure)
+        {
+            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+            buttonBool = value;
+            ControllerInteractionEventArgs e;
+            e.controllerIndex = controllerIndex;
+            e.buttonPressure = buttonPressure;
+            e.touchpadAxis = VRTK_SDK_Bridge.GetTouchpadAxisOnIndex(controllerIndex);
+            e.touchpadAngle = CalculateTouchpadAxisAngle(e.touchpadAxis);
+            return e;
+        }
+
+        private void TrackedControllerEnabled(object sender, VRTKTrackedControllerEventArgs e)
+        {
+            var nullBool = false;
+            OnControllerEnabled(SetButtonEvent(ref nullBool, true, 0f));
+        }
+
+        private void TrackedControllerDisabled(object sender, VRTKTrackedControllerEventArgs e)
+        {
+            DisableEvents();
+            var nullBool = false;
+            OnControllerDisabled(SetButtonEvent(ref nullBool, false, 0f));
+        }
+
+        private void TrackedControllerIndexChanged(object sender, VRTKTrackedControllerEventArgs e)
+        {
+            var nullBool = false;
+            OnControllerIndexChanged(SetButtonEvent(ref nullBool, false, 0f));
+        }
+
+        private float CalculateTouchpadAxisAngle(Vector2 axis)
+        {
+            float angle = Mathf.Atan2(axis.y, axis.x) * Mathf.Rad2Deg;
+            angle = 90.0f - angle;
+            if (angle < 0)
+            {
+                angle += 360.0f;
+            }
+            return angle;
+        }
+
+        private void EmitAlias(ButtonAlias type, bool touchDown, float buttonPressure, ref bool buttonBool)
+        {
+            if (pointerToggleButton == type)
+            {
+                if (touchDown)
+                {
+                    pointerPressed = true;
+                    OnAliasPointerOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
+                }
+                else
+                {
+                    pointerPressed = false;
+                    OnAliasPointerOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+
+            if (pointerSetButton == type)
+            {
+                if (!touchDown)
+                {
+                    OnAliasPointerSet(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+
+            if (grabToggleButton == type)
+            {
+                if (touchDown)
+                {
+                    grabPressed = true;
+                    OnAliasGrabOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
+                }
+                else
+                {
+                    grabPressed = false;
+                    OnAliasGrabOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+
+            if (useToggleButton == type)
+            {
+                if (touchDown)
+                {
+                    usePressed = true;
+                    OnAliasUseOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
+                }
+                else
+                {
+                    usePressed = false;
+                    OnAliasUseOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+
+            if (uiClickButton == type)
+            {
+                if (touchDown)
+                {
+                    uiClickPressed = true;
+                    OnAliasUIClickOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
+                }
+                else
+                {
+                    uiClickPressed = false;
+                    OnAliasUIClickOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+
+            if (menuToggleButton == type)
+            {
+                if (touchDown)
+                {
+                    menuPressed = true;
+                    OnAliasMenuOn(SetButtonEvent(ref buttonBool, true, buttonPressure));
+                }
+                else
+                {
+                    menuPressed = false;
+                    OnAliasMenuOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+        }
+
+        private bool Vector2ShallowEquals(Vector2 vectorA, Vector2 vectorB)
+        {
+            var distanceVector = vectorA - vectorB;
+            return Math.Round(Mathf.Abs(distanceVector.x), axisFidelity, MidpointRounding.AwayFromZero) < float.Epsilon
+                   && Math.Round(Mathf.Abs(distanceVector.y), axisFidelity, MidpointRounding.AwayFromZero) < float.Epsilon;
+        }
+
+        private void DisableEvents()
+        {
+            if (triggerPressed)
+            {
+                OnTriggerReleased(SetButtonEvent(ref triggerPressed, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Press, false, 0f, ref triggerPressed);
+            }
+
+            if (triggerTouched)
+            {
+                OnTriggerTouchEnd(SetButtonEvent(ref triggerTouched, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Touch, false, 0f, ref triggerTouched);
+            }
+
+            if (triggerHairlinePressed)
+            {
+                OnTriggerHairlineEnd(SetButtonEvent(ref triggerHairlinePressed, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Hairline, false, 0f, ref triggerHairlinePressed);
+            }
+
+            if (triggerClicked)
+            {
+                OnTriggerUnclicked(SetButtonEvent(ref triggerClicked, false, 0f));
+                EmitAlias(ButtonAlias.Trigger_Click, false, 0f, ref triggerClicked);
+            }
+
+            if (gripPressed)
+            {
+                OnGripReleased(SetButtonEvent(ref gripPressed, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Press, false, 0f, ref gripPressed);
+            }
+
+            if (gripTouched)
+            {
+                OnGripTouchEnd(SetButtonEvent(ref gripTouched, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Touch, false, 0f, ref gripTouched);
+            }
+
+            if (gripHairlinePressed)
+            {
+                OnGripHairlineEnd(SetButtonEvent(ref gripHairlinePressed, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Hairline, false, 0f, ref gripHairlinePressed);
+            }
+
+            if (gripClicked)
+            {
+                OnGripUnclicked(SetButtonEvent(ref gripClicked, false, 0f));
+                EmitAlias(ButtonAlias.Grip_Click, false, 0f, ref gripClicked);
+            }
+
+            if (touchpadPressed)
+            {
+                OnTouchpadReleased(SetButtonEvent(ref touchpadPressed, false, 0f));
+                EmitAlias(ButtonAlias.Touchpad_Press, false, 0f, ref touchpadPressed);
+            }
+
+            if (touchpadTouched)
+            {
+                OnTouchpadTouchEnd(SetButtonEvent(ref touchpadTouched, false, 0f));
+                EmitAlias(ButtonAlias.Touchpad_Touch, false, 0f, ref touchpadTouched);
+            }
+
+            if (buttonOnePressed)
+            {
+                OnButtonOneReleased(SetButtonEvent(ref buttonOnePressed, false, 0f));
+                EmitAlias(ButtonAlias.Button_One_Press, false, 0f, ref buttonOnePressed);
+            }
+
+            if (buttonOneTouched)
+            {
+                OnButtonOneTouchEnd(SetButtonEvent(ref buttonOneTouched, false, 0f));
+                EmitAlias(ButtonAlias.Button_One_Touch, false, 0f, ref buttonOneTouched);
+            }
+
+            if (buttonTwoPressed)
+            {
+                OnButtonTwoReleased(SetButtonEvent(ref buttonTwoPressed, false, 0f));
+                EmitAlias(ButtonAlias.Button_Two_Press, false, 0f, ref buttonTwoPressed);
+            }
+
+            if (buttonTwoTouched)
+            {
+                OnButtonTwoTouchEnd(SetButtonEvent(ref buttonTwoTouched, false, 0f));
+                EmitAlias(ButtonAlias.Button_Two_Touch, false, 0f, ref buttonTwoTouched);
+            }
+
+            if (startMenuPressed)
+            {
+                OnStartMenuReleased(SetButtonEvent(ref startMenuPressed, false, 0f));
+                EmitAlias(ButtonAlias.Start_Menu_Press, false, 0f, ref startMenuPressed);
+            }
+
+            triggerAxisChanged = false;
+            gripAxisChanged = false;
+            touchpadAxisChanged = false;
+
+            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+
+            if (controllerIndex < uint.MaxValue)
+            {
+                Vector2 currentTriggerAxis = VRTK_SDK_Bridge.GetTriggerAxisOnIndex(controllerIndex);
+                Vector2 currentGripAxis = VRTK_SDK_Bridge.GetGripAxisOnIndex(controllerIndex);
+                Vector2 currentTouchpadAxis = VRTK_SDK_Bridge.GetTouchpadAxisOnIndex(controllerIndex);
+
+                // Save current touch and trigger settings to detect next change.
+                touchpadAxis = new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y);
+                triggerAxis = new Vector2(currentTriggerAxis.x, currentTriggerAxis.y);
+                gripAxis = new Vector2(currentGripAxis.x, currentGripAxis.y);
+                hairTriggerDelta = VRTK_SDK_Bridge.GetTriggerHairlineDeltaOnIndex(controllerIndex);
+                hairGripDelta = VRTK_SDK_Bridge.GetGripHairlineDeltaOnIndex(controllerIndex);
+            }
         }
     }
 }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
@@ -40,7 +40,7 @@ namespace VRTK
         /// <param name="showController">If true then the controller will attempt to be made visible when no longer touching, if false then the controller will be hidden on touch.</param>
         /// <param name="controllerActions">The controller to apply the visibility state to.</param>
         /// <param name="obj">The object that is currently being interacted with by the controller which is passed through to the visibility to prevent the object from being hidden as well.</param>
-        public void ToggleControllerOnTouch(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)
+        public virtual void ToggleControllerOnTouch(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)
         {
             if (hideControllerOnTouch)
             {
@@ -55,7 +55,7 @@ namespace VRTK
         /// <param name="showController">If true then the controller will attempt to be made visible when no longer grabbing, if false then the controller will be hidden on grab.</param>
         /// <param name="controllerActions">The controller to apply the visibility state to.</param>
         /// <param name="obj">The object that is currently being interacted with by the controller which is passed through to the visibility to prevent the object from being hidden as well.</param>
-        public void ToggleControllerOnGrab(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)
+        public virtual void ToggleControllerOnGrab(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)
         {
             if (hideControllerOnGrab)
             {
@@ -77,7 +77,7 @@ namespace VRTK
         /// <param name="showController">If true then the controller will attempt to be made visible when no longer using, if false then the controller will be hidden on use.</param>
         /// <param name="controllerActions">The controller to apply the visibility state to.</param>
         /// <param name="obj">The object that is currently being interacted with by the controller which is passed through to the visibility to prevent the object from being hidden as well.</param>
-        public void ToggleControllerOnUse(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)
+        public virtual void ToggleControllerOnUse(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)
         {
             if (hideControllerOnUse)
             {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -98,14 +98,14 @@ namespace VRTK
             return grabbedObject;
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             interactTouch = GetComponent<VRTK_InteractTouch>();
             controllerActions = GetComponent<VRTK_ControllerActions>();
             controllerEvents = GetComponent<VRTK_ControllerEvents>();
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             RegrabUndroppableObject();
 
@@ -115,12 +115,19 @@ namespace VRTK
             SetControllerAttachPoint();
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             SetUndroppableObject();
             ForceRelease();
             controllerEvents.AliasGrabOn -= new ControllerInteractionEventHandler(DoGrabObject);
             controllerEvents.AliasGrabOff -= new ControllerInteractionEventHandler(DoReleaseObject);
+        }
+
+        protected virtual void Update()
+        {
+            CheckControllerAttachPointSet();
+            CreateNonTouchingRigidbody();
+            CheckPrecognitionGrab();
         }
 
         private void RegrabUndroppableObject()
@@ -398,13 +405,6 @@ namespace VRTK
         private void DoReleaseObject(object sender, ControllerInteractionEventArgs e)
         {
             AttemptReleaseObject();
-        }
-
-        private void Update()
-        {
-            CheckControllerAttachPointSet();
-            CreateNonTouchingRigidbody();
-            CheckPrecognitionGrab();
         }
 
         private void CheckControllerAttachPointSet()

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -41,7 +41,7 @@ namespace VRTK
         /// The HapticsOnTouch method triggers the haptic feedback on the given controller for the settings associated with touch.
         /// </summary>
         /// <param name="controllerActions">The controller to activate the haptic feedback on.</param>
-        public void HapticsOnTouch(VRTK_ControllerActions controllerActions)
+        public virtual void HapticsOnTouch(VRTK_ControllerActions controllerActions)
         {
             if (strengthOnTouch > 0 && durationOnTouch > 0f)
             {
@@ -53,7 +53,7 @@ namespace VRTK
         /// The HapticsOnGrab method triggers the haptic feedback on the given controller for the settings associated with grab.
         /// </summary>
         /// <param name="controllerActions">The controller to activate the haptic feedback on.</param>
-        public void HapticsOnGrab(VRTK_ControllerActions controllerActions)
+        public virtual void HapticsOnGrab(VRTK_ControllerActions controllerActions)
         {
             if (strengthOnGrab > 0 && durationOnGrab > 0f)
             {
@@ -65,7 +65,7 @@ namespace VRTK
         /// The HapticsOnUse method triggers the haptic feedback on the given controller for the settings associated with use.
         /// </summary>
         /// <param name="controllerActions">The controller to activate the haptic feedback on.</param>
-        public void HapticsOnUse(VRTK_ControllerActions controllerActions)
+        public virtual void HapticsOnUse(VRTK_ControllerActions controllerActions)
         {
             if (strengthOnUse > 0 && durationOnUse > 0f)
             {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -84,20 +84,20 @@ namespace VRTK
             }
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             interactTouch = GetComponent<VRTK_InteractTouch>();
             controllerActions = GetComponent<VRTK_ControllerActions>();
             controllerEvents = GetComponent<VRTK_ControllerEvents>();
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             controllerEvents.AliasUseOn += new ControllerInteractionEventHandler(DoStartUseObject);
             controllerEvents.AliasUseOff += new ControllerInteractionEventHandler(DoStopUseObject);
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             ForceStopUsing();
             controllerEvents.AliasUseOn -= new ControllerInteractionEventHandler(DoStartUseObject);

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -402,7 +402,7 @@ namespace VRTK
         /// The PauseCollisions method temporarily pauses all collisions on the object at grab time by removing the object's rigidbody's ability to detect collisions. This can be useful for preventing clipping when initially grabbing an item.
         /// </summary>
         /// <param name="delay">The amount of time to pause the collisions for.</param>
-        public void PauseCollisions(float delay)
+        public virtual void PauseCollisions(float delay)
         {
             if (delay > 0f)
             {
@@ -417,7 +417,7 @@ namespace VRTK
         /// <summary>
         /// The ZeroVelocity method resets the velocity and angular velocity to zero on the rigidbody attached to the object.
         /// </summary>
-        public void ZeroVelocity()
+        public virtual void ZeroVelocity()
         {
             if (interactableRigidbody)
             {
@@ -429,7 +429,7 @@ namespace VRTK
         /// <summary>
         /// The SaveCurrentState method stores the existing object parent and the object's rigidbody kinematic setting.
         /// </summary>
-        public void SaveCurrentState()
+        public virtual void SaveCurrentState()
         {
             if (!IsGrabbed() && !snappedInSnapDropZone)
             {
@@ -484,7 +484,7 @@ namespace VRTK
         /// <param name="actualController">The game object of the controller that is being checked.</param>
         /// <param name="controllerCheck">The value of which controller is allowed to interact with this object.</param>
         /// <returns>Is true if the interacting controller is allowed to grab the object.</returns>
-        public bool IsValidInteractableController(GameObject actualController, AllowedController controllerCheck)
+        public virtual bool IsValidInteractableController(GameObject actualController, AllowedController controllerCheck)
         {
             if (controllerCheck == AllowedController.Both)
             {
@@ -498,7 +498,7 @@ namespace VRTK
         /// <summary>
         /// The ForceStopInteracting method forces the object to no longer be interacted with and will cause a controller to drop the object and stop touching it. This is useful if the controller is required to auto interact with another object.
         /// </summary>
-        public void ForceStopInteracting()
+        public virtual void ForceStopInteracting()
         {
             if (gameObject.activeInHierarchy)
             {
@@ -516,7 +516,7 @@ namespace VRTK
         /// <summary>
         /// The ForceStopSecondaryGrabInteraction method forces the object to no longer be influenced by the second controller grabbing it.
         /// </summary>
-        public void ForceStopSecondaryGrabInteraction()
+        public virtual void ForceStopSecondaryGrabInteraction()
         {
             var grabbingObject = GetSecondaryGrabbingObject();
             if (grabbingObject)
@@ -548,7 +548,7 @@ namespace VRTK
         /// <summary>
         /// the StoreLocalScale method saves the current transform local scale values.
         /// </summary>
-        public void StoreLocalScale()
+        public virtual void StoreLocalScale()
         {
             previousLocalScale = transform.localScale;
         }
@@ -558,7 +558,7 @@ namespace VRTK
         /// </summary>
         /// <param name="snapDropZone">The Snap Drop Zone object that is being interacted with.</param>
         /// <param name="state">The state of whether the interactable object is fixed in or removed from the Snap Drop Zone. True denotes the interactable object is fixed to the Snap Drop Zone and false denotes it has been removed from the Snap Drop Zone.</param>
-        public void ToggleSnapDropZone(VRTK_SnapDropZone snapDropZone, bool state)
+        public virtual void ToggleSnapDropZone(VRTK_SnapDropZone snapDropZone, bool state)
         {
             snappedInSnapDropZone = state;
             if (state)

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAutoGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAutoGrab.cs
@@ -32,7 +32,7 @@ namespace VRTK
             previousClonedObject = null;
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             //Must always clone if the object is a prefab
             if (objectIsPrefab)

--- a/Assets/VRTK/Scripts/Internal/VRTK_ControllerTracker.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_ControllerTracker.cs
@@ -6,7 +6,7 @@
     {
         private VRTK_TrackedController trackedController;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
             if (actualController)
@@ -15,7 +15,7 @@
             }
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (trackedController && transform.parent != trackedController.transform)
             {

--- a/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
@@ -12,7 +12,7 @@
         private Transform playArea;
         private VRTK_RoomExtender roomExtender;
 
-        private void Awake()
+        protected virtual void Awake()
         {
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
             roomExtender = FindObjectOfType<VRTK_RoomExtender>();
@@ -23,7 +23,7 @@
             }
         }
 
-        private void OnDrawGizmos()
+        protected virtual void OnDrawGizmos()
         {
             if (!drawWireframeWhenSelectedOnly)
             {
@@ -31,7 +31,7 @@
             }
         }
 
-        private void OnDrawGizmosSelected()
+        protected virtual void OnDrawGizmosSelected()
         {
             if (drawWireframeWhenSelectedOnly)
             {

--- a/Assets/VRTK/Scripts/Internal/VRTK_ScreenFade.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_ScreenFade.cs
@@ -33,13 +33,13 @@
             }
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             fadeMaterial = new Material(Shader.Find("Unlit/TransparentColor"));
             instance = this;
         }
 
-        private void OnPostRender()
+        protected virtual void OnPostRender()
         {
             if (currentColor != targetColor)
             {

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
@@ -55,7 +55,7 @@
             return e;
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             aliasController = VRTK_DeviceFinder.GetScriptAliasController(gameObject);
 
@@ -66,25 +66,12 @@
             enableControllerCoroutine = StartCoroutine(Enable());
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             Invoke("Disable", 0f);
         }
 
-        private IEnumerator Enable()
-        {
-            yield return new WaitForEndOfFrame();
-
-            while (!gameObject.activeInHierarchy)
-            {
-                yield return null;
-            }
-
-            currentIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
-            OnControllerEnabled(SetEventPayload());
-        }
-
-        private void Disable()
+        protected virtual void Disable()
         {
             if (enableControllerCoroutine != null)
             {
@@ -94,7 +81,7 @@
             OnControllerDisabled(SetEventPayload());
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             var checkIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
             if (currentIndex < uint.MaxValue && checkIndex != currentIndex)
@@ -110,6 +97,19 @@
             {
                 aliasController.SetActive(true);
             }
+        }
+
+        private IEnumerator Enable()
+        {
+            yield return new WaitForEndOfFrame();
+
+            while (!gameObject.activeInHierarchy)
+            {
+                yield return null;
+            }
+
+            currentIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+            OnControllerEnabled(SetEventPayload());
         }
     }
 }

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedHeadset.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedHeadset.cs
@@ -4,7 +4,7 @@
 
     public class VRTK_TrackedHeadset : MonoBehaviour
     {
-        private void Update()
+        protected virtual void Update()
         {
             VRTK_SDK_Bridge.HeadsetProcessUpdate();
         }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -63,7 +63,7 @@ namespace VRTK
         /// </summary>
         /// <param name="markerMaker">The game object that is used to generate destination marker events, such as a controller.</param>
         /// <param name="register">Determines whether to register or unregister the listeners.</param>
-        public void InitDestinationSetListener(GameObject markerMaker, bool register)
+        public virtual void InitDestinationSetListener(GameObject markerMaker, bool register)
         {
             if (markerMaker)
             {
@@ -88,11 +88,17 @@ namespace VRTK
         /// The ToggleTeleportEnabled method is used to determine whether the teleporter will initiate a teleport on a destination set event, if the state is true then the teleporter will work as normal, if the state is false then the teleporter will not be operational.
         /// </summary>
         /// <param name="state">Toggles whether the teleporter is enabled or disabled.</param>
-        public void ToggleTeleportEnabled(bool state)
+        public virtual void ToggleTeleportEnabled(bool state)
         {
             enableTeleport = state;
         }
 
+        /// <summary>
+        /// The ValidLocation method determines if the given target is a location that can be teleported to
+        /// </summary>
+        /// <param name="target">The Transform that the destination marker is touching.</param>
+        /// <param name="destinationPosition">The position in world space that is the destination.</param>
+        /// <returns>Returns true if the target is a valid location.</returns>
         public virtual bool ValidLocation(Transform target, Vector3 destinationPosition)
         {
             //If the target is one of the player objects or a UI Canvas then it's never a valid location
@@ -134,22 +140,6 @@ namespace VRTK
         {
             InitDestinationMarkerListeners(false);
             VRTK_ObjectCache.registeredTeleporters.Remove(this);
-        }
-
-        protected void OnTeleporting(object sender, DestinationMarkerEventArgs e)
-        {
-            if (Teleporting != null)
-            {
-                Teleporting(this, e);
-            }
-        }
-
-        protected void OnTeleported(object sender, DestinationMarkerEventArgs e)
-        {
-            if (Teleported != null)
-            {
-                Teleported(this, e);
-            }
         }
 
         protected virtual void Blink(float transitionSpeed)
@@ -203,6 +193,22 @@ namespace VRTK
                 position.y = (terrainHeight > position.y ? position.y : terrainHeight);
             }
             return position;
+        }
+
+        protected void OnTeleporting(object sender, DestinationMarkerEventArgs e)
+        {
+            if (Teleporting != null)
+            {
+                Teleporting(this, e);
+            }
+        }
+
+        protected void OnTeleported(object sender, DestinationMarkerEventArgs e)
+        {
+            if (Teleported != null)
+            {
+                Teleported(this, e);
+            }
         }
 
         private void CalculateBlinkDelay(float blinkSpeed, Vector3 newPosition)

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_MoveInPlace.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_MoveInPlace.cs
@@ -175,7 +175,7 @@ namespace VRTK
             return curSpeed;
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             controllerLeftHand = VRTK_DeviceFinder.GetControllerLeftHand();
             controllerRightHand = VRTK_DeviceFinder.GetControllerRightHand();
@@ -184,19 +184,19 @@ namespace VRTK
             SetControlOptions(controlOptions);
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             engageButtonPressed += DoTouchpadDown;
             engageButtonUp += DoTouchpadUp;
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             engageButtonPressed -= DoTouchpadDown;
             engageButtonUp -= DoTouchpadUp;
         }
 
-        private void Start()
+        protected virtual void Start()
         {
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
             SetControllerListeners(controllerLeftHand);
@@ -214,26 +214,7 @@ namespace VRTK
             }
         }
 
-        private void DoTouchpadDown(object sender, ControllerInteractionEventArgs e)
-        {
-            active = true;
-        }
-
-        private void DoTouchpadUp(object sender, ControllerInteractionEventArgs e)
-        {
-            // If the button is released, clear all the lists.
-            foreach (Transform obj in trackedObjects)
-            {
-                movementList[obj].Clear();
-            }
-            initalGaze = Vector3.zero;
-            direction = Vector3.zero;
-            curSpeed = 0;
-
-            active = false;
-        }
-
-        private void FixedUpdate()
+        protected virtual void FixedUpdate()
         {
             // If Move In Place is currently engaged.
             if (active)
@@ -343,6 +324,25 @@ namespace VRTK
             {
                 playArea.position = new Vector3(movement.x + playArea.position.x, playArea.position.y, movement.z + playArea.position.z);
             }
+        }
+
+        private void DoTouchpadDown(object sender, ControllerInteractionEventArgs e)
+        {
+            active = true;
+        }
+
+        private void DoTouchpadUp(object sender, ControllerInteractionEventArgs e)
+        {
+            // If the button is released, clear all the lists.
+            foreach (Transform obj in trackedObjects)
+            {
+                movementList[obj].Clear();
+            }
+            initalGaze = Vector3.zero;
+            direction = Vector3.zero;
+            curSpeed = 0;
+
+            active = false;
         }
 
         private Quaternion DetermineAverageControllerRotation()

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
@@ -50,6 +50,31 @@ namespace VRTK
         private VRTK_BodyPhysics bodyPhysics;
         private bool isClimbing = false;
 
+        protected virtual void Awake()
+        {
+            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+            bodyPhysics = GetComponent<VRTK_BodyPhysics>();
+        }
+
+        protected virtual void OnEnable()
+        {
+            InitListeners(true);
+        }
+
+        protected virtual void OnDisable()
+        {
+            Ungrab(false, 0, climbingObject);
+            InitListeners(false);
+        }
+
+        protected virtual void Update()
+        {
+            if (isClimbing)
+            {
+                playArea.position = startPosition - (GetPosition(grabbingController.transform) - startControllerPosition);
+            }
+        }
+
         private void OnPlayerClimbStarted(PlayerClimbEventArgs e)
         {
             if (PlayerClimbStarted != null)
@@ -72,31 +97,6 @@ namespace VRTK
             e.controllerIndex = controllerIndex;
             e.target = target;
             return e;
-        }
-
-        private void Awake()
-        {
-            playArea = VRTK_DeviceFinder.PlayAreaTransform();
-            bodyPhysics = GetComponent<VRTK_BodyPhysics>();
-        }
-
-        private void OnEnable()
-        {
-            InitListeners(true);
-        }
-
-        private void OnDisable()
-        {
-            Ungrab(false, 0, climbingObject);
-            InitListeners(false);
-        }
-
-        private void Update()
-        {
-            if (isClimbing)
-            {
-                playArea.position = startPosition - (GetPosition(grabbingController.transform) - startControllerPosition);
-            }
         }
 
         private void InitListeners(bool state)

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_RoomExtender.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_RoomExtender.cs
@@ -49,7 +49,7 @@ namespace VRTK
         protected Vector3 lastPosition;
         protected Vector3 lastMovement;
 
-        private void Start()
+        protected virtual void Start()
         {
             if (movementTransform == null)
             {
@@ -72,7 +72,7 @@ namespace VRTK
             lastPosition = movementTransform.localPosition;
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             switch (movementFunction)
             {

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TeleportDisableOnControllerObscured.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TeleportDisableOnControllerObscured.cs
@@ -13,10 +13,24 @@ namespace VRTK
         private VRTK_BasicTeleport basicTeleport;
         private VRTK_HeadsetControllerAware headset;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             basicTeleport = GetComponent<VRTK_BasicTeleport>();
             StartCoroutine(EnableAtEndOfFrame());
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (basicTeleport == null)
+            {
+                return;
+            }
+
+            if (headset)
+            {
+                headset.ControllerObscured -= new HeadsetControllerAwareEventHandler(DisableTeleport);
+                headset.ControllerUnobscured -= new HeadsetControllerAwareEventHandler(EnableTeleport);
+            }
         }
 
         private IEnumerator EnableAtEndOfFrame()
@@ -32,20 +46,6 @@ namespace VRTK
             {
                 headset.ControllerObscured += new HeadsetControllerAwareEventHandler(DisableTeleport);
                 headset.ControllerUnobscured += new HeadsetControllerAwareEventHandler(EnableTeleport);
-            }
-        }
-
-        private void OnDisable()
-        {
-            if (basicTeleport == null)
-            {
-                return;
-            }
-
-            if (headset)
-            {
-                headset.ControllerObscured -= new HeadsetControllerAwareEventHandler(DisableTeleport);
-                headset.ControllerUnobscured -= new HeadsetControllerAwareEventHandler(EnableTeleport);
             }
         }
 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TeleportDisableOnHeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TeleportDisableOnHeadsetCollision.cs
@@ -12,10 +12,24 @@ namespace VRTK
         private VRTK_BasicTeleport basicTeleport;
         private VRTK_HeadsetCollision headsetCollision;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             basicTeleport = GetComponent<VRTK_BasicTeleport>();
             StartCoroutine(EnableAtEndOfFrame());
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (basicTeleport == null)
+            {
+                return;
+            }
+
+            if (headsetCollision)
+            {
+                headsetCollision.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(DisableTeleport);
+                headsetCollision.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(EnableTeleport);
+            }
         }
 
         private IEnumerator EnableAtEndOfFrame()
@@ -31,20 +45,6 @@ namespace VRTK
             {
                 headsetCollision.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(DisableTeleport);
                 headsetCollision.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(EnableTeleport);
-            }
-        }
-
-        private void OnDisable()
-        {
-            if (basicTeleport == null)
-            {
-                return;
-            }
-
-            if (headsetCollision)
-            {
-                headsetCollision.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(DisableTeleport);
-                headsetCollision.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(EnableTeleport);
             }
         }
 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadWalking.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadWalking.cs
@@ -67,7 +67,7 @@ namespace VRTK
         private bool multiplySpeed = false;
         private VRTK_ControllerEvents controllerEvents;
 
-        private void Awake()
+        protected virtual void Awake()
         {
             touchpadAxisChanged = new ControllerInteractionEventHandler(DoTouchpadAxisChanged);
             touchpadUntouched = new ControllerInteractionEventHandler(DoTouchpadTouchEnd);
@@ -80,11 +80,23 @@ namespace VRTK
             }
         }
 
-        private void Start()
+        protected virtual void Start()
         {
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
             SetControllerListeners(controllerLeftHand);
             SetControllerListeners(controllerRightHand);
+        }
+
+        protected virtual void Update()
+        {
+            multiplySpeed = (controllerEvents && speedMultiplierButton != VRTK_ControllerEvents.ButtonAlias.Undefined && controllerEvents.IsButtonPressed(speedMultiplierButton));
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            CalculateSpeed(ref movementSpeed, touchAxis.y);
+            CalculateSpeed(ref strafeSpeed, touchAxis.x);
+            Move();
         }
 
         private void DoTouchpadAxisChanged(object sender, ControllerInteractionEventArgs e)
@@ -152,18 +164,6 @@ namespace VRTK
                 playArea.position += (movement + strafe);
                 playArea.position = new Vector3(playArea.position.x, fixY, playArea.position.z);
             }
-        }
-
-        private void Update()
-        {
-            multiplySpeed = (controllerEvents && speedMultiplierButton != VRTK_ControllerEvents.ButtonAlias.Undefined && controllerEvents.IsButtonPressed(speedMultiplierButton));
-        }
-
-        private void FixedUpdate()
-        {
-            CalculateSpeed(ref movementSpeed, touchAxis.y);
-            CalculateSpeed(ref strafeSpeed, touchAxis.x);
-            Move();
         }
 
         private void SetControllerListeners(GameObject controller)

--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -272,12 +272,7 @@ namespace VRTK
             targetListPolicy = list;
         }
 
-        private bool ValidTarget(Collider collider)
-        {
-            return (!VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && !(VRTK_PolicyList.Check(collider.gameObject, targetListPolicy)));
-        }
-
-        private void OnTriggerStay(Collider collider)
+        protected virtual void OnTriggerStay(Collider collider)
         {
             if (parent.enabled && parent.gameObject.activeInHierarchy && ValidTarget(collider))
             {
@@ -285,12 +280,17 @@ namespace VRTK
             }
         }
 
-        private void OnTriggerExit(Collider collider)
+        protected virtual void OnTriggerExit(Collider collider)
         {
             if (ValidTarget(collider))
             {
                 parent.SetPlayAreaCursorCollision(false);
             }
+        }
+
+        private bool ValidTarget(Collider collider)
+        {
+            return (!VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && !(VRTK_PolicyList.Check(collider.gameObject, targetListPolicy)));
         }
     }
 }

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -249,7 +249,7 @@ namespace VRTK
             DisableBodyPhysics();
         }
 
-        protected void FixedUpdate()
+        protected virtual void FixedUpdate()
         {
             CheckBodyCollisionsSetting();
             if (!isFalling)
@@ -267,7 +267,7 @@ namespace VRTK
             UpdateCollider();
         }
 
-        protected void OnCollisionEnter(Collision collision)
+        protected virtual void OnCollisionEnter(Collision collision)
         {
             if (!VRTK_PlayerObject.IsPlayerObject(collision.gameObject) && currentValidFloorObject && !currentValidFloorObject.Equals(collision.gameObject))
             {
@@ -276,7 +276,7 @@ namespace VRTK
             }
         }
 
-        protected void OnTriggerEnter(Collider collider)
+        protected virtual void OnTriggerEnter(Collider collider)
         {
             if (!VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && currentValidFloorObject && !currentValidFloorObject.Equals(collider.gameObject))
             {
@@ -286,7 +286,7 @@ namespace VRTK
 
         }
 
-        protected void OnCollisionExit(Collision collision)
+        protected virtual void OnCollisionExit(Collision collision)
         {
             if (currentCollidingObject && currentCollidingObject.Equals(collision.gameObject))
             {
@@ -295,12 +295,23 @@ namespace VRTK
             }
         }
 
-        protected void OnTriggerExit(Collider collider)
+        protected virtual void OnTriggerExit(Collider collider)
         {
             if (currentCollidingObject && currentCollidingObject.Equals(collider.gameObject))
             {
                 OnStopColliding(SetBodyPhysicsEvent(currentCollidingObject));
                 currentCollidingObject = null;
+            }
+        }
+
+        protected virtual void OnDrawGizmos()
+        {
+            if (drawDebugGizmo && headset)
+            {
+                Gizmos.color = Color.green;
+                Gizmos.DrawSphere(new Vector3(headset.position.x, headset.position.y - 0.3f, headset.position.z), 0.075f);
+                Gizmos.color = Color.red;
+                Gizmos.DrawSphere(new Vector3(currentStandingPosition.x, headset.position.y - 0.3f, currentStandingPosition.y), 0.05f);
             }
         }
 
@@ -849,17 +860,6 @@ namespace VRTK
             teleporter.blinkTransitionSpeed = originalblinkTransitionSpeed;
 
             resetPhysicsAfterTeleport = true;
-        }
-
-        private void OnDrawGizmos()
-        {
-            if (drawDebugGizmo && headset)
-            {
-                Gizmos.color = Color.green;
-                Gizmos.DrawSphere(new Vector3(headset.position.x, headset.position.y - 0.3f, headset.position.z), 0.075f);
-                Gizmos.color = Color.red;
-                Gizmos.DrawSphere(new Vector3(currentStandingPosition.x, headset.position.y - 0.3f, currentStandingPosition.y), 0.05f);
-            }
         }
     }
 }

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollision.cs
@@ -88,7 +88,7 @@ namespace VRTK
             return headsetColliding;
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             VRTK_ObjectCache.registeredHeadsetCollider = this;
             headset = VRTK_DeviceFinder.HeadsetTransform();
@@ -100,7 +100,7 @@ namespace VRTK
             }
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             if (headset)
             {
@@ -110,7 +110,7 @@ namespace VRTK
             }
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (headsetColliderContainer && headsetColliderContainer.transform.parent != headset)
             {
@@ -211,6 +211,29 @@ namespace VRTK
             }
         }
 
+        protected virtual void OnTriggerStay(Collider collider)
+        {
+            if (enabled && !VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && ValidTarget(collider.transform))
+            {
+                parent.headsetColliding = true;
+                parent.collidingWith = collider;
+                parent.OnHeadsetCollisionDetect(SetHeadsetCollisionEvent(collider, transform));
+            }
+        }
+
+        protected virtual void OnTriggerExit(Collider collider)
+        {
+            EndCollision(collider);
+        }
+
+        protected virtual void Update()
+        {
+            if (parent.headsetColliding && (!parent.collidingWith || !parent.collidingWith.gameObject.activeInHierarchy))
+            {
+                EndCollision(parent.collidingWith);
+            }
+        }
+
         private HeadsetCollisionEventArgs SetHeadsetCollisionEvent(Collider collider, Transform currentTransform)
         {
             HeadsetCollisionEventArgs e;
@@ -222,29 +245,6 @@ namespace VRTK
         private bool ValidTarget(Transform target)
         {
             return (target && !(VRTK_PolicyList.Check(target.gameObject, targetListPolicy)));
-        }
-
-        private void OnTriggerStay(Collider collider)
-        {
-            if (enabled && !VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && ValidTarget(collider.transform))
-            {
-                parent.headsetColliding = true;
-                parent.collidingWith = collider;
-                parent.OnHeadsetCollisionDetect(SetHeadsetCollisionEvent(collider, transform));
-            }
-        }
-
-        private void OnTriggerExit(Collider collider)
-        {
-            EndCollision(collider);
-        }
-
-        private void Update()
-        {
-            if (parent.headsetColliding && (!parent.collidingWith || !parent.collidingWith.gameObject.activeInHierarchy))
-            {
-                EndCollision(parent.collidingWith);
-            }
         }
     }
 }

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollisionFade.cs
@@ -25,13 +25,19 @@ namespace VRTK
         private VRTK_HeadsetCollision headsetCollision;
         private VRTK_HeadsetFade headsetFade;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             headsetFade = GetComponent<VRTK_HeadsetFade>();
             headsetCollision = GetComponent<VRTK_HeadsetCollision>();
 
             headsetCollision.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollisionDetect);
             headsetCollision.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
+        }
+
+        protected virtual void OnDisable()
+        {
+            headsetCollision.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollisionDetect);
+            headsetCollision.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
         }
 
         private void OnHeadsetCollisionDetect(object sender, HeadsetCollisionEventArgs e)
@@ -42,12 +48,6 @@ namespace VRTK
         private void OnHeadsetCollisionEnded(object sender, HeadsetCollisionEventArgs e)
         {
             headsetFade.Unfade(blinkTransitionSpeed);
-        }
-
-        private void OnDisable()
-        {
-            headsetCollision.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollisionDetect);
-            headsetCollision.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
@@ -140,7 +140,7 @@ namespace VRTK
             return rightControllerGlance;
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             VRTK_ObjectCache.registeredHeadsetControllerAwareness = this;
             headset = VRTK_DeviceFinder.HeadsetTransform();
@@ -148,14 +148,14 @@ namespace VRTK
             rightController = VRTK_DeviceFinder.GetControllerRightHand();
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             VRTK_ObjectCache.registeredHeadsetControllerAwareness = null;
             leftController = null;
             rightController = null;
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (trackLeftController)
             {

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetFade.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetFade.cs
@@ -132,7 +132,7 @@ namespace VRTK
             Invoke("UnfadeComplete", duration);
         }
 
-        private void Start()
+        protected virtual void Start()
         {
             headset = VRTK_DeviceFinder.HeadsetTransform();
             isTransitioning = false;

--- a/Assets/VRTK/Scripts/Presence/VRTK_HipTracking.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HipTracking.cs
@@ -23,7 +23,7 @@ namespace VRTK
 
         private Transform playerHead;
 
-        private void Awake()
+        protected virtual void Awake()
         {
             if (headOverride != null)
             {
@@ -35,7 +35,7 @@ namespace VRTK
             }
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (playerHead == null)
             {

--- a/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
@@ -33,7 +33,7 @@ namespace VRTK
         private bool isColliding = false;
         private float collideTimer = 0f;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             lastGoodPositionSet = false;
             headset = VRTK_DeviceFinder.HeadsetTransform();
@@ -46,12 +46,12 @@ namespace VRTK
             }
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             ManageHeadsetListeners(false);
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (isColliding)
             {
@@ -68,7 +68,7 @@ namespace VRTK
             }
         }
 
-        private void FixedUpdate()
+        protected virtual void FixedUpdate()
         {
             if (!isColliding && playArea)
             {

--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -26,19 +26,38 @@ namespace VRTK
         private const string CANVAS_DRAGGABLE_PANEL = "VRTK_UICANVAS_DRAGGABLE_PANEL";
         private const string ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT = "VRTK_UICANVAS_ACTIVATOR_FRONT_TRIGGER";
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             SetupCanvas();
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             RemoveCanvas();
         }
 
-        private void OnDestroy()
+        protected virtual void OnDestroy()
         {
             RemoveCanvas();
+        }
+
+        protected virtual void OnTriggerEnter(Collider collider)
+        {
+            var colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
+            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
+            if (pointerCheck && colliderCheck && colliderCheck.objectType == VRTK_PlayerObject.ObjectTypes.Collider)
+            {
+                pointerCheck.collisionClick = (clickOnPointerCollision ? true : false);
+            }
+        }
+
+        protected virtual void OnTriggerExit(Collider collider)
+        {
+            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
+            if (pointerCheck)
+            {
+                pointerCheck.collisionClick = false;
+            }
         }
 
         private void SetupCanvas()
@@ -184,30 +203,11 @@ namespace VRTK
                 Destroy(frontTrigger.gameObject);
             }
         }
-
-        private void OnTriggerEnter(Collider collider)
-        {
-            var colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
-            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
-            if (pointerCheck && colliderCheck && colliderCheck.objectType == VRTK_PlayerObject.ObjectTypes.Collider)
-            {
-                pointerCheck.collisionClick = (clickOnPointerCollision ? true : false);
-            }
-        }
-
-        private void OnTriggerExit(Collider collider)
-        {
-            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
-            if (pointerCheck)
-            {
-                pointerCheck.collisionClick = false;
-            }
-        }
     }
 
     public class VRTK_UIPointerAutoActivator : MonoBehaviour
     {
-        private void OnTriggerEnter(Collider collider)
+        protected virtual void OnTriggerEnter(Collider collider)
         {
             var colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
             var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
@@ -217,7 +217,7 @@ namespace VRTK
             }
         }
 
-        private void OnTriggerExit(Collider collider)
+        protected virtual void OnTriggerExit(Collider collider)
         {
             var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
             if (pointerCheck && pointerCheck.autoActivatingCanvas == gameObject)

--- a/Assets/VRTK/Scripts/UI/VRTK_UIDraggableItem.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIDraggableItem.cs
@@ -37,7 +37,7 @@ namespace VRTK
         private Canvas startCanvas;
         private CanvasGroup canvasGroup;
 
-        public void OnBeginDrag(PointerEventData eventData)
+        public virtual void OnBeginDrag(PointerEventData eventData)
         {
             startPosition = transform.position;
             startRotation = transform.rotation;
@@ -59,12 +59,12 @@ namespace VRTK
             }
         }
 
-        public void OnDrag(PointerEventData eventData)
+        public virtual void OnDrag(PointerEventData eventData)
         {
             SetDragPosition(eventData);
         }
 
-        public void OnEndDrag(PointerEventData eventData)
+        public virtual void OnEndDrag(PointerEventData eventData)
         {
             canvasGroup.blocksRaycasts = true;
             dragTransform = null;
@@ -107,7 +107,7 @@ namespace VRTK
             startCanvas = null;
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             canvasGroup = GetComponent<CanvasGroup>();
             if (restrictToDropZone && !GetComponentInParent<VRTK_UIDropZone>())

--- a/Assets/VRTK/Scripts/UI/VRTK_UIDropZone.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIDropZone.cs
@@ -17,7 +17,7 @@ namespace VRTK
     {
         private VRTK_UIDraggableItem droppableItem;
 
-        public void OnPointerEnter(PointerEventData eventData)
+        public virtual void OnPointerEnter(PointerEventData eventData)
         {
             if (eventData.pointerDrag)
             {
@@ -30,7 +30,7 @@ namespace VRTK
             }
         }
 
-        public void OnPointerExit(PointerEventData eventData)
+        public virtual void OnPointerExit(PointerEventData eventData)
         {
             if (droppableItem)
             {

--- a/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
@@ -201,7 +201,7 @@ namespace VRTK
             }
         }
 
-        public UIPointerEventArgs SetUIPointerEvent(GameObject currentTarget, GameObject lastTarget = null)
+        public virtual UIPointerEventArgs SetUIPointerEvent(GameObject currentTarget, GameObject lastTarget = null)
         {
             UIPointerEventArgs e;
             e.controllerIndex = VRTK_DeviceFinder.GetControllerIndex(controller.gameObject);
@@ -216,7 +216,7 @@ namespace VRTK
         /// </summary>
         /// <param name="eventSystem">The global Unity event system to be used by the UI pointers.</param>
         /// <returns>A custom event system input class that is used to detect input from VR pointers.</returns>
-        public VRTK_EventSystemVRInput SetEventSystem(EventSystem eventSystem)
+        public virtual VRTK_EventSystemVRInput SetEventSystem(EventSystem eventSystem)
         {
             if (!eventSystem)
             {
@@ -257,7 +257,7 @@ namespace VRTK
         /// <summary>
         /// The RemoveEventSystem resets the Unity EventSystem back to the original state before the VRTK_EventSystemVRInput was swapped for it.
         /// </summary>
-        public void RemoveEventSystem()
+        public virtual void RemoveEventSystem()
         {
             var eventSystem = FindObjectOfType<EventSystem>();
 
@@ -301,7 +301,7 @@ namespace VRTK
         /// The PointerActive method determines if the ui pointer beam should be active based on whether the pointer alias is being held and whether the Hold Button To Use parameter is checked.
         /// </summary>
         /// <returns>Returns true if the ui pointer should be currently active.</returns>
-        public bool PointerActive()
+        public virtual bool PointerActive()
         {
             if (activationMode == ActivationMethods.Always_On || autoActivatingCanvas != null)
             {
@@ -335,7 +335,7 @@ namespace VRTK
         /// <param name="checkLastClick">If this is true then the last frame's state of the UI Click button is also checked to see if a valid click has happened.</param>
         /// <param name="lastClickState">This determines what the last frame's state of the UI Click button should be in for it to be a valid click.</param>
         /// <returns>Returns true if the UI Click button is in a valid state to action a click, returns false if it is not in a valid state.</returns>
-        public bool ValidClick(bool checkLastClick, bool lastClickState = false)
+        public virtual bool ValidClick(bool checkLastClick, bool lastClickState = false)
         {
             var controllerClicked = (collisionClick ? collisionClick : controller.uiClickPressed);
             var result = (checkLastClick ? controllerClicked && lastPointerClickState == lastClickState : controllerClicked);
@@ -348,7 +348,7 @@ namespace VRTK
         /// The GetOriginPosition method returns the relevant transform position for the pointer based on whether the pointerOriginTransform variable is valid.
         /// </summary>
         /// <returns>A Vector3 of the pointer transform position</returns>
-        public Vector3 GetOriginPosition()
+        public virtual Vector3 GetOriginPosition()
         {
             return (pointerOriginTransform ? pointerOriginTransform.position : transform.position);
         }
@@ -357,12 +357,12 @@ namespace VRTK
         /// The GetOriginPosition method returns the relevant transform forward for the pointer based on whether the pointerOriginTransform variable is valid.
         /// </summary>
         /// <returns>A Vector3 of the pointer transform forward</returns>
-        public Vector3 GetOriginForward()
+        public virtual Vector3 GetOriginForward()
         {
             return (pointerOriginTransform ? pointerOriginTransform.forward : transform.forward);
         }
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             pointerOriginTransform = (pointerOriginTransform == null ? VRTK_SDK_Bridge.GenerateControllerPointerOrigin(gameObject) : pointerOriginTransform);
 
@@ -378,7 +378,7 @@ namespace VRTK
             controllerRenderModel = VRTK_SDK_Bridge.GetControllerRenderModel(controller.gameObject);
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             if (cachedEventSystemInput && cachedEventSystemInput.pointers.Contains(this))
             {

--- a/Assets/VRTK/Scripts/Utilities/VRTK_ObjectFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_ObjectFollow.cs
@@ -17,7 +17,7 @@ namespace VRTK
         [Tooltip("Follow the scale of the given object.")]
         public bool followScale = true;
 
-        private void Update()
+        protected virtual void Update()
         {
             if (objectToFollow != null)
             {

--- a/Assets/VRTK/Scripts/Utilities/VRTK_PolicyList.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_PolicyList.cs
@@ -59,7 +59,7 @@ namespace VRTK
         /// </remarks>
         /// <param name="obj">The game object to check if it has a tag or script that is listed in the identifiers list.</param>
         /// <returns>If the operation is `Ignore` and the game object is matched by an identifier from the list then it returns true. If the operation is `Include` and the game object is not matched by an identifier from the list then it returns true.</returns>
-        public bool Find(GameObject obj)
+        public virtual bool Find(GameObject obj)
         {
             if (operation == OperationTypes.Ignore)
             {

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -177,7 +177,7 @@ namespace VRTK
             return returnSDK;
         }
 
-        private void Awake()
+        protected virtual void Awake()
         {
             CreateInstance();
             if (!VRTK_SharedMethods.IsEditTime())

--- a/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs
@@ -41,7 +41,7 @@ namespace VRTK
         private Vector3 initialPosition;
         private Quaternion initialRotation;
 
-        private void Start()
+        protected virtual void Start()
         {
             // don't run in builds outside the editor
             if (onlyInEditor && !Application.isEditor)
@@ -69,7 +69,7 @@ namespace VRTK
             initialRotation = playArea.rotation;
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             Vector3 movDir = Vector3.zero;
             Vector3 rotDir = Vector3.zero;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,11 @@ it's not necessary.
 
   > `GameObject.FindObjectsOfType` *is simplified to* `FindObjectsOfType`
 
+All MonoBehaviour inherited classes that implement a MonoBehaviour
+[Message](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html)
+method must at least be `protected virtual` to allow any further
+inherited class to override and extend the methods.
+
 ## Documentation
 
 All scripts that require documentation need to include a comment marker

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -301,7 +301,7 @@ Adding the `VRTK_SnapDropZone_UnityEvents` component to `VRTK_SnapDropZone` obje
 
 #### InitaliseHighlightObject/1
 
-  > `public void InitaliseHighlightObject(bool removeOldObject = false)`
+  > `public virtual void InitaliseHighlightObject(bool removeOldObject = false)`
 
   * Parameters
    * `bool removeOldObject` - If this is set to true then it attempts to delete the old highlight object if it exists. Defaults to `false`
@@ -312,7 +312,7 @@ The InitaliseHighlightObject method sets up the highlight object based on the gi
 
 #### ForceSnap/1
 
-  > `public void ForceSnap(GameObject objectToSnap)`
+  > `public virtual void ForceSnap(GameObject objectToSnap)`
 
   * Parameters
    * `GameObject objectToSnap` - The GameObject to attempt to snap.
@@ -323,7 +323,7 @@ the ForceSnap method attempts to automatically attach a valid game object to the
 
 #### ForceUnsnap/0
 
-  > `public void ForceUnsnap()`
+  > `public virtual void ForceUnsnap()`
 
   * Parameters
    * _none_
@@ -858,7 +858,7 @@ Adding the `VRTK_BasicTeleport_UnityEvents` component to `VRTK_BasicTeleport` ob
 
 #### InitDestinationSetListener/2
 
-  > `public void InitDestinationSetListener(GameObject markerMaker, bool register)`
+  > `public virtual void InitDestinationSetListener(GameObject markerMaker, bool register)`
 
   * Parameters
    * `GameObject markerMaker` - The game object that is used to generate destination marker events, such as a controller.
@@ -870,7 +870,7 @@ The InitDestinationSetListener method is used to register the teleport script to
 
 #### ToggleTeleportEnabled/1
 
-  > `public void ToggleTeleportEnabled(bool state)`
+  > `public virtual void ToggleTeleportEnabled(bool state)`
 
   * Parameters
    * `bool state` - Toggles whether the teleporter is enabled or disabled.
@@ -878,6 +878,18 @@ The InitDestinationSetListener method is used to register the teleport script to
    * _none_
 
 The ToggleTeleportEnabled method is used to determine whether the teleporter will initiate a teleport on a destination set event, if the state is true then the teleporter will work as normal, if the state is false then the teleporter will not be operational.
+
+#### ValidLocation/2
+
+  > `public virtual bool ValidLocation(Transform target, Vector3 destinationPosition)`
+
+  * Parameters
+   * `Transform target` - The Transform that the destination marker is touching.
+   * `Vector3 destinationPosition` - The position in world space that is the destination.
+  * Returns
+   * `bool` - Returns true if the target is a valid location.
+
+The ValidLocation method determines if the given target is a location that can be teleported to
 
 ### Example
 
@@ -1555,7 +1567,7 @@ The IsControllerVisible method returns true if the controller is currently visib
 
 #### ToggleControllerModel/2
 
-  > `public void ToggleControllerModel(bool state, GameObject grabbedChildObject)`
+  > `public virtual void ToggleControllerModel(bool state, GameObject grabbedChildObject)`
 
   * Parameters
    * `bool state` - The visibility state to toggle the controller to, `true` will make the controller visible - `false` will hide the controller model.
@@ -1567,7 +1579,7 @@ The ToggleControllerModel method is used to turn on or off the controller model 
 
 #### SetControllerOpacity/1
 
-  > `public void SetControllerOpacity(float alpha)`
+  > `public virtual void SetControllerOpacity(float alpha)`
 
   * Parameters
    * `float alpha` - The alpha level to apply to opacity of the controller object. `0f` to `1f`.
@@ -1578,7 +1590,7 @@ The SetControllerOpacity method allows the opacity of the controller model to be
 
 #### HighlightControllerElement/3
 
-  > `public void HighlightControllerElement(GameObject element, Color? highlight, float fadeDuration = 0f)`
+  > `public virtual void HighlightControllerElement(GameObject element, Color? highlight, float fadeDuration = 0f)`
 
   * Parameters
    * `GameObject element` - The element of the controller to apply the highlight to.
@@ -1591,7 +1603,7 @@ The HighlightControllerElement method allows for an element of the controller to
 
 #### UnhighlightControllerElement/1
 
-  > `public void UnhighlightControllerElement(GameObject element)`
+  > `public virtual void UnhighlightControllerElement(GameObject element)`
 
   * Parameters
    * `GameObject element` - The element of the controller to remove the highlight from.
@@ -1602,7 +1614,7 @@ The UnhighlightControllerElement method is the inverse of the HighlightControlle
 
 #### ToggleHighlightControllerElement/4
 
-  > `public void ToggleHighlightControllerElement(bool state, GameObject element, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightControllerElement(bool state, GameObject element, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the given element and `false` will remove the highlight from the given element.
@@ -1616,7 +1628,7 @@ The ToggleHighlightControllerElement method is a shortcut method that makes it e
 
 #### ToggleHighlightTrigger/3
 
-  > `public void ToggleHighlightTrigger(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightTrigger(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the trigger and `false` will remove the highlight from the trigger.
@@ -1629,7 +1641,7 @@ The ToggleHighlightTrigger method is a shortcut method that makes it easier to t
 
 #### ToggleHighlightGrip/3
 
-  > `public void ToggleHighlightGrip(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightGrip(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the grip and `false` will remove the highlight from the grip.
@@ -1642,7 +1654,7 @@ The ToggleHighlightGrip method is a shortcut method that makes it easier to togg
 
 #### ToggleHighlightTouchpad/3
 
-  > `public void ToggleHighlightTouchpad(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightTouchpad(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the touchpad and `false` will remove the highlight from the touchpad.
@@ -1655,7 +1667,7 @@ The ToggleHighlightTouchpad method is a shortcut method that makes it easier to 
 
 #### ToggleHighlightButtonOne/3
 
-  > `public void ToggleHighlightButtonOne(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightButtonOne(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on button one and `false` will remove the highlight from button one.
@@ -1668,7 +1680,7 @@ The ToggleHighlightButtonOne method is a shortcut method that makes it easier to
 
 #### ToggleHighlightButtonTwo/3
 
-  > `public void ToggleHighlightButtonTwo(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightButtonTwo(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on button two and `false` will remove the highlight from button two.
@@ -1681,7 +1693,7 @@ The ToggleHighlightButtonTwo method is a shortcut method that makes it easier to
 
 #### ToggleHighlightStartMenu/3
 
-  > `public void ToggleHighlightStartMenu(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightStartMenu(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the start menu and `false` will remove the highlight from the start menu.
@@ -1694,7 +1706,7 @@ The ToggleHighlightStartMenu method is a shortcut method that makes it easier to
 
 #### ToggleHighlighBody/3
 
-  > `public void ToggleHighlighBody(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlighBody(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the body and `false` will remove the highlight from the body.
@@ -1707,7 +1719,7 @@ The ToggleHighlighBody method is a shortcut method that makes it easier to toggl
 
 #### ToggleHighlightController/3
 
-  > `public void ToggleHighlightController(bool state, Color? highlight = null, float duration = 0f)`
+  > `public virtual void ToggleHighlightController(bool state, Color? highlight = null, float duration = 0f)`
 
   * Parameters
    * `bool state` - The highlight colour state, `true` will enable the highlight on the entire controller `false` will remove the highlight from the entire controller.
@@ -1720,7 +1732,7 @@ The ToggleHighlightController method is a shortcut method that makes it easier t
 
 #### TriggerHapticPulse/1
 
-  > `public void TriggerHapticPulse(float strength)`
+  > `public virtual void TriggerHapticPulse(float strength)`
 
   * Parameters
    * `float strength` - The intensity of the rumble of the controller motor. `0` to `1`.
@@ -1731,7 +1743,7 @@ The TriggerHapticPulse/1 method calls a single haptic pulse call on the controll
 
 #### TriggerHapticPulse/3
 
-  > `public void TriggerHapticPulse(float strength, float duration, float pulseInterval)`
+  > `public virtual void TriggerHapticPulse(float strength, float duration, float pulseInterval)`
 
   * Parameters
    * `float strength` - The intensity of the rumble of the controller motor. `0` to `1`.
@@ -1744,7 +1756,7 @@ The TriggerHapticPulse/3 method calls a haptic pulse for a specified amount of t
 
 #### InitaliseHighlighters/0
 
-  > `public void InitaliseHighlighters()`
+  > `public virtual void InitaliseHighlighters()`
 
   * Parameters
    * _none_
@@ -1953,7 +1965,7 @@ The ResetHighlighter method is used to reset the currently attached highlighter.
 
 #### PauseCollisions/1
 
-  > `public void PauseCollisions(float delay)`
+  > `public virtual void PauseCollisions(float delay)`
 
   * Parameters
    * `float delay` - The amount of time to pause the collisions for.
@@ -1964,7 +1976,7 @@ The PauseCollisions method temporarily pauses all collisions on the object at gr
 
 #### ZeroVelocity/0
 
-  > `public void ZeroVelocity()`
+  > `public virtual void ZeroVelocity()`
 
   * Parameters
    * _none_
@@ -1975,7 +1987,7 @@ The ZeroVelocity method resets the velocity and angular velocity to zero on the 
 
 #### SaveCurrentState/0
 
-  > `public void SaveCurrentState()`
+  > `public virtual void SaveCurrentState()`
 
   * Parameters
    * _none_
@@ -2030,7 +2042,7 @@ The GetUsingObject method is used to return the game object that is currently us
 
 #### IsValidInteractableController/2
 
-  > `public bool IsValidInteractableController(GameObject actualController, AllowedController controllerCheck)`
+  > `public virtual bool IsValidInteractableController(GameObject actualController, AllowedController controllerCheck)`
 
   * Parameters
    * `GameObject actualController` - The game object of the controller that is being checked.
@@ -2042,7 +2054,7 @@ The IsValidInteractableController method is used to check to see if a controller
 
 #### ForceStopInteracting/0
 
-  > `public void ForceStopInteracting()`
+  > `public virtual void ForceStopInteracting()`
 
   * Parameters
    * _none_
@@ -2053,7 +2065,7 @@ The ForceStopInteracting method forces the object to no longer be interacted wit
 
 #### ForceStopSecondaryGrabInteraction/0
 
-  > `public void ForceStopSecondaryGrabInteraction()`
+  > `public virtual void ForceStopSecondaryGrabInteraction()`
 
   * Parameters
    * _none_
@@ -2086,7 +2098,7 @@ The UnregisterTeleporters method is used to unregister all teleporter events tha
 
 #### StoreLocalScale/0
 
-  > `public void StoreLocalScale()`
+  > `public virtual void StoreLocalScale()`
 
   * Parameters
    * _none_
@@ -2097,7 +2109,7 @@ the StoreLocalScale method saves the current transform local scale values.
 
 #### ToggleSnapDropZone/2
 
-  > `public void ToggleSnapDropZone(VRTK_SnapDropZone snapDropZone, bool state)`
+  > `public virtual void ToggleSnapDropZone(VRTK_SnapDropZone snapDropZone, bool state)`
 
   * Parameters
    * `VRTK_SnapDropZone snapDropZone` - The Snap Drop Zone object that is being interacted with.
@@ -2492,7 +2504,7 @@ The Interact Haptics script is attached on the same GameObject as an Interactabl
 
 #### HapticsOnTouch/1
 
-  > `public void HapticsOnTouch(VRTK_ControllerActions controllerActions)`
+  > `public virtual void HapticsOnTouch(VRTK_ControllerActions controllerActions)`
 
   * Parameters
    * `VRTK_ControllerActions controllerActions` - The controller to activate the haptic feedback on.
@@ -2503,7 +2515,7 @@ The HapticsOnTouch method triggers the haptic feedback on the given controller f
 
 #### HapticsOnGrab/1
 
-  > `public void HapticsOnGrab(VRTK_ControllerActions controllerActions)`
+  > `public virtual void HapticsOnGrab(VRTK_ControllerActions controllerActions)`
 
   * Parameters
    * `VRTK_ControllerActions controllerActions` - The controller to activate the haptic feedback on.
@@ -2514,7 +2526,7 @@ The HapticsOnGrab method triggers the haptic feedback on the given controller fo
 
 #### HapticsOnUse/1
 
-  > `public void HapticsOnUse(VRTK_ControllerActions controllerActions)`
+  > `public virtual void HapticsOnUse(VRTK_ControllerActions controllerActions)`
 
   * Parameters
    * `VRTK_ControllerActions controllerActions` - The controller to activate the haptic feedback on.
@@ -2544,7 +2556,7 @@ The Interact Controller Appearance script is attached on the same GameObject as 
 
 #### ToggleControllerOnTouch/3
 
-  > `public void ToggleControllerOnTouch(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)`
+  > `public virtual void ToggleControllerOnTouch(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)`
 
   * Parameters
    * `bool showController` - If true then the controller will attempt to be made visible when no longer touching, if false then the controller will be hidden on touch.
@@ -2557,7 +2569,7 @@ The ToggleControllerOnTouch method determines whether the controller should be s
 
 #### ToggleControllerOnGrab/3
 
-  > `public void ToggleControllerOnGrab(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)`
+  > `public virtual void ToggleControllerOnGrab(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)`
 
   * Parameters
    * `bool showController` - If true then the controller will attempt to be made visible when no longer grabbing, if false then the controller will be hidden on grab.
@@ -2570,7 +2582,7 @@ The ToggleControllerOnGrab method determines whether the controller should be sh
 
 #### ToggleControllerOnUse/3
 
-  > `public void ToggleControllerOnUse(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)`
+  > `public virtual void ToggleControllerOnUse(bool showController, VRTK_ControllerActions controllerActions, GameObject obj)`
 
   * Parameters
    * `bool showController` - If true then the controller will attempt to be made visible when no longer using, if false then the controller will be hidden on use.
@@ -4146,7 +4158,7 @@ Adding the `VRTK_UIPointer_UnityEvents` component to `VRTK_UIPointer` object all
 
 #### SetEventSystem/1
 
-  > `public VRTK_EventSystemVRInput SetEventSystem(EventSystem eventSystem)`
+  > `public virtual VRTK_EventSystemVRInput SetEventSystem(EventSystem eventSystem)`
 
   * Parameters
    * `EventSystem eventSystem` - The global Unity event system to be used by the UI pointers.
@@ -4157,7 +4169,7 @@ The SetEventSystem method is used to set up the global Unity event system for th
 
 #### RemoveEventSystem/0
 
-  > `public void RemoveEventSystem()`
+  > `public virtual void RemoveEventSystem()`
 
   * Parameters
    * _none_
@@ -4168,7 +4180,7 @@ The RemoveEventSystem resets the Unity EventSystem back to the original state be
 
 #### PointerActive/0
 
-  > `public bool PointerActive()`
+  > `public virtual bool PointerActive()`
 
   * Parameters
    * _none_
@@ -4179,7 +4191,7 @@ The PointerActive method determines if the ui pointer beam should be active base
 
 #### ValidClick/2
 
-  > `public bool ValidClick(bool checkLastClick, bool lastClickState = false)`
+  > `public virtual bool ValidClick(bool checkLastClick, bool lastClickState = false)`
 
   * Parameters
    * `bool checkLastClick` - If this is true then the last frame's state of the UI Click button is also checked to see if a valid click has happened.
@@ -4191,7 +4203,7 @@ The ValidClick method determines if the UI Click button is in a valid state to r
 
 #### GetOriginPosition/0
 
-  > `public Vector3 GetOriginPosition()`
+  > `public virtual Vector3 GetOriginPosition()`
 
   * Parameters
    * _none_
@@ -4202,7 +4214,7 @@ The GetOriginPosition method returns the relevant transform position for the poi
 
 #### GetOriginForward/0
 
-  > `public Vector3 GetOriginForward()`
+  > `public virtual Vector3 GetOriginForward()`
 
   * Parameters
    * _none_
@@ -5046,7 +5058,7 @@ Then in the component that has a Policy List paramter (e.g. BasicTeleporter has 
 
 #### Find/1
 
-  > `public bool Find(GameObject obj)`
+  > `public virtual bool Find(GameObject obj)`
 
   * Parameters
    * `GameObject obj` - The game object to check if it has a tag or script that is listed in the identifiers list.


### PR DESCRIPTION
All of the VRTK scripts that utilise MonoBehaviour magic methods
e.g. Awake, Update, OnCollisionEnter have all been changed to at least
protected virtual so any VRTK script can be inherited and any of the
magic methods can be overriden.