### PR TITLE
feat(Interaction): allow custom idle checks on Interactable Objects

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -642,7 +642,7 @@ namespace VRTK
                 interactableRigidbody.maxAngularVelocity = float.MaxValue;
             }
 
-            if (disableWhenIdle && enabled)
+            if (disableWhenIdle && enabled && IsIdle())
             {
                 enabled = false;
             }
@@ -703,9 +703,20 @@ namespace VRTK
             }
         }
 
+        /// <summary>
+        /// determines if this object is currently idle
+        /// used to determine whether or not the script
+        /// can be disabled for now
+        /// </summary>
+        /// <returns>whether or not the script is currently idle</returns>
+        protected virtual bool IsIdle()
+        {
+            return !IsTouched() && !IsGrabbed() && !IsUsing();
+        }
+
         protected virtual void LateUpdate()
         {
-            if (disableWhenIdle && !IsTouched() && !IsGrabbed() && !IsUsing())
+            if (disableWhenIdle && IsIdle())
             {
                 ToggleEnableState(false);
             }


### PR DESCRIPTION
- up to now, a VRTK_InteractableObject is disabled when it's neither
  used nor touched nor grabbed
- however, there may be interactable objects which require more
  complex conditions, e.g. a throwable interactable object which
  needs to stay enabled until it is no longer moving
- this commit introduces an overridable `IsIdle()` function which
  can be overriden by derived interactable objects