### PR TITLE
feat(SDK): allow for dynamic SDK discovery

### DIFF
--- a/Assets/VRTK/Editor/VRTK_EditorUtilities.cs
+++ b/Assets/VRTK/Editor/VRTK_EditorUtilities.cs
@@ -22,9 +22,13 @@
             AddHeader(headerAttribute == null ? displayName : headerAttribute.header);
         }
 
-        public static void AddHeader(string header)
+        public static void AddHeader(string header, bool spaceBeforeHeader = true)
         {
-            EditorGUILayout.Space();
+            if (spaceBeforeHeader)
+            {
+                EditorGUILayout.Space();
+            }
+
             EditorGUILayout.LabelField(header, EditorStyles.boldLabel);
         }
     }

--- a/Assets/VRTK/Editor/VRTK_SDKManagerEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_SDKManagerEditor.cs
@@ -1,50 +1,129 @@
 ﻿namespace VRTK
 {
-    using UnityEngine;
     using UnityEditor;
-    using System.Collections.Generic;
+    using UnityEngine;
     using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Reflection;
 
     [CustomEditor(typeof(VRTK_SDKManager))]
     public class VRTK_SDKManagerEditor : Editor
     {
-        private SDK_BaseHeadset previousHeadsetSDK;
-        private SDK_BaseController previousControllerSDK;
-        private SDK_BaseBoundaries previousBoundariesSDK;
-        private VRTK_SDKManager.SupportedSDKs quicklySelectedSDK = VRTK_SDKManager.SupportedSDKs.None;
+        private const string SDKNotInstalledDescription = " (not installed)";
+        private const string SDKNotFoundAnymoreDescription = " (not found)";
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
-            //Get actual inspector
-            VRTK_SDKManager sdkManager = (VRTK_SDKManager)target;
-
-            EditorGUILayout.BeginVertical("Box");
+            var sdkManager = (VRTK_SDKManager)target;
 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("persistOnLoad"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("autoManageScriptDefines"));
 
-            sdkManager.systemSDK = (VRTK_SDKManager.SupportedSDKs)EditorGUILayout.EnumPopup(VRTK_EditorUtilities.BuildGUIContent<VRTK_SDKManager>("systemSDK"), sdkManager.systemSDK);
-            sdkManager.boundariesSDK = (VRTK_SDKManager.SupportedSDKs)EditorGUILayout.EnumPopup(VRTK_EditorUtilities.BuildGUIContent<VRTK_SDKManager>("boundariesSDK"), sdkManager.boundariesSDK);
-            sdkManager.headsetSDK = (VRTK_SDKManager.SupportedSDKs)EditorGUILayout.EnumPopup(VRTK_EditorUtilities.BuildGUIContent<VRTK_SDKManager>("headsetSDK"), sdkManager.headsetSDK);
-            sdkManager.controllerSDK = (VRTK_SDKManager.SupportedSDKs)EditorGUILayout.EnumPopup(VRTK_EditorUtilities.BuildGUIContent<VRTK_SDKManager>("controllerSDK"), sdkManager.controllerSDK);
+            EditorGUILayout.BeginHorizontal();
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("autoPopulateObjectReferences"), GUILayout.ExpandWidth(false));
+            if (EditorGUI.EndChangeCheck())
+            {
+                serializedObject.ApplyModifiedProperties();
+                sdkManager.PopulateObjectReferences(false);
+            }
+
+            EditorGUI.BeginDisabledGroup(sdkManager.autoPopulateObjectReferences);
+            const string populateNowDescription = "Populate Now";
+            var populateNowGUIContent = new GUIContent(populateNowDescription, "Set the SDK object references to the objects of the selected SDKs.");
+            if (GUILayout.Button(populateNowGUIContent, GUILayout.MaxHeight(GUI.skin.label.CalcSize(populateNowGUIContent).y)))
+            {
+                Undo.RecordObject(sdkManager, populateNowDescription);
+                sdkManager.PopulateObjectReferences(true);
+            }
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("autoManageScriptDefines"), GUILayout.ExpandWidth(false));
+            if (EditorGUI.EndChangeCheck())
+            {
+                serializedObject.ApplyModifiedProperties();
+                sdkManager.ManageScriptingDefineSymbols(false, false);
+            }
+
+            EditorGUI.BeginDisabledGroup(sdkManager.autoManageScriptDefines);
+            const string manageNowDescription = "Manage Now";
+            var manageNowGUIContent = new GUIContent(manageNowDescription, "Manage the scripting define symbols defined by the selected SDKs.");
+            if (GUILayout.Button(manageNowGUIContent, GUILayout.MaxHeight(GUI.skin.label.CalcSize(manageNowGUIContent).y)))
+            {
+                Undo.RecordObject(sdkManager, manageNowDescription);
+                sdkManager.ManageScriptingDefineSymbols(true, true);
+            }
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginVertical("Box");
+            VRTK_EditorUtilities.AddHeader("SDK Selection", false);
+
+            HandleSDKSelection<SDK_BaseSystem>("The SDK to use to deal with all system actions.");
+            HandleSDKSelection<SDK_BaseBoundaries>("The SDK to use to utilize room scale boundaries.");
+            HandleSDKSelection<SDK_BaseHeadset>("The SDK to use to utilize the VR headset.");
+            HandleSDKSelection<SDK_BaseController>("The SDK to use to utilize the input devices.");
+
+            string sdkErrorDescriptions = string.Join("\n", sdkManager.GetSimplifiedSDKErrorDescriptions());
+            if (!string.IsNullOrEmpty(sdkErrorDescriptions))
+            {
+                EditorGUILayout.HelpBox(sdkErrorDescriptions, MessageType.Error);
+            }
 
             EditorGUILayout.Space();
 
-            quicklySelectedSDK = (VRTK_SDKManager.SupportedSDKs)EditorGUILayout.EnumPopup(new GUIContent("Quick select SDK", "Quickly select one of the SDKs into all slots."), quicklySelectedSDK);
-            if (quicklySelectedSDK != VRTK_SDKManager.SupportedSDKs.None)
+            string[] availableSystemSDKNames = VRTK_SDKManager.AvailableSystemSDKInfos.Select(info => info.description.prettyName + (VRTK_SDKManager.InstalledSystemSDKInfos.Contains(info) ? "" : SDKNotInstalledDescription)).ToArray();
+            string[] availableBoundariesSDKNames = VRTK_SDKManager.AvailableBoundariesSDKInfos.Select(info => info.description.prettyName + (VRTK_SDKManager.InstalledBoundariesSDKInfos.Contains(info) ? "" : SDKNotInstalledDescription)).ToArray();
+            string[] availableHeadsetSDKNames = VRTK_SDKManager.AvailableHeadsetSDKInfos.Select(info => info.description.prettyName + (VRTK_SDKManager.InstalledHeadsetSDKInfos.Contains(info) ? "" : SDKNotInstalledDescription)).ToArray();
+            string[] availableControllerSDKNames = VRTK_SDKManager.AvailableControllerSDKInfos.Select(info => info.description.prettyName + (VRTK_SDKManager.InstalledControllerSDKInfos.Contains(info) ? "" : SDKNotInstalledDescription)).ToArray();
+
+            Func<string, GUIContent> guiContentCreator = sdkName => new GUIContent(sdkName);
+            GUIContent[] availableSDKGUIContents = availableSystemSDKNames
+                .Intersect(availableBoundariesSDKNames)
+                .Intersect(availableHeadsetSDKNames)
+                .Intersect(availableControllerSDKNames)
+                .Select(guiContentCreator)
+                .ToArray();
+
+            EditorGUI.BeginChangeCheck();
+            int quicklySelectedSDKIndex = EditorGUILayout.Popup(new GUIContent("Quick select SDK", "Quickly select one of the SDKs into all slots."), 0, availableSDKGUIContents);
+            if (EditorGUI.EndChangeCheck())
             {
-                QuickSelectSDK(quicklySelectedSDK);
-                quicklySelectedSDK = VRTK_SDKManager.SupportedSDKs.None;
+                string quicklySelectedSDKName = availableSDKGUIContents[quicklySelectedSDKIndex].text.Replace(SDKNotInstalledDescription, "");
+
+                Undo.RecordObject(sdkManager, "SDK Change (Quick Select)");
+                sdkManager.systemSDKInfo = VRTK_SDKManager.AvailableSystemSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
+                sdkManager.boundariesSDKInfo = VRTK_SDKManager.AvailableBoundariesSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
+                sdkManager.headsetSDKInfo = VRTK_SDKManager.AvailableHeadsetSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
+                sdkManager.controllerSDKInfo = VRTK_SDKManager.AvailableControllerSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
             }
 
-            CheckSDKUsage(sdkManager);
+            GUIContent[] availableSystemSDKGUIContents = availableSystemSDKNames.Select(guiContentCreator).ToArray();
+            GUIContent[] availableBoundariesSDKGUIContents = availableBoundariesSDKNames.Select(guiContentCreator).ToArray();
+            GUIContent[] availableHeadsetSDKGUIContents = availableHeadsetSDKNames.Select(guiContentCreator).ToArray();
+            GUIContent[] availableControllerSDKGUIContents = availableControllerSDKNames.Select(guiContentCreator).ToArray();
+            if (availableSDKGUIContents.Length != availableSystemSDKGUIContents.Length
+                || availableSDKGUIContents.Length != availableBoundariesSDKGUIContents.Length
+                || availableSDKGUIContents.Length != availableHeadsetSDKGUIContents.Length
+                || availableSDKGUIContents.Length != availableControllerSDKGUIContents.Length)
+            {
+                EditorGUILayout.HelpBox("Some of the available SDK implementations are only available for a subset of SDK endpoints. Quick Select only shows SDKs that provide an implementation for *all* the different SDK endpoints in VRTK (System, Boundaries, Headset, Controller).", MessageType.Info);
+            }
 
             EditorGUILayout.EndVertical();
 
             EditorGUILayout.BeginVertical("Box");
+            VRTK_EditorUtilities.AddHeader("Linked Objects", false);
 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("actualBoundaries"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("actualHeadset"));
@@ -57,220 +136,73 @@
 
             EditorGUILayout.EndVertical();
 
-            EditorGUILayout.BeginVertical("Box");
-            EditorGUILayout.Space();
-            if (GUILayout.Button("Auto Populate Linked Objects"))
-            {
-                AutoPopulate(sdkManager);
-            }
-            EditorGUILayout.Space();
-            EditorGUILayout.EndVertical();
-
             serializedObject.ApplyModifiedProperties();
         }
 
-        private void QuickSelectSDK(VRTK_SDKManager.SupportedSDKs sdk)
-        {
-            VRTK_SDKManager sdkManager = (VRTK_SDKManager)target;
+        #region Handle undo
 
-            sdkManager.systemSDK = sdk;
-            sdkManager.boundariesSDK = sdk;
-            sdkManager.headsetSDK = sdk;
-            sdkManager.controllerSDK = sdk;
+        protected virtual void OnEnable()
+        {
+            Undo.undoRedoPerformed += UndoRedoPerformed;
         }
 
-        private SDK_BaseHeadset GetHeadsetSDK(VRTK_SDKManager sdkManager)
+        protected virtual void OnDisable()
         {
-            return sdkManager.GetHeadsetSDK();
+            Undo.undoRedoPerformed -= UndoRedoPerformed;
         }
 
-        private SDK_BaseController GetControllerSDK(VRTK_SDKManager sdkManager)
+        private void UndoRedoPerformed()
         {
-            return sdkManager.GetControllerSDK();
+            //make sure to manage scripting define symbols in case an SDK change was undone
+            ((VRTK_SDKManager)target).ManageScriptingDefineSymbols(false, false);
         }
 
-        private SDK_BaseBoundaries GetBoundariesSDK(VRTK_SDKManager sdkManager)
+        #endregion
+
+        /// <summary>
+        /// Draws a popup menu and handles the selection for an SDK info.
+        /// </summary>
+        /// <typeparam name="BaseType">The SDK base type. Must be a subclass of <see cref="SDK_Base"/>.</typeparam>
+        /// <param name="description">The description of the SDK base.</param>
+        private void HandleSDKSelection<BaseType>(string description) where BaseType : SDK_Base
         {
-            return sdkManager.GetBoundariesSDK();
-        }
+            Type baseType = typeof(BaseType);
+            Type sdkManagerType = typeof(VRTK_SDKManager);
+            string baseName = baseType.Name.Remove(0, typeof(SDK_Base).Name.Length);
 
-        private void AutoPopulate(VRTK_SDKManager sdkManager)
-        {
-            var boundariesSDK = GetBoundariesSDK(sdkManager);
-            var headsetSDK = GetHeadsetSDK(sdkManager);
-            var controllerSDK = GetControllerSDK(sdkManager);
+            var availableSDKInfos = (ReadOnlyCollection<VRTK_SDKInfo>)sdkManagerType
+                .GetProperty(string.Format("Available{0}SDKInfos", baseName), BindingFlags.Public | BindingFlags.Static)
+                .GetGetMethod()
+                .Invoke(null, null);
+            var installedSDKInfos = (ReadOnlyCollection<VRTK_SDKInfo>)sdkManagerType
+                .GetProperty(string.Format("Installed{0}SDKInfos", baseName), BindingFlags.Public | BindingFlags.Static)
+                .GetGetMethod()
+                .Invoke(null, null);
 
-            var forceSaveScene = false;
+            PropertyInfo sdkInfoPropertyInfo = sdkManagerType.GetProperty(string.Format("{0}SDKInfo", baseName.ToLowerInvariant()));
+            var sdkManager = (VRTK_SDKManager)target;
+            var selectedSDKInfo = (VRTK_SDKInfo)sdkInfoPropertyInfo.GetGetMethod().Invoke(sdkManager, null);
 
-            if (boundariesSDK && (!sdkManager.actualBoundaries || !previousBoundariesSDK || boundariesSDK.GetType() != previousBoundariesSDK.GetType()))
+            List<string> availableSDKNames = availableSDKInfos.Select(info => info.description.prettyName + (installedSDKInfos.Contains(info) ? "" : SDKNotInstalledDescription)).ToList();
+            int selectedSDKIndex = availableSDKInfos.IndexOf(selectedSDKInfo);
+            if (selectedSDKInfo.originalTypeNameWhenFallbackIsUsed != null)
             {
-                var playareaTransform = boundariesSDK.GetPlayArea();
-                sdkManager.actualBoundaries = (playareaTransform ? playareaTransform.gameObject : null);
-                previousBoundariesSDK = boundariesSDK;
-                forceSaveScene = true;
+                availableSDKNames.Add(selectedSDKInfo.originalTypeNameWhenFallbackIsUsed + SDKNotFoundAnymoreDescription);
+                selectedSDKIndex = availableSDKNames.Count - 1;
             }
 
-            if (headsetSDK && (!sdkManager.actualHeadset || !previousHeadsetSDK || headsetSDK.GetType() != previousHeadsetSDK.GetType()))
+            GUIContent[] availableSDKGUIContents = availableSDKNames.Select(availableSDKName => new GUIContent(availableSDKName)).ToArray();
+
+            EditorGUI.BeginChangeCheck();
+            int newSelectedSDKIndex = EditorGUILayout.Popup(new GUIContent(string.Format("{0} SDK", baseName), description), selectedSDKIndex, availableSDKGUIContents);
+            VRTK_SDKInfo newSelectedSDKInfo = selectedSDKInfo.originalTypeNameWhenFallbackIsUsed != null && newSelectedSDKIndex == availableSDKNames.Count - 1
+                ? selectedSDKInfo
+                : availableSDKInfos[newSelectedSDKIndex];
+            if (EditorGUI.EndChangeCheck() && newSelectedSDKInfo != selectedSDKInfo)
             {
-                var headsetTransform = headsetSDK.GetHeadset();
-                sdkManager.actualHeadset = (headsetTransform ? headsetTransform.gameObject : null);
-                previousHeadsetSDK = headsetSDK;
-                forceSaveScene = true;
+                Undo.RecordObject(sdkManager, string.Format("{0} SDK Change", baseName));
+                sdkInfoPropertyInfo.GetSetMethod().Invoke(sdkManager, new object[] { newSelectedSDKInfo });
             }
-
-            var setPreviousControllerSDK = false;
-
-            if (controllerSDK && (!sdkManager.actualLeftController || !previousControllerSDK || controllerSDK.GetType() != previousControllerSDK.GetType()))
-            {
-                var controllerLeft = controllerSDK.GetControllerLeftHand(true);
-                sdkManager.actualLeftController = (controllerLeft ? controllerLeft : null);
-                setPreviousControllerSDK = true;
-            }
-
-            if (controllerSDK && (!sdkManager.actualRightController || !previousControllerSDK || controllerSDK.GetType() != previousControllerSDK.GetType()))
-            {
-                var controllerRight = controllerSDK.GetControllerRightHand(true);
-                sdkManager.actualRightController = (controllerRight ? controllerRight : null);
-                setPreviousControllerSDK = true;
-            }
-
-            if (controllerSDK && (!sdkManager.modelAliasLeftController || !previousControllerSDK || controllerSDK.GetType() != previousControllerSDK.GetType()))
-            {
-                var controllerLeft = controllerSDK.GetControllerModel(SDK_BaseController.ControllerHand.Left);
-                sdkManager.modelAliasLeftController = (controllerLeft ? controllerLeft : null);
-                setPreviousControllerSDK = true;
-            }
-
-            if (controllerSDK && (!sdkManager.modelAliasRightController || !previousControllerSDK || controllerSDK.GetType() != previousControllerSDK.GetType()))
-            {
-                var controllerRight = controllerSDK.GetControllerModel(SDK_BaseController.ControllerHand.Right);
-                sdkManager.modelAliasRightController = (controllerRight ? controllerRight : null);
-                setPreviousControllerSDK = true;
-            }
-
-            if (setPreviousControllerSDK)
-            {
-                previousControllerSDK = controllerSDK;
-                forceSaveScene = true;
-            }
-
-            if (forceSaveScene)
-            {
-                UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(UnityEngine.SceneManagement.SceneManager.GetActiveScene());
-            }
-        }
-
-        private void CheckSDKUsage(VRTK_SDKManager sdkManager)
-        {
-            ProcessSDK(sdkManager, VRTK_SDKManager.SupportedSDKs.SteamVR);
-            ProcessSDK(sdkManager, VRTK_SDKManager.SupportedSDKs.OculusVR);
-            ProcessSDK(sdkManager, VRTK_SDKManager.SupportedSDKs.Simulator);
-        }
-
-        private void ProcessSDK(VRTK_SDKManager sdkManager, VRTK_SDKManager.SupportedSDKs supportedSDK)
-        {
-            var system = sdkManager.systemSDK;
-            var headset = sdkManager.headsetSDK;
-            var controller = sdkManager.controllerSDK;
-            var boundaries = sdkManager.boundariesSDK;
-            var sdkDetails = sdkManager.sdkDetails[supportedSDK];
-
-            var defineSymbol = sdkDetails.defineSymbol;
-            var prettyName = sdkDetails.prettyName;
-            var checkType = sdkDetails.checkType;
-
-            var message = "SDK has been selected but is not currently installed.";
-
-            if ((!CheckSDKInstalled(prettyName + message, checkType, false) || (system != supportedSDK && headset != supportedSDK && controller != supportedSDK && boundaries != supportedSDK)) && sdkManager.autoManageScriptDefines)
-            {
-                RemoveScriptingDefineSymbol(defineSymbol);
-            }
-
-            if (system == supportedSDK || headset == supportedSDK || controller == supportedSDK || boundaries == supportedSDK)
-            {
-                if (CheckSDKInstalled(prettyName + message, checkType, true) && sdkManager.autoManageScriptDefines)
-                {
-                    AddScriptingDefineSymbol(defineSymbol);
-                }
-            }
-
-            if (sdkManager.autoManageScriptDefines)
-            {
-                CheckAvatarSupport(supportedSDK);
-            }
-        }
-
-        private void CheckAvatarSupport(VRTK_SDKManager.SupportedSDKs sdk)
-        {
-            switch (sdk)
-            {
-                case VRTK_SDKManager.SupportedSDKs.OculusVR:
-                    var defineSymbol = "VRTK_SDK_OCULUSVR_AVATAR";
-                    if (TypeExists("OvrAvatar"))
-                    {
-                        AddScriptingDefineSymbol(defineSymbol);
-                    }
-                    else
-                    {
-                        RemoveScriptingDefineSymbol(defineSymbol);
-                    }
-                    break;
-            }
-        }
-
-        private bool CheckSDKInstalled(string message, string checkType, bool showMessage)
-        {
-            if (!TypeExists(checkType))
-            {
-                if (showMessage)
-                {
-                    EditorGUILayout.HelpBox(message, MessageType.Warning);
-                }
-                return false;
-            }
-            return true;
-        }
-
-        private void AddScriptingDefineSymbol(string define)
-        {
-            if (define == "")
-            {
-                return;
-            }
-            string scriptingDefineSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone);
-            List<string> definesList = new List<string>(scriptingDefineSymbols.Split(';'));
-            if (!definesList.Contains(define))
-            {
-                definesList.Add(define);
-                Debug.Log("Scripting Define Symbol Added To [Project Settings->Player]: " + define);
-            }
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, string.Join(";", definesList.ToArray()));
-        }
-
-        private void RemoveScriptingDefineSymbol(string define)
-        {
-            if (define == "")
-            {
-                return;
-            }
-            string scriptingDefineSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone);
-            List<string> definesList = new List<string>(scriptingDefineSymbols.Split(';'));
-            if (definesList.Contains(define))
-            {
-                definesList.Remove(define);
-                Debug.Log("Scripting Define Symbol Removed from [Project Settings->Player]: " + define);
-            }
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, string.Join(";", definesList.ToArray()));
-        }
-
-        private bool TypeExists(string className)
-        {
-            var foundType = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                             from type in assembly.GetTypes()
-                             where type.Name == className
-                             select type).FirstOrDefault();
-
-            return foundType != null;
         }
     }
 }

--- a/Assets/VRTK/SDK/Base/SDK_Base.cs
+++ b/Assets/VRTK/SDK/Base/SDK_Base.cs
@@ -1,0 +1,15 @@
+﻿// SDK Base|SDK_Base|001
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Abstract superclass that defines that a particular class is an SDK.
+    /// </summary>
+    /// <remarks>
+    /// This is an abstract class to mark all different SDK endpoints with. This is used to allow for type safety when talking about 'an SDK' instead of one of the different endpoints (System, Boundaries, Headset, Controller).
+    /// </remarks>
+    public abstract class SDK_Base : ScriptableObject
+    {
+    }
+}

--- a/Assets/VRTK/SDK/Base/SDK_Base.cs.meta
+++ b/Assets/VRTK/SDK/Base/SDK_Base.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 76e3630e592546a4380ad4d75678be81
+timeCreated: 1485249871
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/Base/SDK_BaseBoundaries.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseBoundaries.cs
@@ -1,4 +1,4 @@
-﻿// Base Boundaries|SDK_Base|004
+﻿// Base Boundaries|SDK_Base|007
 namespace VRTK
 {
     using UnityEngine;
@@ -9,7 +9,7 @@ namespace VRTK
     /// <remarks>
     /// This is an abstract class to implement the interface required by all implemented SDKs.
     /// </remarks>
-    public abstract class SDK_BaseBoundaries : ScriptableObject
+    public abstract class SDK_BaseBoundaries : SDK_Base
     {
         protected Transform cachedPlayArea;
 

--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -1,4 +1,4 @@
-﻿// Base Controller|SDK_Base|003
+﻿// Base Controller|SDK_Base|006
 namespace VRTK
 {
     using UnityEngine;
@@ -10,7 +10,7 @@ namespace VRTK
     /// <remarks>
     /// This is an abstract class to implement the interface required by all implemented SDKs.
     /// </remarks>
-    public abstract class SDK_BaseController : ScriptableObject
+    public abstract class SDK_BaseController : SDK_Base
     {
         /// <summary>
         /// Concepts of controller button press

--- a/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
@@ -1,4 +1,4 @@
-﻿// Base Headset|SDK_Base|002
+﻿// Base Headset|SDK_Base|005
 namespace VRTK
 {
     using UnityEngine;
@@ -10,7 +10,7 @@ namespace VRTK
     /// <remarks>
     /// This is an abstract class to implement the interface required by all implemented SDKs.
     /// </remarks>
-    public abstract class SDK_BaseHeadset : ScriptableObject
+    public abstract class SDK_BaseHeadset : SDK_Base
     {
         protected Transform cachedHeadset;
         protected Transform cachedHeadsetCamera;

--- a/Assets/VRTK/SDK/Base/SDK_BaseSystem.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseSystem.cs
@@ -1,15 +1,13 @@
-﻿// Base System|SDK_Base|001
+﻿// Base System|SDK_Base|004
 namespace VRTK
 {
-    using UnityEngine;
-
     /// <summary>
     /// The Base System SDK script provides a bridge to core system SDK methods.
     /// </summary>
     /// <remarks>
     /// This is an abstract class to implement the interface required by all implemented SDKs.
     /// </remarks>
-    public abstract class SDK_BaseSystem : ScriptableObject
+    public abstract class SDK_BaseSystem : SDK_Base
     {
         /// <summary>
         /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.

--- a/Assets/VRTK/SDK/Base/SDK_DescriptionAttribute.cs
+++ b/Assets/VRTK/SDK/Base/SDK_DescriptionAttribute.cs
@@ -1,0 +1,69 @@
+﻿// SDK Description|SDK_Base|002
+namespace VRTK
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Describes a class that represents an SDK. Only allowed on classes that inherit from <see cref="SDK_Base"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class SDK_DescriptionAttribute : Attribute
+    {
+        /// <summary>
+        /// The description of a fallback SDK.
+        /// </summary>
+        public static readonly SDK_DescriptionAttribute Fallback = new SDK_DescriptionAttribute("Fallback", null);
+
+        /// <summary>
+        /// The pretty name of the SDK. Uniquely identifies the SDK.
+        /// </summary>
+        public readonly string prettyName;
+        /// <summary>
+        /// The scripting define symbol needed for the SDK. Needs to be the same as <see cref="SDK_ScriptingDefineSymbolPredicateAttribute.symbol"/> to add and remove the scripting define symbol automatically using <see cref="VRTK_SDKManager"/>.
+        /// </summary>
+        public readonly string symbol;
+
+        /// <summary>
+        /// Creates a new attribute.
+        /// </summary>
+        /// <param name="prettyName">The pretty name of the SDK. Uniquely identifies the SDK. <see langword="null"/> and <see cref="string.Empty"/> aren't allowed.</param>
+        /// <param name="symbol">The scripting define symbol needed for the SDK. Needs to be the same as <see cref="SDK_ScriptingDefineSymbolPredicateAttribute.symbol"/> to add and remove the scripting define symbol automatically using <see cref="VRTK_SDKManager"/>. <see langword="null"/> and <see cref="string.Empty"/> are allowed.</param>
+        public SDK_DescriptionAttribute(string prettyName, string symbol)
+        {
+            if (prettyName == null)
+            {
+                throw new ArgumentNullException("prettyName");
+            }
+            if (prettyName == string.Empty)
+            {
+                throw new ArgumentOutOfRangeException("prettyName", prettyName, "An empty string isn't allowed.");
+            }
+
+            this.prettyName = prettyName;
+            this.symbol = symbol;
+        }
+
+        /// <summary>
+        /// Creates a new attribute by copying from another attribute on a given type.
+        /// </summary>
+        /// <param name="typeToCopyExistingDescriptionFrom">The type to copy the existing <see cref="SDK_DescriptionAttribute"/> from. <see langword="null"/> is not allowed.</param>
+        public SDK_DescriptionAttribute(Type typeToCopyExistingDescriptionFrom)
+        {
+            if (typeToCopyExistingDescriptionFrom == null)
+            {
+                throw new ArgumentNullException("typeToCopyExistingDescriptionFrom");
+            }
+
+            Type descriptionType = typeof(SDK_DescriptionAttribute);
+            var description = (SDK_DescriptionAttribute)typeToCopyExistingDescriptionFrom.GetCustomAttributes(descriptionType, false).FirstOrDefault();
+            if (description == null)
+            {
+                throw new ArgumentOutOfRangeException("typeToCopyExistingDescriptionFrom", typeToCopyExistingDescriptionFrom, string.Format("'{0}' doesn't specify an SDK description via '{1}' to copy.", typeToCopyExistingDescriptionFrom.Name, descriptionType.Name));
+            }
+
+            prettyName = description.prettyName;
+            symbol = description.symbol;
+        }
+    }
+}

--- a/Assets/VRTK/SDK/Base/SDK_DescriptionAttribute.cs.meta
+++ b/Assets/VRTK/SDK/Base/SDK_DescriptionAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 288db3697d634c94d8079f642aa977f5
+timeCreated: 1485801748
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/Base/SDK_ScriptingDefineSymbolPredicateAttribute.cs
+++ b/Assets/VRTK/SDK/Base/SDK_ScriptingDefineSymbolPredicateAttribute.cs
@@ -1,0 +1,76 @@
+﻿// SDK Scripting Define Symbol Predicate|SDK_Base|003
+namespace VRTK
+{
+#if UNITY_EDITOR
+    using UnityEditor;
+#endif
+    using System;
+
+    /// <summary>
+    /// Specifies a method to be used as a predicate to allow <see cref="VRTK_SDKManager"/> to automatically add and remove scripting define symbols. Only allowed on <see langword="static"/> methods that take no arguments and return <see cref="bool"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public sealed class SDK_ScriptingDefineSymbolPredicateAttribute : Attribute
+    {
+        /// <summary>
+        /// The prefix of scripting define symbols that must be used to be able to automatically remove the symbols.
+        /// </summary>
+        public const string RemovableSymbolPrefix = "VRTK_DEFINE_";
+
+        /// <summary>
+        /// The scripting define symbol to conditionally add or remove.
+        /// </summary>
+        public readonly string symbol;
+#if UNITY_EDITOR
+        /// <summary>
+        /// The build target group to use when conditionally adding or removing <see cref="symbol"/>.
+        /// </summary>
+        public readonly BuildTargetGroup buildTargetGroup;
+#endif
+
+        /// <summary>
+        /// Creates a new attribute.
+        /// </summary>
+        /// <param name="symbol">The scripting define symbol to conditionally add or remove. Needs to start with <see cref="RemovableSymbolPrefix"/> to be able to automatically remove the symbol. <see langword="null"/> and <see cref="string.Empty"/> aren't allowed.</param>
+        /// <param name="buildTargetGroupName">The name of a constant of <see cref="BuildTargetGroup"/>. <see cref="BuildTargetGroup.Unknown"/>, <see langword="null"/> and <see cref="string.Empty"/> aren't allowed.</param>
+        public SDK_ScriptingDefineSymbolPredicateAttribute(string symbol, string buildTargetGroupName)
+        {
+            if (symbol == null)
+            {
+                throw new ArgumentNullException("symbol");
+            }
+            if (symbol == string.Empty)
+            {
+                throw new ArgumentOutOfRangeException("symbol", symbol, "An empty string isn't allowed.");
+            }
+
+            this.symbol = symbol;
+
+            if (buildTargetGroupName == null)
+            {
+                throw new ArgumentNullException("buildTargetGroupName");
+            }
+            if (buildTargetGroupName == string.Empty)
+            {
+                throw new ArgumentOutOfRangeException("buildTargetGroupName", buildTargetGroupName, "An empty string isn't allowed.");
+            }
+
+#if UNITY_EDITOR
+            Type buildTargetGroupType = typeof(BuildTargetGroup);
+            try
+            {
+                buildTargetGroup = (BuildTargetGroup)Enum.Parse(buildTargetGroupType, buildTargetGroupName);
+            }
+            catch (Exception exception)
+            {
+                throw new ArgumentOutOfRangeException(string.Format("'{0}' isn't a valid constant name of '{1}'.", buildTargetGroupName, buildTargetGroupType.Name), exception);
+            }
+
+            if (buildTargetGroup == BuildTargetGroup.Unknown)
+            {
+                throw new ArgumentOutOfRangeException("buildTargetGroupName", buildTargetGroupName, string.Format("The buildTargetGroupName '{0}' isn't allowed.", buildTargetGroupName));
+            }
+#endif
+        }
+    }
+}

--- a/Assets/VRTK/SDK/Base/SDK_ScriptingDefineSymbolPredicateAttribute.cs.meta
+++ b/Assets/VRTK/SDK/Base/SDK_ScriptingDefineSymbolPredicateAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: dc0e49e0e9c20594ca1ed0b6e965c89b
+timeCreated: 1485801748
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/Daydream/DaydreamReach.cs
+++ b/Assets/VRTK/SDK/Daydream/DaydreamReach.cs
@@ -1,4 +1,4 @@
-﻿#if VRTK_SDK_DAYDREAM
+﻿#if VRTK_DEFINE_SDK_DAYDREAM
 namespace VRTK
 {
     using UnityEngine;

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamBoundaries.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamBoundaries.cs
@@ -1,14 +1,22 @@
-﻿// Daydream Boundaries|SDK_Daydream|004
+﻿// Daydream Boundaries|SDK_Daydream|005
 namespace VRTK
 {
-#if VRTK_SDK_DAYDREAM
+#if VRTK_DEFINE_SDK_DAYDREAM
     using UnityEngine;
+#endif
 
     /// <summary>
-    /// The Daydream Boundaries SDK script provides dummy functions for the play area bounderies.
+    /// The Daydream Boundaries SDK script provides dummy functions for the play area boundaries.
     /// </summary>
-    public class SDK_DaydreamBoundaries : SDK_BaseBoundaries
+    [SDK_Description(typeof(SDK_DaydreamSystem))]
+    public class SDK_DaydreamBoundaries
+#if VRTK_DEFINE_SDK_DAYDREAM
+        : SDK_BaseBoundaries
+#else
+        : SDK_FallbackBoundaries
+#endif
     {
+#if VRTK_DEFINE_SDK_DAYDREAM
         private Transform area;
 
         /// <summary>
@@ -79,10 +87,6 @@ namespace VRTK
         {
             return true;
         }
-    }
-#else
-    public class SDK_DaydreamBoundaries : SDK_FallbackBoundaries
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -1,15 +1,23 @@
-﻿// Daydream Controller|SDK_Daydream|003
+﻿// Daydream Controller|SDK_Daydream|004
 namespace VRTK
 {
-#if VRTK_SDK_DAYDREAM
+#if VRTK_DEFINE_SDK_DAYDREAM
     using UnityEngine;
     using System.Collections.Generic;
+#endif
 
     /// <summary>
     /// The Daydream Controller SDK script provides a bridge to SDK methods that deal with the input devices.
     /// </summary>
-    public class SDK_DaydreamController : SDK_FallbackController
+    [SDK_Description(typeof(SDK_DaydreamSystem))]
+    public class SDK_DaydreamController
+#if VRTK_DEFINE_SDK_DAYDREAM
+        : SDK_BaseController
+#else
+        : SDK_FallbackController
+#endif
     {
+#if VRTK_DEFINE_SDK_DAYDREAM
         private GameObject controller;
 
         private Vector3 prevPosition;
@@ -44,8 +52,7 @@ namespace VRTK
         /// <returns>A path to the resource that contains the collider GameObject.</returns>
         public override string GetControllerDefaultColliderPath(ControllerHand hand)
         {
-            var returnCollider = "ControllerColliders/Fallback";
-            return returnCollider;
+            return "ControllerColliders/Fallback";
         }
 
         /// <summary>
@@ -104,7 +111,7 @@ namespace VRTK
         /// </summary>
         /// <param name="index">The index of the controller to find.</param>
         /// <param name="actual">If true it will return the actual controller, if false it will return the script alias controller GameObject.</param>
-        /// <returns>The GameObject of the controller</returns>
+        /// <returns></returns>
         public override GameObject GetControllerByIndex(uint index, bool actual = false)
         {
             switch (index)
@@ -124,6 +131,26 @@ namespace VRTK
         public override Transform GetControllerOrigin(GameObject controller)
         {
             return controller.transform;
+        }
+
+        /// <summary>
+        /// The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
+        /// </summary>
+        /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
+        /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        public override Transform GenerateControllerPointerOrigin(GameObject parent)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// The GetControllerLeftHand method returns the GameObject containing the representation of the left hand controller.
+        /// </summary>
+        /// <param name="actual">If true it will return the actual controller, if false it will return the script alias controller GameObject.</param>
+        /// <returns>The GameObject containing the left hand controller.</returns>
+        public override GameObject GetControllerLeftHand(bool actual = false)
+        {
+            return null;
         }
 
         /// <summary>
@@ -147,6 +174,16 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsControllerLeftHand/1 method is used to check if the given controller is the the left hand controller.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <returns>Returns true if the given controller is the left hand controller.</returns>
+        public override bool IsControllerLeftHand(GameObject controller)
+        {
+            return false;
+        }
+
+        /// <summary>
         /// The IsControllerRightHand/1 method is used to check if the given controller is the the right hand controller.
         /// </summary>
         /// <param name="controller">The GameObject to check.</param>
@@ -154,6 +191,17 @@ namespace VRTK
         public override bool IsControllerRightHand(GameObject controller)
         {
             return true;
+        }
+
+        /// <summary>
+        /// The IsControllerLeftHand/2 method is used to check if the given controller is the the left hand controller.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <param name="actual">If true it will check the actual controller, if false it will check the script alias controller.</param>
+        /// <returns>Returns true if the given controller is the left hand controller.</returns>
+        public override bool IsControllerLeftHand(GameObject controller, bool actual)
+        {
+            return false;
         }
 
         /// <summary>
@@ -203,6 +251,33 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The SetControllerRenderModelWheel method sets the state of the scroll wheel on the controller render model.
+        /// </summary>
+        /// <param name="renderModel">The GameObject containing the controller render model.</param>
+        /// <param name="state">If true and the render model has a scroll wheen then it will be displayed, if false then the scroll wheel will be hidden.</param>
+        public override void SetControllerRenderModelWheel(GameObject renderModel, bool state)
+        {
+        }
+
+        /// <summary>
+        /// The HapticPulseOnIndex method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
+        public override void HapticPulseOnIndex(uint index, float strength = 0.5f)
+        {
+        }
+
+        /// <summary>
+        /// The GetHapticModifiers method is used to return modifiers for the duration and interval if the SDK handles it slightly differently.
+        /// </summary>
+        /// <returns>An SDK_ControllerHapticModifiers object with a given `durationModifier` and an `intervalModifier`.</returns>
+        public override SDK_ControllerHapticModifiers GetHapticModifiers()
+        {
+            return new SDK_ControllerHapticModifiers();
+        }
+
+        /// <summary>
         /// The GetVelocityOnIndex method is used to determine the current velocity of the tracked object on the given index.
         /// </summary>
         /// <param name="index">The index of the tracked object to check for.</param>
@@ -230,6 +305,206 @@ namespace VRTK
         public override Vector2 GetTouchpadAxisOnIndex(uint index)
         {
             return GvrController.TouchPos;
+        }
+
+        /// <summary>
+        /// The GetTriggerAxisOnIndex method is used to get the current trigger position on the controller.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector2 containing the current position of the trigger.</returns>
+        public override Vector2 GetTriggerAxisOnIndex(uint index)
+        {
+            return Vector2.zero;
+        }
+
+        /// <summary>
+        /// The GetGripAxisOnIndex method is used to get the current grip position on the controller.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector2 containing the current position of the grip.</returns>
+        public override Vector2 GetGripAxisOnIndex(uint index)
+        {
+            return Vector2.zero;
+        }
+
+        /// <summary>
+        /// The GetTriggerHairlineDeltaOnIndex method is used to get the difference between the current trigger press and the previous frame trigger press.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>The delta between the trigger presses.</returns>
+        public override float GetTriggerHairlineDeltaOnIndex(uint index)
+        {
+            return 0f;
+        }
+
+        /// <summary>
+        /// The GetGripHairlineDeltaOnIndex method is used to get the difference between the current grip press and the previous frame grip press.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>The delta between the grip presses.</returns>
+        public override float GetGripHairlineDeltaOnIndex(uint index)
+        {
+            return 0f;
+        }
+
+        /// <summary>
+        /// The IsTriggerPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsTriggerPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsTriggerPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsTriggerPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsTriggerTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsTriggerTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsTriggerTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairTriggerDownOnIndex method is used to determine if the controller button has passed it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has passed it's press threshold.</returns>
+        public override bool IsHairTriggerDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairTriggerUpOnIndex method is used to determine if the controller button has been released from it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released from it's press threshold.</returns>
+        public override bool IsHairTriggerUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsGripPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsGripPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsGripPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsGripTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsGripTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsGripTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairGripDownOnIndex method is used to determine if the controller button has passed it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has passed it's press threshold.</returns>
+        public override bool IsHairGripDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairGripUpOnIndex method is used to determine if the controller button has been released from it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released from it's press threshold.</returns>
+        public override bool IsHairGripUpOnIndex(uint index)
+        {
+            return false;
         }
 
         /// <summary>
@@ -321,10 +596,156 @@ namespace VRTK
         {
             return GvrController.AppButtonUp;
         }
-    }
-#else
-    public class SDK_DaydreamController : SDK_FallbackController
-    {
-    }
+
+        /// <summary>
+        /// The IsButtonOneTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsButtonOneTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonOneTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsButtonOneTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonOneTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonOneTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsButtonTwoPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsButtonTwoPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonTwoPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsButtonTwoTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsButtonTwoTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonTwoTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamDefines.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamDefines.cs
@@ -1,0 +1,20 @@
+﻿// Daydream Defines|SDK_Daydream|001
+namespace VRTK
+{
+    /// <summary>
+    /// Handles all the scripting define symbols for the Daydream SDK.
+    /// </summary>
+    public static class SDK_DaydreamDefines
+    {
+        /// <summary>
+        /// The scripting define symbol for the Daydream SDK.
+        /// </summary>
+        public const string ScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_DAYDREAM";
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Android")]
+        private static bool IsDaydreamAvailable()
+        {
+            return typeof(SDK_DaydreamDefines).Assembly.GetType("GvrController") != null;
+        }
+    }
+}

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamDefines.cs.meta
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamDefines.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8935bf74ab4561941aab516287d66367
+timeCreated: 1488012370
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamHeadset.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamHeadset.cs
@@ -1,15 +1,23 @@
-﻿// Daydream Headset|SDK_Daydream|002
+﻿// Daydream Headset|SDK_Daydream|003
 namespace VRTK
 {
-#if VRTK_SDK_DAYDREAM
+#if VRTK_DEFINE_SDK_DAYDREAM
     using UnityEngine;
     using System.Collections.Generic;
+#endif
 
     /// <summary>
-    /// The Daydream Headset SDK script  provides dummy functions for the headset.
+    /// The Daydream Headset SDK script provides dummy functions for the headset.
     /// </summary>
-    public class SDK_DaydreamHeadset : SDK_BaseHeadset
+    [SDK_Description(typeof(SDK_DaydreamSystem))]
+    public class SDK_DaydreamHeadset
+#if VRTK_DEFINE_SDK_DAYDREAM
+        : SDK_BaseHeadset
+#else
+        : SDK_FallbackHeadset
+#endif
     {
+#if VRTK_DEFINE_SDK_DAYDREAM
         private Quaternion previousHeadsetRotation;
         private Quaternion currentHeadsetRotation;
 
@@ -106,10 +114,6 @@ namespace VRTK
                 camera.gameObject.AddComponent<VRTK_ScreenFade>();
             }
         }
-    }
-#else
-    public class SDK_DaydreamHeadset : SDK_FallbackHeadset
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamSystem.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamSystem.cs
@@ -1,12 +1,18 @@
-﻿// Daydream System|SDK_Daydream|001
+﻿// Daydream System|SDK_Daydream|002
 namespace VRTK
 {
-#if VRTK_SDK_DAYDREAM
     /// <summary>
     /// The Daydream System SDK script provides dummy functions for system functions.
     /// </summary>
-    public class SDK_DaydreamSystem : SDK_BaseSystem
+    [SDK_Description("Daydream", SDK_DaydreamDefines.ScriptingDefineSymbol)]
+    public class SDK_DaydreamSystem
+#if VRTK_DEFINE_SDK_DAYDREAM
+        : SDK_BaseSystem
+#else
+        : SDK_FallbackSystem
+#endif
     {
+#if VRTK_DEFINE_SDK_DAYDREAM
         /// <summary>
         /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.
         /// </summary>
@@ -32,10 +38,6 @@ namespace VRTK
         public override void ForceInterleavedReprojectionOn(bool force)
         {
         }
-    }
-#else
-    public class SDK_DaydreamSystem : SDK_FallbackSystem
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackBoundaries.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackBoundaries.cs
@@ -4,7 +4,7 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
-    /// The Base Boundaries SDK script provides a bridge to SDK methods that deal with the play area of SDKs that support room scale play spaces.
+    /// The Fallback Boundaries SDK script provides a fallback collection of methods that return null or default headset values.
     /// </summary>
     /// <remarks>
     /// This is the fallback class that will just return default values.
@@ -65,11 +65,6 @@ namespace VRTK
         public override bool IsPlayAreaSizeCalibrated(GameObject playArea)
         {
             return false;
-        }
-
-        private void Awake()
-        {
-            Debug.LogError("Fallback Boundaries SDK is being used. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
         }
     }
 }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -5,7 +5,7 @@ namespace VRTK
     using System.Collections.Generic;
 
     /// <summary>
-    /// The Base Controller SDK script provides a bridge to SDK methods that deal with the input devices.
+    /// The Fallback Controller SDK script provides a fallback collection of methods that return null or default headset values.
     /// </summary>
     /// <remarks>
     /// This is the fallback class that will just return default values.
@@ -671,11 +671,6 @@ namespace VRTK
         public override bool IsStartMenuTouchedUpOnIndex(uint index)
         {
             return false;
-        }
-
-        private void Awake()
-        {
-            Debug.LogError("Fallback Controller SDK is being used. Have you selected a valid Controller SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Controller SDK from the dropdown.");
         }
     }
 }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackHeadset.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackHeadset.cs
@@ -5,7 +5,7 @@ namespace VRTK
     using System.Collections.Generic;
 
     /// <summary>
-    /// The Fallback System SDK script provides a fallback collection of methods that return null or default Headset values.
+    /// The Fallback Headset SDK script provides a fallback collection of methods that return null or default headset values.
     /// </summary>
     /// <remarks>
     /// This is the fallback class that will just return default values.
@@ -82,11 +82,6 @@ namespace VRTK
         /// <param name="camera">The Transform to with the camera on to add the fade functionality to.</param>
         public override void AddHeadsetFade(Transform camera)
         {
-        }
-
-        private void Awake()
-        {
-            Debug.LogError("Fallback Headset SDK is being used. Have you selected a valid Headset SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Headset SDK from the dropdown.");
         }
     }
 }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackSystem.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackSystem.cs
@@ -1,8 +1,6 @@
 ﻿// Fallback System|SDK_Fallback|001
 namespace VRTK
 {
-    using UnityEngine;
-
     /// <summary>
     /// The Fallback System SDK script provides a fallback collection of methods that return null or default system values.
     /// </summary>
@@ -35,11 +33,6 @@ namespace VRTK
         /// <param name="force">If true then Interleaved Reprojection will be forced on, if false it will not be forced on.</param>
         public override void ForceInterleavedReprojectionOn(bool force)
         {
-        }
-
-        private void Awake()
-        {
-            Debug.LogError("Fallback System SDK is being used. Have you selected a valid System SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a System SDK from the dropdown.");
         }
     }
 }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
@@ -1,20 +1,28 @@
-﻿// OculusVR Boundaries|SDK_OculusVR|004
+﻿// OculusVR Boundaries|SDK_OculusVR|005
 namespace VRTK
 {
-#if VRTK_SDK_OCULUSVR
+#if VRTK_DEFINE_SDK_OCULUSVR
     using UnityEngine;
+#endif
 
     /// <summary>
     /// The OculusVR Boundaries SDK script provides a bridge to the OculusVR SDK play area.
     /// </summary>
-    public class SDK_OculusVRBoundaries : SDK_BaseBoundaries
+    [SDK_Description(typeof(SDK_OculusVRSystem))]
+    public class SDK_OculusVRBoundaries
+#if VRTK_DEFINE_SDK_OCULUSVR
+        : SDK_BaseBoundaries
+#else
+        : SDK_FallbackBoundaries
+#endif
     {
+#if VRTK_DEFINE_SDK_OCULUSVR
         /// <summary>
         /// The InitBoundaries method is run on start of scene and can be used to initialse anything on game start.
         /// </summary>
         public override void InitBoundaries()
         {
-#if VRTK_SDK_OCULUSVR_AVATAR
+#if VRTK_DEFINE_SDK_OCULUSVR_AVATAR
             GetAvatar();
 #endif
         }
@@ -88,7 +96,7 @@ namespace VRTK
             return true;
         }
 
-#if VRTK_SDK_OCULUSVR_AVATAR
+#if VRTK_DEFINE_SDK_OCULUSVR_AVATAR
         private OvrAvatar avatarContainer;
 
         /// <summary>
@@ -109,10 +117,6 @@ namespace VRTK
             return avatarContainer;
         }
 #endif
-    }
-#else
-    public class SDK_OculusVRBoundaries : SDK_FallbackBoundaries
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
@@ -1,15 +1,23 @@
-﻿// OculusVR Controller|SDK_OculusVR|003
+﻿// OculusVR Controller|SDK_OculusVR|004
 namespace VRTK
 {
-#if VRTK_SDK_OCULUSVR
+#if VRTK_DEFINE_SDK_OCULUSVR
     using UnityEngine;
     using System.Collections.Generic;
+#endif
 
     /// <summary>
     /// The OculusVR Controller SDK script provides a bridge to SDK methods that deal with the input devices.
     /// </summary>
-    public class SDK_OculusVRController : SDK_BaseController
+    [SDK_Description(typeof(SDK_OculusVRSystem))]
+    public class SDK_OculusVRController
+#if VRTK_DEFINE_SDK_OCULUSVR
+        : SDK_BaseController
+#else
+        : SDK_FallbackController
+#endif
     {
+#if VRTK_DEFINE_SDK_OCULUSVR
         private bool floorLevelSet = false;
         private SDK_OculusVRBoundaries cachedBoundariesSDK;
         private VRTK_TrackedController cachedLeftController;
@@ -1017,7 +1025,7 @@ namespace VRTK
         private bool HasAvatar(bool controllersAreVisible = true)
         {
             GetBoundariesSDK();
-#if VRTK_SDK_OCULUSVR_AVATAR
+#if VRTK_DEFINE_SDK_OCULUSVR_AVATAR
             if (cachedBoundariesSDK)
             {
                 var avatar = cachedBoundariesSDK.GetAvatar();
@@ -1030,7 +1038,7 @@ namespace VRTK
         private GameObject GetAvatar()
         {
             GetBoundariesSDK();
-#if VRTK_SDK_OCULUSVR_AVATAR
+#if VRTK_DEFINE_SDK_OCULUSVR_AVATAR
             if (cachedBoundariesSDK)
             {
                 var avatar = cachedBoundariesSDK.GetAvatar();
@@ -1042,10 +1050,6 @@ namespace VRTK
 #endif
             return null;
         }
-    }
-#else
-    public class SDK_OculusVRController : SDK_FallbackController
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs
@@ -1,0 +1,32 @@
+﻿// OculusVR Defines|SDK_OculusVR|001
+namespace VRTK
+{
+    /// <summary>
+    /// Handles all the scripting define symbols for the OculusVR and Avatar SDKs.
+    /// </summary>
+    public static class SDK_OculusVRDefines
+    {
+        /// <summary>
+        /// The scripting define symbol for the OculusVR SDK.
+        /// </summary>
+        public const string ScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_OCULUSVR";
+        /// <summary>
+        /// The scripting define symbol for the OculusVR Avatar SDK.
+        /// </summary>
+        public const string AvatarScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_OCULUSVR_AVATAR";
+
+        private const string BuildTargetGroupName = "Standalone";
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
+        private static bool IsOculusVRAvailable()
+        {
+            return typeof(SDK_OculusVRDefines).Assembly.GetType("OVRInput") != null;
+        }
+
+        [SDK_ScriptingDefineSymbolPredicate(AvatarScriptingDefineSymbol, BuildTargetGroupName)]
+        private static bool IsOculusVRAvatarAvailable()
+        {
+            return IsOculusVRAvailable() && typeof(SDK_OculusVRDefines).Assembly.GetType("OVRAvatar") != null;
+        }
+    }
+}

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs.meta
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 84b7772a979101d4cbe8cf5dcfa69860
+timeCreated: 1485691994
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
@@ -1,15 +1,23 @@
-﻿// OculusVR Headset|SDK_OculusVR|002
+﻿// OculusVR Headset|SDK_OculusVR|003
 namespace VRTK
 {
-#if VRTK_SDK_OCULUSVR
+#if VRTK_DEFINE_SDK_OCULUSVR
     using UnityEngine;
     using System.Collections.Generic;
+#endif
 
     /// <summary>
     /// The OculusVR Headset SDK script provides a bridge to the OculusVR SDK.
     /// </summary>
-    public class SDK_OculusVRHeadset : SDK_BaseHeadset
+    [SDK_Description(typeof(SDK_OculusVRSystem))]
+    public class SDK_OculusVRHeadset
+#if VRTK_DEFINE_SDK_OCULUSVR
+        : SDK_BaseHeadset
+#else
+        : SDK_FallbackHeadset
+#endif
     {
+#if VRTK_DEFINE_SDK_OCULUSVR
         private Quaternion previousHeadsetRotation;
         private Quaternion currentHeadsetRotation;
 
@@ -111,10 +119,6 @@ namespace VRTK
                 camera.gameObject.AddComponent<VRTK_ScreenFade>();
             }
         }
-    }
-#else
-    public class SDK_OculusVRHeadset : SDK_FallbackHeadset
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRSystem.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRSystem.cs
@@ -1,12 +1,18 @@
-﻿// OculusVR System|SDK_OculusVR|001
+﻿// OculusVR System|SDK_OculusVR|002
 namespace VRTK
 {
-#if VRTK_SDK_OCULUSVR
     /// <summary>
     /// The OculusVR System SDK script provides a bridge to the OculusVR SDK.
     /// </summary>
-    public class SDK_OculusVRSystem : SDK_BaseSystem
+    [SDK_Description("OculusVR", SDK_OculusVRDefines.ScriptingDefineSymbol)]
+    public class SDK_OculusVRSystem
+#if VRTK_DEFINE_SDK_OCULUSVR
+        : SDK_BaseSystem
+#else
+        : SDK_FallbackSystem
+#endif
     {
+#if VRTK_DEFINE_SDK_OCULUSVR
         /// <summary>
         /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.
         /// </summary>
@@ -32,10 +38,6 @@ namespace VRTK
         public override void ForceInterleavedReprojectionOn(bool force)
         {
         }
-    }
-#else
-    public class SDK_OculusVRSystem : SDK_FallbackSystem
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
@@ -109,21 +109,22 @@ namespace VRTK
             leftController.Selected = false;
             destroyed = false;
 
-#if VRTK_SDK_SIM
-            Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
+            var controllerSDK = VRTK_SDK_Bridge.GetControllerSDK() as SDK_SimController;
+            if (controllerSDK != null)
             {
-                {"Trigger", triggerAlias },
-                {"Grip", gripAlias },
-                {"TouchpadPress", touchpadAlias },
-                {"ButtonOne", buttonOneAlias },
-                {"ButtonTwo", buttonTwoAlias },
-                {"StartMenu", startMenuAlias },
-                {"TouchModifier", touchModifier },
-                {"HairTouchModifier", hairTouchModifier }
-            };
-            SDK_SimController controllerSDK = (SDK_SimController)VRTK_SDK_Bridge.GetControllerSDK();
-            controllerSDK.SetKeyMappings(keyMappings);
-#endif
+                Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
+                {
+                    {"Trigger", triggerAlias },
+                    {"Grip", gripAlias },
+                    {"TouchpadPress", touchpadAlias },
+                    {"ButtonOne", buttonOneAlias },
+                    {"ButtonTwo", buttonTwoAlias },
+                    {"StartMenu", startMenuAlias },
+                    {"TouchModifier", touchModifier },
+                    {"HairTouchModifier", hairTouchModifier }
+                };
+                controllerSDK.SetKeyMappings(keyMappings);
+            }
         }
 
         private void OnDestroy()

--- a/Assets/VRTK/SDK/Simulator/SDK_SimBoundaries.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimBoundaries.cs
@@ -1,12 +1,12 @@
 ﻿// Simulator Boundaries|SDK_Simulator|004
 namespace VRTK
 {
-#if VRTK_SDK_SIM
     using UnityEngine;
 
     /// <summary>
-    /// The Sim Boundaries SDK script provides dummy functions for the play area bounderies.
+    /// The Sim Boundaries SDK script provides dummy functions for the play area boundaries.
     /// </summary>
+    [SDK_Description(typeof(SDK_SimSystem))]
     public class SDK_SimBoundaries : SDK_BaseBoundaries
     {
         private Transform area;
@@ -75,9 +75,4 @@ namespace VRTK
             return true;
         }
     }
-#else
-    public class SDK_SimBoundaries : SDK_FallbackBoundaries
-    {
-    }
-#endif
 }

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -1,13 +1,13 @@
 ﻿// Simulator Controller|SDK_Simulator|003
 namespace VRTK
 {
-#if VRTK_SDK_SIM
     using UnityEngine;
     using System.Collections.Generic;
 
     /// <summary>
     /// The Sim Controller SDK script provides functions to help simulate VR controllers.
     /// </summary>
+    [SDK_Description(typeof(SDK_SimSystem))]
     public class SDK_SimController : SDK_BaseController
     {
         private SimControllers controllers;
@@ -915,7 +915,6 @@ namespace VRTK
                 return false;
             }
 
-
             switch (type)
             {
                 case ButtonPressTypes.Press:
@@ -947,9 +946,4 @@ namespace VRTK
             }
         }
     }
-#else
-    public class SDK_SimController : SDK_FallbackController
-    {
-    }
-#endif
 }

--- a/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
@@ -1,13 +1,13 @@
 ﻿// Simulator Headset|SDK_Simulator|002
 namespace VRTK
 {
-#if VRTK_SDK_SIM
     using UnityEngine;
     using System.Collections.Generic;
 
     /// <summary>
     /// The Sim Headset SDK script  provides dummy functions for the headset.
     /// </summary>
+    [SDK_Description(typeof(SDK_SimSystem))]
     public class SDK_SimHeadset : SDK_BaseHeadset
     {
         private Transform camera;
@@ -142,9 +142,4 @@ namespace VRTK
             lastRot = headset.rotation.eulerAngles;
         }
     }
-#else
-    public class SDK_SimHeadset : SDK_FallbackHeadset
-    {
-    }
-#endif
 }

--- a/Assets/VRTK/SDK/Simulator/SDK_SimSystem.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimSystem.cs
@@ -1,12 +1,10 @@
 ﻿// Simulator System|SDK_Simulator|001
 namespace VRTK
 {
-#if VRTK_SDK_SIM
-    using UnityEngine;
-
     /// <summary>
     /// The Sim System SDK script provides dummy functions for system functions.
     /// </summary>
+    [SDK_Description("Simulator", null)]
     public class SDK_SimSystem : SDK_BaseSystem
     {
         /// <summary>
@@ -36,9 +34,4 @@ namespace VRTK
 
         }
     }
-#else
-    public class SDK_SimSystem : SDK_FallbackSystem
-    {
-    }
-#endif
 }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -1,14 +1,22 @@
-﻿// SteamVR Boundaries|SDK_SteamVR|004
+﻿// SteamVR Boundaries|SDK_SteamVR|005
 namespace VRTK
 {
-#if VRTK_SDK_STEAMVR
+#if VRTK_DEFINE_SDK_STEAMVR
     using UnityEngine;
+#endif
 
     /// <summary>
     /// The SteamVR Boundaries SDK script provides a bridge to the SteamVR SDK play area.
     /// </summary>
-    public class SDK_SteamVRBoundaries : SDK_BaseBoundaries
+    [SDK_Description(typeof(SDK_SteamVRSystem))]
+    public class SDK_SteamVRBoundaries
+#if VRTK_DEFINE_SDK_STEAMVR
+        : SDK_BaseBoundaries
+#else
+        : SDK_FallbackBoundaries
+#endif
     {
+#if VRTK_DEFINE_SDK_STEAMVR
         /// <summary>
         /// The InitBoundaries method is run on start of scene and can be used to initialse anything on game start.
         /// </summary>
@@ -74,10 +82,6 @@ namespace VRTK
             var area = playArea.GetComponent<SteamVR_PlayArea>();
             return (area.size == SteamVR_PlayArea.Size.Calibrated);
         }
-    }
-#else
-    public class SDK_SteamVRBoundaries : SDK_FallbackBoundaries
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
@@ -1,0 +1,84 @@
+﻿// SteamVR Defines|SDK_SteamVR|001
+namespace VRTK
+{
+    using System;
+    using System.Reflection;
+    using Valve.VR;
+
+    /// <summary>
+    /// Handles all the scripting define symbols for the SteamVR SDK.
+    /// </summary>
+    public static class SDK_SteamVRDefines
+    {
+        /// <summary>
+        /// The scripting define symbol for the SteamVR SDK.
+        /// </summary>
+        public const string ScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_STEAMVR";
+
+        private const string BuildTargetGroupName = "Standalone";
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_1_OR_NEWER", BuildTargetGroupName)]
+        private static bool IsPluginVersion121OrNewer()
+        {
+            Type eventClass = typeof(SDK_SteamVRDefines).Assembly.GetType("SteamVR_Events");
+            if (eventClass == null)
+            {
+                return false;
+            }
+
+            MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
+            if (systemMethod == null)
+            {
+                return false;
+            }
+
+            ParameterInfo[] systemMethodParameters = systemMethod.GetParameters();
+            if (systemMethodParameters.Length != 1)
+            {
+                return false;
+            }
+
+            return systemMethodParameters[0].ParameterType == typeof(EVREventType);
+        }
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_0", BuildTargetGroupName)]
+        private static bool IsPluginVersion120()
+        {
+            Type eventClass = typeof(SDK_SteamVRDefines).Assembly.GetType("SteamVR_Events");
+            if (eventClass == null)
+            {
+                return false;
+            }
+
+            MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
+            if (systemMethod == null)
+            {
+                return false;
+            }
+
+            ParameterInfo[] systemMethodParameters = systemMethod.GetParameters();
+            if (systemMethodParameters.Length != 1)
+            {
+                return false;
+            }
+
+            return systemMethodParameters[0].ParameterType == typeof(string);
+        }
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_1_1_OR_OLDER", BuildTargetGroupName)]
+        private static bool IsPluginVersion111OrOlder()
+        {
+            Type utilsClass = typeof(SDK_SteamVRDefines).Assembly.GetType("SteamVR_Utils");
+            if (utilsClass == null)
+            {
+                return false;
+            }
+
+            Type eventClass = utilsClass.GetNestedType("Event");
+            return eventClass != null && eventClass.GetMethod("Listen", BindingFlags.Public | BindingFlags.Static) != null;
+        }
+    }
+}

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs.meta
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a6dbadd5d74fcda40bcf112f8f43d3bb
+timeCreated: 1485617852
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -1,15 +1,23 @@
-﻿// SteamVR Headset|SDK_SteamVR|002
+﻿// SteamVR Headset|SDK_SteamVR|003
 namespace VRTK
 {
-#if VRTK_SDK_STEAMVR
+#if VRTK_DEFINE_SDK_STEAMVR
     using UnityEngine;
     using System.Collections.Generic;
+#endif
 
     /// <summary>
     /// The SteamVR Headset SDK script provides a bridge to the SteamVR SDK.
     /// </summary>
-    public class SDK_SteamVRHeadset : SDK_BaseHeadset
+    [SDK_Description(typeof(SDK_SteamVRSystem))]
+    public class SDK_SteamVRHeadset
+#if VRTK_DEFINE_SDK_STEAMVR
+        : SDK_BaseHeadset
+#else
+        : SDK_FallbackHeadset
+#endif
     {
+#if VRTK_DEFINE_SDK_STEAMVR
         /// <summary>
         /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
         /// </summary>
@@ -112,10 +120,6 @@ namespace VRTK
                 camera.gameObject.AddComponent<SteamVR_Fade>();
             }
         }
-    }
-#else
-    public class SDK_SteamVRHeadset : SDK_FallbackHeadset
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRSystem.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRSystem.cs
@@ -1,14 +1,22 @@
-﻿// SteamVR System|SDK_SteamVR|001
+﻿// SteamVR System|SDK_SteamVR|002
 namespace VRTK
 {
-#if VRTK_SDK_STEAMVR
+#if VRTK_DEFINE_SDK_STEAMVR
     using Valve.VR;
+#endif
 
     /// <summary>
     /// The SteamVR System SDK script provides a bridge to the SteamVR SDK.
     /// </summary>
-    public class SDK_SteamVRSystem : SDK_BaseSystem
+    [SDK_Description("SteamVR", SDK_SteamVRDefines.ScriptingDefineSymbol)]
+    public class SDK_SteamVRSystem
+#if VRTK_DEFINE_SDK_STEAMVR
+        : SDK_BaseSystem
+#else
+        : SDK_FallbackSystem
+#endif
     {
+#if VRTK_DEFINE_SDK_STEAMVR
         /// <summary>
         /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.
         /// </summary>
@@ -38,10 +46,6 @@ namespace VRTK
                 OpenVR.Compositor.ForceInterleavedReprojectionOn(force);
             }
         }
-    }
-#else
-    public class SDK_SteamVRSystem : SDK_FallbackSystem
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRBoundaries.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRBoundaries.cs
@@ -1,14 +1,22 @@
-﻿// XimmerseVR Boundaries|SDK_XimmerseVR|004
+﻿// XimmerseVR Boundaries|SDK_XimmerseVR|005
 namespace VRTK
 {
-#if VRTK_SDK_XIMMERSEVR
+#if VRTK_DEFINE_SDK_XIMMERSEVR
     using UnityEngine;
+#endif
 
     /// <summary>
     /// The XimmerseVR Boundaries SDK script provides a bridge to the XimmerseVR SDK play area.
     /// </summary>
-    public class SDK_XimmerseVRBoundaries : SDK_BaseBoundaries
+    [SDK_Description(typeof(SDK_XimmerseVRSystem))]
+    public class SDK_XimmerseVRBoundaries
+#if VRTK_DEFINE_SDK_XIMMERSEVR
+        : SDK_BaseBoundaries
+#else
+        : SDK_FallbackBoundaries
+#endif
     {
+#if VRTK_DEFINE_SDK_XIMMERSEVR
         /// <summary>
         /// The InitBoundaries method is run on start of scene and can be used to initialse anything on game start.
         /// </summary>
@@ -69,10 +77,6 @@ namespace VRTK
         {
             return true;
         }
-    }
-#else
-    public class SDK_XimmerseVRBoundaries : SDK_FallbackBoundaries
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRController.cs
@@ -1,17 +1,24 @@
-﻿// XimmerseVR Controller|SDK_XimmerseVR|003
+﻿// XimmerseVR Controller|SDK_XimmerseVR|004
 namespace VRTK
 {
-#if VRTK_SDK_XIMMERSEVR
-    using System.Collections;
-    using System.Collections.Generic;
+#if VRTK_DEFINE_SDK_XIMMERSEVR
     using UnityEngine;
+    using System.Collections.Generic;
     using Ximmerse.InputSystem;
+#endif
 
     /// <summary>
     /// The XimmerseVR Controller SDK script provides a bridge to SDK methods that deal with the input devices.
     /// </summary>
-    public class SDK_XimmerseVRController : SDK_BaseController
+    [SDK_Description(typeof(SDK_XimmerseVRSystem))]
+    public class SDK_XimmerseVRController
+#if VRTK_DEFINE_SDK_XIMMERSEVR
+        : SDK_BaseController
+#else
+        : SDK_FallbackController
+#endif
     {
+#if VRTK_DEFINE_SDK_XIMMERSEVR
         private TrackedObject cachedLeftTrackedObject;
         private TrackedObject cachedRightTrackedObject;
 
@@ -73,7 +80,7 @@ namespace VRTK
         public override string GetControllerElementPath(ControllerElements element, ControllerHand hand, bool fullPath = false)
         {
             var suffix = (fullPath ? "" : "");
-            var handName = (hand == ControllerHand.Left) ? "cobra02-L" : "cobra02-R"; 
+            var handName = (hand == ControllerHand.Left) ? "cobra02-L" : "cobra02-R";
             var path = handName + "/Dummy";
             switch (element)
             {
@@ -129,7 +136,7 @@ namespace VRTK
         /// </summary>
         /// <param name="index">The index of the controller to find.</param>
         /// <param name="actual">If true it will return the actual controller, if false it will return the script alias controller GameObject.</param>
-        /// <returns>The GameObject of the controller</returns>
+        /// <returns></returns>
         public override GameObject GetControllerByIndex(uint index, bool actual = false)
         {
             SetTrackedControllerCaches();
@@ -296,7 +303,7 @@ namespace VRTK
         /// <param name="state">If true and the render model has a scroll wheen then it will be displayed, if false then the scroll wheel will be hidden.</param>
         public override void SetControllerRenderModelWheel(GameObject renderModel, bool state)
         {
-			
+
         }
 
         /// <summary>
@@ -347,7 +354,7 @@ namespace VRTK
                 return Vector3.zero;
             }
 
-            var device = GetControllerInputByIndex(index); 
+            var device = GetControllerInputByIndex(index);
             if (device == null)
                 return Vector3.zero;
 
@@ -388,7 +395,7 @@ namespace VRTK
             {
                 return Vector2.zero;
             }
-            
+
             var result = device.GetTouchPos() - new Vector2(0.5f, 0.5f);
             result = new Vector2(result.x, -result.y);
 
@@ -939,8 +946,10 @@ namespace VRTK
             }
             var device = GetControllerInputByIndex(index);
             if (device == null)
+            {
                 return false;
-			
+            }
+
             switch (type)
             {
                 case ButtonPressTypes.Press:
@@ -997,10 +1006,6 @@ namespace VRTK
 
             return result;
         }
-    }
-#else
-    public class SDK_XimmerseVRController : SDK_FallbackController
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRDefines.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRDefines.cs
@@ -1,0 +1,21 @@
+﻿// XimmerseVR Defines|SDK_XimmerseVR|001
+namespace VRTK
+{
+    /// <summary>
+    /// Handles all the scripting define symbols for the XimmerseVR SDK.
+    /// </summary>
+    public static class SDK_XimmerseVRDefines
+    {
+        /// <summary>
+        /// The scripting define symbol for the XimmerseVR SDK.
+        /// </summary>
+        public const string ScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_XIMMERSEVR";
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Standalone")]
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Android")]
+        private static bool IsXimmerseVRAvailable()
+        {
+            return typeof(SDK_XimmerseVRDefines).Assembly.GetType("Ximmerse.InputSystem.XDevicePlugin") != null;
+        }
+    }
+}

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRDefines.cs.meta
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRDefines.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2f5c4e083592de140b429b6047de59aa
+timeCreated: 1488204240
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRHeadset.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRHeadset.cs
@@ -1,17 +1,25 @@
-﻿// XimmerseVR Headset|SDK_XimmerseVR|002
+﻿// XimmerseVR Headset|SDK_XimmerseVR|003
 namespace VRTK
 {
-#if VRTK_SDK_XIMMERSEVR
+#if VRTK_DEFINE_SDK_XIMMERSEVR
+    using UnityEngine;
     using System.Collections.Generic;
     using Ximmerse.InputSystem;
     using Ximmerse.VR;
-    using UnityEngine;
+#endif
 
     /// <summary>
     /// The XimmerseVR Headset SDK script provides a bridge to the XimmerseVR SDK.
     /// </summary>
-    public class SDK_XimmerseVRHeadset : SDK_BaseHeadset
+    [SDK_Description(typeof(SDK_XimmerseVRSystem))]
+    public class SDK_XimmerseVRHeadset
+#if VRTK_DEFINE_SDK_XIMMERSEVR
+        : SDK_BaseHeadset
+#else
+        : SDK_FallbackHeadset
+#endif
     {
+#if VRTK_DEFINE_SDK_XIMMERSEVR
         private Quaternion previousHeadsetRotation;
         private Quaternion currentHeadsetRotation;
 
@@ -125,10 +133,6 @@ namespace VRTK
                 camera.gameObject.AddComponent<VRTK_ScreenFade>();
             }
         }
-    }
-#else
-    public class SDK_XimmerseVRHeadset : SDK_FallbackHeadset
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRSystem.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRSystem.cs
@@ -1,14 +1,18 @@
-﻿// XimmerseVR System|SDK_XimmerseVR|001
+﻿// XimmerseVR System|SDK_XimmerseVR|002
 namespace VRTK
 {
-#if VRTK_SDK_XIMMERSEVR
-    using Ximmerse.InputSystem;
-
     /// <summary>
     /// The XimmerseVR System SDK script provides a bridge to the XimmerseVR SDK.
     /// </summary>
-    public class SDK_XimmerseVRSystem : SDK_BaseSystem
+    [SDK_Description("XimmerseVR", SDK_XimmerseVRDefines.ScriptingDefineSymbol)]
+    public class SDK_XimmerseVRSystem
+#if VRTK_DEFINE_SDK_XIMMERSEVR
+        : SDK_BaseSystem
+#else
+        : SDK_FallbackSystem
+#endif
     {
+#if VRTK_DEFINE_SDK_XIMMERSEVR
         /// <summary>
         /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.
         /// </summary>
@@ -33,12 +37,7 @@ namespace VRTK
         /// <param name="force">If true then Interleaved Reprojection will be forced on, if false it will not be forced on.</param>
         public override void ForceInterleavedReprojectionOn(bool force)
         {
-            
         }
-    }
-#else
-    public class SDK_XimmerseVRSystem : SDK_FallbackSystem
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs
@@ -1,0 +1,195 @@
+﻿// SDK Info|Utilities|90011
+namespace VRTK
+{
+    using UnityEngine;
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Holds all the info necessary to describe an SDK.
+    /// </summary>
+    [Serializable]
+    public sealed class VRTK_SDKInfo : ISerializationCallbackReceiver
+    {
+        /// <summary>
+        /// The type of the SDK.
+        /// </summary>
+        public Type type { get; private set; }
+        /// <summary>
+        /// The name of the type of which this SDK info was created from. This is only used if said type wasn't found.
+        /// </summary>
+        public string originalTypeNameWhenFallbackIsUsed { get; private set; }
+        /// <summary>
+        /// The description of the SDK.
+        /// </summary>
+        public SDK_DescriptionAttribute description { get; private set; }
+
+        [SerializeField]
+        private string baseTypeName;
+        [SerializeField]
+        private string fallbackTypeName;
+        [SerializeField]
+        private string typeName;
+
+        /// <summary>
+        /// Creates a new SDK info for a type that is known at compile time.
+        /// </summary>
+        /// <typeparam name="BaseType">The SDK base type. Must be a subclass of <see cref="SDK_Base"/>.</typeparam>
+        /// <typeparam name="FallbackType">The SDK type to fall back on if problems occur. Must be a subclass of <typeparamref name="BaseType"/>.</typeparam>
+        /// <typeparam name="ActualType">The SDK type to use. Must be a subclass of <typeparamref name="BaseType"/>.</typeparam>
+        /// <returns>A newly created instance.</returns>
+        public static VRTK_SDKInfo Create<BaseType, FallbackType, ActualType>() where BaseType : SDK_Base where FallbackType : BaseType where ActualType : BaseType
+        {
+            var sdkInfo = new VRTK_SDKInfo();
+            sdkInfo.SetUp(typeof(BaseType), typeof(FallbackType), typeof(ActualType).FullName);
+
+            return sdkInfo;
+        }
+
+        /// <summary>
+        /// Creates a new SDK info for a type.
+        /// </summary>
+        /// <typeparam name="BaseType">The SDK base type. Must be a subclass of <see cref="SDK_Base"/>.</typeparam>
+        /// <typeparam name="FallbackType">The SDK type to fall back on if problems occur. Must be a subclass of <typeparamref name="BaseType"/>.</typeparam>
+        /// <param name="actualType">The SDK type to use. Must be a subclass of <typeparamref name="BaseType"/>.</param>
+        /// <returns>A newly created instance.</returns>
+        public static VRTK_SDKInfo Create<BaseType, FallbackType>(Type actualType) where BaseType : SDK_Base where FallbackType : BaseType
+        {
+            var sdkInfo = new VRTK_SDKInfo();
+            sdkInfo.SetUp(typeof(BaseType), typeof(FallbackType), actualType.FullName);
+
+            return sdkInfo;
+        }
+
+        private VRTK_SDKInfo()
+        {
+        }
+
+        private void SetUp(Type baseType, Type fallbackType, string actualTypeName)
+        {
+            if (!baseType.IsSubclassOf(typeof(SDK_Base)))
+            {
+                throw new ArgumentOutOfRangeException("baseType", baseType, string.Format("'{0}' is not a subclass of the SDK base type '{1}'.", baseType.Name, typeof(SDK_Base).Name));
+            }
+
+            if (!fallbackType.IsSubclassOf(baseType))
+            {
+                throw new ArgumentOutOfRangeException("fallbackType", fallbackType, string.Format("'{0}' is not a subclass of the SDK base type '{1}'.", fallbackType.Name, baseType.Name));
+            }
+
+            baseTypeName = baseType.FullName;
+            fallbackTypeName = fallbackType.FullName;
+            typeName = actualTypeName;
+
+            if (string.IsNullOrEmpty(actualTypeName))
+            {
+                type = fallbackType;
+                originalTypeNameWhenFallbackIsUsed = null;
+                description = SDK_DescriptionAttribute.Fallback;
+
+                return;
+            }
+
+            Type actualType = Type.GetType(actualTypeName);
+            if (actualType == null)
+            {
+                Debug.LogError(string.Format("The SDK '{0}' doesn't exist anymore. The fallback SDK '{1}' will be used instead.", actualTypeName, fallbackType.Name));
+
+                type = fallbackType;
+                originalTypeNameWhenFallbackIsUsed = actualTypeName;
+                description = SDK_DescriptionAttribute.Fallback;
+
+                return;
+            }
+
+            if (!actualType.IsSubclassOf(baseType))
+            {
+                throw new ArgumentOutOfRangeException("actualTypeName", actualTypeName, string.Format("'{0}' is not a subclass of the SDK base type '{1}'.", actualTypeName, baseType.Name));
+            }
+
+            string fallbackNamespace = typeof(SDK_FallbackSystem).Namespace;
+            string fallbackNamePrefix = typeof(SDK_FallbackSystem).Name.Replace("System", "");
+            if (actualType.Namespace == fallbackNamespace && actualType.Name.StartsWith(fallbackNamePrefix, StringComparison.Ordinal))
+            {
+                type = actualType;
+                originalTypeNameWhenFallbackIsUsed = null;
+                description = SDK_DescriptionAttribute.Fallback;
+
+                return;
+            }
+
+            var actualDescription = (SDK_DescriptionAttribute)actualType.GetCustomAttributes(typeof(SDK_DescriptionAttribute), false).FirstOrDefault();
+            if (actualDescription == null)
+            {
+                throw new ArgumentException(string.Format("'{0}' doesn't specify an SDK description via '{1}'.", actualTypeName, typeof(SDK_DescriptionAttribute).Name), "actualTypeName");
+            }
+
+            type = actualType;
+            originalTypeNameWhenFallbackIsUsed = null;
+            description = actualDescription;
+        }
+
+        #region ISerializationCallbackReceiver
+
+        public void OnBeforeSerialize()
+        {
+        }
+
+        public void OnAfterDeserialize()
+        {
+            SetUp(Type.GetType(baseTypeName), Type.GetType(fallbackTypeName), typeName);
+        }
+
+        #endregion
+
+        #region Equality via type
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as VRTK_SDKInfo;
+            if ((object)other == null)
+            {
+                return false;
+            }
+
+            return type == other.type;
+        }
+
+        public bool Equals(VRTK_SDKInfo other)
+        {
+            if ((object)other == null)
+            {
+                return false;
+            }
+
+            return type == other.type;
+        }
+
+        public override int GetHashCode()
+        {
+            return type.GetHashCode();
+        }
+
+        public static bool operator ==(VRTK_SDKInfo x, VRTK_SDKInfo y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if ((object)x == null || (object)y == null)
+            {
+                return false;
+            }
+
+            return x.type == y.type;
+        }
+
+        public static bool operator !=(VRTK_SDKInfo x, VRTK_SDKInfo y)
+        {
+            return !(x == y);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d68dc3ec5c98d27458fced5b490753ad
+timeCreated: 1485729497
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -2,60 +2,187 @@
 namespace VRTK
 {
     using UnityEngine;
+#if UNITY_EDITOR
+    using UnityEngine.SceneManagement;
+    using UnityEditor;
+    using UnityEditor.Callbacks;
+#endif
+    using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Reflection;
 
     /// <summary>
-    /// The SDK Manager script provides configuration of supported SDKs
+    /// The SDK Manager script provides configuration of supported SDKs.
     /// </summary>
-    [ExecuteInEditMode]
     public class VRTK_SDKManager : MonoBehaviour
     {
         /// <summary>
-        /// The supported SDKs
+        /// All found scripting define symbol predicate attributes with associated method info.
         /// </summary>
-        public enum SupportedSDKs
-        {
-            None,
-            SteamVR,
-            OculusVR,
-            XimmerseVR,
-            Daydream,
-            Simulator
-        }
+        public static ReadOnlyCollection<ScriptingDefineSymbolPredicateInfo> AvailableScriptingDefineSymbolPredicateInfos { get; private set; }
 
-        public Dictionary<SupportedSDKs, VRTK_SDKDetails> sdkDetails = new Dictionary<SupportedSDKs, VRTK_SDKDetails>()
-        {
-            { SupportedSDKs.None, new VRTK_SDKDetails("", "", "") },
-            { SupportedSDKs.SteamVR, new VRTK_SDKDetails("VRTK_SDK_STEAMVR", "SteamVR", "SteamVR") },
-            { SupportedSDKs.OculusVR, new VRTK_SDKDetails("VRTK_SDK_OCULUSVR", "OculusVR", "OVRInput") },
-            { SupportedSDKs.XimmerseVR, new VRTK_SDKDetails("VRTK_SDK_XIMMERSEVR", "XimmerseVR", "XimmerseVR") },
-            { SupportedSDKs.Daydream, new VRTK_SDKDetails("VRTK_SDK_DAYDREAM", "Daydream", "VRTK_SDKManager") }, // JSL: maybe use GVR here?
-            { SupportedSDKs.Simulator, new VRTK_SDKDetails("VRTK_SDK_SIM", "Simulator", "VRTK_SDKManager") }
-        };
+        /// <summary>
+        /// All available system SDK infos.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> AvailableSystemSDKInfos { get; private set; }
+        /// <summary>
+        /// All available boundaries SDK infos.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> AvailableBoundariesSDKInfos { get; private set; }
+        /// <summary>
+        /// All available headset SDK infos.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> AvailableHeadsetSDKInfos { get; private set; }
+        /// <summary>
+        /// All available controller SDK infos.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> AvailableControllerSDKInfos { get; private set; }
+
+        /// <summary>
+        /// All installed system SDK infos. This is a subset of <see cref="AvailableSystemSDKInfos"/>. It contains only those available SDK infos for which an <see cref="SDK_ScriptingDefineSymbolPredicateAttribute"/> exists that uses the same symbol and whose associated method returns true.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> InstalledSystemSDKInfos { get; private set; }
+        /// <summary>
+        /// All installed boundaries SDK infos. This is a subset of <see cref="AvailableBoundariesSDKInfos"/>. It contains only those available SDK infos for which an <see cref="SDK_ScriptingDefineSymbolPredicateAttribute"/> exists that uses the same symbol and whose associated method returns true.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> InstalledBoundariesSDKInfos { get; private set; }
+        /// <summary>
+        /// All installed headset SDK infos. This is a subset of <see cref="AvailableHeadsetSDKInfos"/>. It contains only those available SDK infos for which an <see cref="SDK_ScriptingDefineSymbolPredicateAttribute"/> exists that uses the same symbol and whose associated method returns true.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> InstalledHeadsetSDKInfos { get; private set; }
+        /// <summary>
+        /// All installed controller SDK infos. This is a subset of <see cref="AvailableControllerSDKInfos"/>. It contains only those available SDK infos for which an <see cref="SDK_ScriptingDefineSymbolPredicateAttribute"/> exists that uses the same symbol and whose associated method returns true.
+        /// </summary>
+        public static ReadOnlyCollection<VRTK_SDKInfo> InstalledControllerSDKInfos { get; private set; }
 
         /// <summary>
         /// The singleton instance to access the SDK Manager variables from.
         /// </summary>
-        public static VRTK_SDKManager instance = null;
-
-        [Header("SDK Selection")]
+        public static VRTK_SDKManager instance;
 
         [Tooltip("If this is true then the instance of the SDK Manager won't be destroyed on every scene load.")]
-        public bool persistOnLoad = false;
+        public bool persistOnLoad;
 
-        [Tooltip("The SDK to use to deal with all system actions.")]
-        public SupportedSDKs systemSDK = SupportedSDKs.None;
-        [Tooltip("The SDK to use to utilise room scale boundaries.")]
-        public SupportedSDKs boundariesSDK = SupportedSDKs.None;
-        [Tooltip("The SDK to use to utilise the VR headset.")]
-        public SupportedSDKs headsetSDK = SupportedSDKs.None;
-        [Tooltip("The SDK to use to utilise the input devices.")]
-        public SupportedSDKs controllerSDK = SupportedSDKs.None;
+        [Tooltip("This determines whether the SDK object references are automatically set to the objects of the selected SDKs. If this is true populating is done whenever the selected SDKs change.")]
+        public bool autoPopulateObjectReferences = true;
 
-        [Tooltip("This determines whether the scripting define symbols required by the selected SDKs are automatically added to the player settings when using the SDK Manager inspector window.")]
+        [Tooltip("This determines whether the scripting define symbols required by the selected SDKs are automatically added to and removed from the player settings. If this is true managing is done whenever the selected SDKs or the current active SDK Manager change in the Editor.")]
         public bool autoManageScriptDefines = true;
 
-        [Header("Linked Objects")]
+        /// <summary>
+        /// The info of the SDK to use to deal with all system actions. By setting this to `null` the fallback SDK will be used.
+        /// </summary>
+        public VRTK_SDKInfo systemSDKInfo
+        {
+            get
+            {
+                return cachedSystemSDKInfo;
+            }
+            set
+            {
+                value = value ?? VRTK_SDKInfo.Create<SDK_BaseSystem, SDK_FallbackSystem, SDK_FallbackSystem>();
+                if (cachedSystemSDKInfo == value)
+                {
+                    return;
+                }
+
+#if UNITY_EDITOR
+                DestroyImmediate(cachedSystemSDK);
+#else
+                Destroy(cachedSystemSDK);
+#endif
+                cachedSystemSDK = null;
+
+                cachedSystemSDKInfo = value;
+                HandleSDKInfoSetter();
+            }
+        }
+        /// <summary>
+        /// The info of the SDK to use to utilize room scale boundaries. By setting this to `null` the fallback SDK will be used.
+        /// </summary>
+        public VRTK_SDKInfo boundariesSDKInfo
+        {
+            get
+            {
+                return cachedBoundariesSDKInfo;
+            }
+            set
+            {
+                value = value ?? VRTK_SDKInfo.Create<SDK_BaseBoundaries, SDK_FallbackBoundaries, SDK_FallbackBoundaries>();
+                if (cachedBoundariesSDKInfo == value)
+                {
+                    return;
+                }
+
+#if UNITY_EDITOR
+                DestroyImmediate(cachedBoundariesSDK);
+#else
+                Destroy(cachedBoundariesSDK);
+#endif
+                cachedBoundariesSDK = null;
+
+                cachedBoundariesSDKInfo = value;
+                HandleSDKInfoSetter();
+            }
+        }
+        /// <summary>
+        /// The info of the SDK to use to utilize the VR headset. By setting this to `null` the fallback SDK will be used.
+        /// </summary>
+        public VRTK_SDKInfo headsetSDKInfo
+        {
+            get
+            {
+                return cachedHeadsetSDKInfo;
+            }
+            set
+            {
+                value = value ?? VRTK_SDKInfo.Create<SDK_BaseHeadset, SDK_FallbackHeadset, SDK_FallbackHeadset>();
+                if (cachedHeadsetSDKInfo == value)
+                {
+                    return;
+                }
+
+#if UNITY_EDITOR
+                DestroyImmediate(cachedHeadsetSDK);
+#else
+                Destroy(cachedHeadsetSDK);
+#endif
+                cachedHeadsetSDK = null;
+
+                cachedHeadsetSDKInfo = value;
+                HandleSDKInfoSetter();
+            }
+        }
+        /// <summary>
+        /// The info of the SDK to use to utilize the input devices. By setting this to `null` the fallback SDK will be used.
+        /// </summary>
+        public VRTK_SDKInfo controllerSDKInfo
+        {
+            get
+            {
+                return cachedControllerSDKInfo;
+            }
+            set
+            {
+                value = value ?? VRTK_SDKInfo.Create<SDK_BaseController, SDK_FallbackController, SDK_FallbackController>();
+                if (cachedControllerSDKInfo == value)
+                {
+                    return;
+                }
+
+#if UNITY_EDITOR
+                DestroyImmediate(cachedControllerSDK);
+#else
+                Destroy(cachedControllerSDK);
+#endif
+                cachedControllerSDK = null;
+
+                cachedControllerSDKInfo = value;
+                HandleSDKInfoSetter();
+            }
+        }
 
         [Tooltip("A reference to the GameObject that is the user's boundary or play area, most likely provided by the SDK's Camera Rig.")]
         public GameObject actualBoundaries;
@@ -78,143 +205,445 @@ namespace VRTK
         public GameObject scriptAliasRightController;
 
         /// <summary>
-        /// The GetSystemSDK method returns the selected system SDK
+        /// Specifies the fallback SDK types for every base SDK type.
         /// </summary>
-        /// <returns>The currently selected System SDK</returns>
+        private static readonly Dictionary<Type, Type> SDKFallbackTypesByBaseType = new Dictionary<Type, Type>
+        {
+            { typeof(SDK_BaseSystem), typeof(SDK_FallbackSystem) },
+            { typeof(SDK_BaseBoundaries), typeof(SDK_FallbackBoundaries) },
+            { typeof(SDK_BaseHeadset), typeof(SDK_FallbackHeadset) },
+            { typeof(SDK_BaseController), typeof(SDK_FallbackController) }
+        };
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// The previously active scene's path. Used to call <see cref="AutoManageScriptingDefineSymbolsAndPopulateObjectReferences"/> when the currently active scene changes. See the static constructor for the usage.
+        /// </summary>
+        private static string PreviousActiveScenePath;
+#endif
+
+        [SerializeField]
+        private VRTK_SDKInfo cachedSystemSDKInfo = VRTK_SDKInfo.Create<SDK_BaseSystem, SDK_FallbackSystem, SDK_FallbackSystem>();
+        [SerializeField]
+        private VRTK_SDKInfo cachedBoundariesSDKInfo = VRTK_SDKInfo.Create<SDK_BaseBoundaries, SDK_FallbackBoundaries, SDK_FallbackBoundaries>();
+        [SerializeField]
+        private VRTK_SDKInfo cachedHeadsetSDKInfo = VRTK_SDKInfo.Create<SDK_BaseHeadset, SDK_FallbackHeadset, SDK_FallbackHeadset>();
+        [SerializeField]
+        private VRTK_SDKInfo cachedControllerSDKInfo = VRTK_SDKInfo.Create<SDK_BaseController, SDK_FallbackController, SDK_FallbackController>();
+
+        private SDK_BaseSystem cachedSystemSDK;
+        private SDK_BaseBoundaries cachedBoundariesSDK;
+        private SDK_BaseHeadset cachedHeadsetSDK;
+        private SDK_BaseController cachedControllerSDK;
+
+        /// <summary>
+        /// The GetSystemSDK method returns the selected system SDK.
+        /// </summary>
+        /// <returns>The currently selected system SDK.</returns>
         public SDK_BaseSystem GetSystemSDK()
         {
-            SDK_BaseSystem returnSDK = null;
-            switch (systemSDK)
+            if (cachedSystemSDK == null)
             {
-                case SupportedSDKs.SteamVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SteamVRSystem>();
-                    break;
-                case SupportedSDKs.OculusVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_OculusVRSystem>();
-                    break;
-                case SupportedSDKs.Daydream:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_DaydreamSystem>();
-                    break;
-                case SupportedSDKs.Simulator:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SimSystem>();
-                    break;
-                case SupportedSDKs.XimmerseVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_XimmerseVRSystem>();
-                    break;
-                default:
-                    Debug.LogError("No valid System SDK has been selected. If you're seeing this error in Unity Edit mode, then try selecting the GameObject with the `VRTK_SDKManager` script and selecting a valid System SDK from the dropdown list.");
-                    returnSDK = ScriptableObject.CreateInstance<SDK_FallbackSystem>();
-                    break;
+                HandleSDKGetter<SDK_BaseSystem>("System", systemSDKInfo, InstalledSystemSDKInfos);
+                cachedSystemSDK = (SDK_BaseSystem)ScriptableObject.CreateInstance(systemSDKInfo.type);
             }
-            return returnSDK;
+
+            return cachedSystemSDK;
         }
 
         /// <summary>
-        /// The GetHeadsetSDK method returns the selected headset SDK
+        /// The GetBoundariesSDK method returns the selected boundaries SDK.
         /// </summary>
-        /// <returns>The currently selected Headset SDK</returns>
-        public SDK_BaseHeadset GetHeadsetSDK()
-        {
-            SDK_BaseHeadset returnSDK = null;
-            switch (headsetSDK)
-            {
-                case SupportedSDKs.SteamVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SteamVRHeadset>();
-                    break;
-                case SupportedSDKs.OculusVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_OculusVRHeadset>();
-                    break;
-                case SupportedSDKs.Daydream:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_DaydreamHeadset>();
-                    break;
-                case SupportedSDKs.Simulator:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SimHeadset>();
-                    break;
-                case SupportedSDKs.XimmerseVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_XimmerseVRHeadset>();
-                    break;
-                default:
-                    Debug.LogError("No valid Headset SDK has been selected. If you're seeing this error in Unity Edit mode, then try selecting the GameObject with the `VRTK_SDKManager` script and selecting a valid Headset SDK from the dropdown list.");
-                    returnSDK = ScriptableObject.CreateInstance<SDK_FallbackHeadset>();
-                    break;
-            }
-            return returnSDK;
-        }
-
-        /// <summary>
-        /// The GetControllerSDK method returns the selected controller SDK
-        /// </summary>
-        /// <returns>The currently selected Controller SDK</returns>
-        public SDK_BaseController GetControllerSDK()
-        {
-            SDK_BaseController returnSDK = null;
-            switch (controllerSDK)
-            {
-                case SupportedSDKs.SteamVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SteamVRController>();
-                    break;
-                case SupportedSDKs.OculusVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_OculusVRController>();
-                    break;
-                case SupportedSDKs.Daydream:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_DaydreamController>();
-                    break;
-                case SupportedSDKs.Simulator:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SimController>();
-                    break;
-                case SupportedSDKs.XimmerseVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_XimmerseVRController>();
-                    break;
-                default:
-                    Debug.LogError("No valid Controller SDK has been selected. If you're seeing this error in Unity Edit mode, then try selecting the GameObject with the `VRTK_SDKManager` script and selecting a valid Controller SDK from the dropdown list.");
-                    returnSDK = ScriptableObject.CreateInstance<SDK_FallbackController>();
-                    break;
-            }
-            return returnSDK;
-        }
-
-        /// <summary>
-        /// The GetBoundariesSDK method returns the selected boundaries SDK
-        /// </summary>
-        /// <returns>The currently selected Boundaries SDK</returns>
+        /// <returns>The currently selected boundaries SDK.</returns>
         public SDK_BaseBoundaries GetBoundariesSDK()
         {
-            SDK_BaseBoundaries returnSDK = null;
-            switch (boundariesSDK)
+            if (cachedBoundariesSDK == null)
             {
-                case SupportedSDKs.SteamVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SteamVRBoundaries>();
-                    break;
-                case SupportedSDKs.OculusVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_OculusVRBoundaries>();
-                    break;
-                case SupportedSDKs.Daydream:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_DaydreamBoundaries>();
-                    break;
-                case SupportedSDKs.Simulator:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_SimBoundaries>();
-                    break;
-                case SupportedSDKs.XimmerseVR:
-                    returnSDK = ScriptableObject.CreateInstance<SDK_XimmerseVRBoundaries>();
-                    break;
-                default:
-                    Debug.LogError("No valid Boundaries SDK has been selected. If you're seeing this error in Unity Edit mode, then try selecting the GameObject with the `VRTK_SDKManager` script and selecting a valid Boundaries SDK from the dropdown list.");
-                    returnSDK = ScriptableObject.CreateInstance<SDK_FallbackBoundaries>();
-                    break;
+                HandleSDKGetter<SDK_BaseBoundaries>("Boundaries", boundariesSDKInfo, InstalledBoundariesSDKInfos);
+                cachedBoundariesSDK = (SDK_BaseBoundaries)ScriptableObject.CreateInstance(boundariesSDKInfo.type);
             }
-            return returnSDK;
+
+            return cachedBoundariesSDK;
+        }
+
+        /// <summary>
+        /// The GetHeadsetSDK method returns the selected headset SDK.
+        /// </summary>
+        /// <returns>The currently selected headset SDK.</returns>
+        public SDK_BaseHeadset GetHeadsetSDK()
+        {
+            if (cachedHeadsetSDK == null)
+            {
+                HandleSDKGetter<SDK_BaseHeadset>("Headset", headsetSDKInfo, InstalledHeadsetSDKInfos);
+                cachedHeadsetSDK = (SDK_BaseHeadset)ScriptableObject.CreateInstance(headsetSDKInfo.type);
+            }
+
+            return cachedHeadsetSDK;
+        }
+
+        /// <summary>
+        /// The GetControllerSDK method returns the selected controller SDK.
+        /// </summary>
+        /// <returns>The currently selected controller SDK.</returns>
+        public SDK_BaseController GetControllerSDK()
+        {
+            if (cachedControllerSDK == null)
+            {
+                HandleSDKGetter<SDK_BaseController>("Controller", controllerSDKInfo, InstalledControllerSDKInfos);
+                cachedControllerSDK = (SDK_BaseController)ScriptableObject.CreateInstance(controllerSDKInfo.type);
+            }
+
+            return cachedControllerSDK;
+        }
+
+        /// <summary>
+        /// Populates the object references by using the currently set SDKs.
+        /// </summary>
+        /// <param name="force">Whether to ignore <see cref="autoPopulateObjectReferences"/> while deciding to populate.</param>
+        public void PopulateObjectReferences(bool force)
+        {
+            if (!(force || autoPopulateObjectReferences))
+            {
+                return;
+            }
+
+            SDK_BaseBoundaries boundariesSDK = GetBoundariesSDK();
+            SDK_BaseHeadset headsetSDK = GetHeadsetSDK();
+            SDK_BaseController controllerSDK = GetControllerSDK();
+
+            Transform playAreaTransform = boundariesSDK.GetPlayArea();
+            Transform headsetTransform = headsetSDK.GetHeadset();
+
+            actualBoundaries = playAreaTransform == null ? null : playAreaTransform.gameObject;
+            actualHeadset = headsetTransform == null ? null : headsetTransform.gameObject;
+            actualLeftController = controllerSDK.GetControllerLeftHand(true);
+            actualRightController = controllerSDK.GetControllerRightHand(true);
+            modelAliasLeftController = controllerSDK.GetControllerModel(SDK_BaseController.ControllerHand.Left);
+            modelAliasRightController = controllerSDK.GetControllerModel(SDK_BaseController.ControllerHand.Right);
+        }
+
+        /// <summary>
+        /// Manages (i.e. adds and removes) the scripting define symbols of the <see cref="PlayerSettings"/> for the currently set SDK infos. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
+        /// </summary>
+        /// <param name="ignoreAutoManageScriptDefines">Whether to ignore <see cref="autoManageScriptDefines"/> while deciding to manage.</param>
+        /// <param name="ignoreIsActiveAndEnabled">Whether to ignore <see cref="Behaviour.isActiveAndEnabled"/> while deciding to manage.</param>
+        /// <returns>Whether the <see cref="PlayerSettings"/>' scripting define symbols were changed.</returns>
+        public bool ManageScriptingDefineSymbols(bool ignoreAutoManageScriptDefines, bool ignoreIsActiveAndEnabled)
+        {
+            if (!((ignoreAutoManageScriptDefines || autoManageScriptDefines) && (ignoreIsActiveAndEnabled || isActiveAndEnabled)))
+            {
+                return false;
+            }
+
+            //get valid BuildTargetGroups
+            BuildTargetGroup[] targetGroups = Enum.GetValues(typeof(BuildTargetGroup)).Cast<BuildTargetGroup>().Where(group =>
+            {
+                if (group == BuildTargetGroup.Unknown)
+                {
+                    return false;
+                }
+
+                string targetGroupName = Enum.GetName(typeof(BuildTargetGroup), group);
+                FieldInfo targetGroupFieldInfo = typeof(BuildTargetGroup).GetField(targetGroupName, BindingFlags.Public | BindingFlags.Static);
+
+                return targetGroupFieldInfo != null && targetGroupFieldInfo.GetCustomAttributes(typeof(ObsoleteAttribute), false).Length == 0;
+            }).ToArray();
+            var newSymbolsByTargetGroup = new Dictionary<BuildTargetGroup, HashSet<string>>(targetGroups.Length);
+
+            //get current non-removable scripting define symbols
+            foreach (BuildTargetGroup targetGroup in targetGroups)
+            {
+                IEnumerable<string> nonSDKSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(targetGroup)
+                    .Split(';')
+                    .Where(symbol => !symbol.StartsWith(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix, StringComparison.Ordinal));
+                newSymbolsByTargetGroup[targetGroup] = new HashSet<string>(nonSDKSymbols);
+            }
+
+            //get scripting define symbols for active SDKs and check whether the predicates allow us to add the symbols
+            var activeSymbols = new[] { systemSDKInfo.description.symbol, boundariesSDKInfo.description.symbol, headsetSDKInfo.description.symbol, controllerSDKInfo.description.symbol };
+            foreach (string activeSymbol in activeSymbols)
+            {
+                foreach (ScriptingDefineSymbolPredicateInfo predicateInfo in AvailableScriptingDefineSymbolPredicateInfos)
+                {
+                    MethodInfo methodInfo = predicateInfo.methodInfo;
+                    if (predicateInfo.attribute.symbol != activeSymbol || !(bool)methodInfo.Invoke(null, null))
+                    {
+                        continue;
+                    }
+
+                    //add symbols from all predicate attributes on the method since multiple ones are allowed
+                    var allAttributes = (SDK_ScriptingDefineSymbolPredicateAttribute[])methodInfo.GetCustomAttributes(typeof(SDK_ScriptingDefineSymbolPredicateAttribute), false);
+                    foreach (SDK_ScriptingDefineSymbolPredicateAttribute attribute in allAttributes)
+                    {
+                        BuildTargetGroup buildTargetGroup = attribute.buildTargetGroup;
+                        HashSet<string> newSymbols;
+                        if (!newSymbolsByTargetGroup.TryGetValue(buildTargetGroup, out newSymbols))
+                        {
+                            newSymbols = new HashSet<string>();
+                            newSymbolsByTargetGroup[buildTargetGroup] = newSymbols;
+                        }
+
+                        newSymbols.Add(attribute.symbol);
+                    }
+                }
+            }
+
+            var changedSymbols = false;
+
+            //apply new set of scripting define symbols
+            foreach (KeyValuePair<BuildTargetGroup, HashSet<string>> keyValuePair in newSymbolsByTargetGroup)
+            {
+                BuildTargetGroup targetGroup = keyValuePair.Key;
+                string[] currentSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(targetGroup)
+                    .Split(';')
+                    .Distinct()
+                    .OrderBy(symbol => symbol, StringComparer.Ordinal)
+                    .ToArray();
+                string[] newSymbols = keyValuePair.Value.OrderBy(symbol => symbol, StringComparer.Ordinal).ToArray();
+
+                if (currentSymbols.SequenceEqual(newSymbols))
+                {
+                    continue;
+                }
+
+                PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, string.Join(";", newSymbols));
+
+                string[] removedSymbols = currentSymbols.Except(newSymbols).ToArray();
+                if (removedSymbols.Length > 0)
+                {
+                    Debug.Log("Scripting Define Symbols removed from [Project Settings->Player]: " + string.Join(", ", removedSymbols));
+                }
+
+                string[] addedSymbols = newSymbols.Except(currentSymbols).ToArray();
+                if (addedSymbols.Length > 0)
+                {
+                    Debug.Log("Scripting Define Symbols added To [Project Settings->Player]: " + string.Join(", ", addedSymbols));
+                }
+
+                if (!changedSymbols)
+                {
+                    changedSymbols = removedSymbols.Length > 0 || addedSymbols.Length > 0;
+                }
+            }
+
+            return changedSymbols;
+        }
+
+        public string[] GetSimplifiedSDKErrorDescriptions()
+        {
+            var sdkErrorDescriptions = new List<string>();
+
+            var installedSDKInfosList = new[] { InstalledSystemSDKInfos, InstalledBoundariesSDKInfos, InstalledHeadsetSDKInfos, InstalledControllerSDKInfos };
+            var currentSDKInfos = new[] { systemSDKInfo, boundariesSDKInfo, headsetSDKInfo, controllerSDKInfo };
+
+            for (var index = 0; index < installedSDKInfosList.Length; index++)
+            {
+                ReadOnlyCollection<VRTK_SDKInfo> installedSDKInfos = installedSDKInfosList[index];
+                VRTK_SDKInfo currentSDKInfo = currentSDKInfos[index];
+
+                Type baseType = currentSDKInfo.type.BaseType;
+                if (baseType == null)
+                {
+                    continue;
+                }
+
+                string baseName = baseType.Name.Remove(0, typeof(SDK_Base).Name.Length);
+
+                if (!installedSDKInfos.Contains(currentSDKInfo))
+                {
+                    sdkErrorDescriptions.Add(string.Format("The vendor SDK '{0}' is not installed.", currentSDKInfo.description.prettyName));
+                }
+                else if (currentSDKInfo.type == typeof(SDK_FallbackSystem))
+                {
+                    if (currentSDKInfo.originalTypeNameWhenFallbackIsUsed != null)
+                    {
+                        sdkErrorDescriptions.Add(string.Format("The SDK '{0}' doesn't exist anymore. The {1} fallback SDK will be used instead.", currentSDKInfo.originalTypeNameWhenFallbackIsUsed, baseName));
+                    }
+                    else
+                    {
+                        sdkErrorDescriptions.Add("A fallback SDK is used. Make sure to set a real SDK.");
+                    }
+                }
+            }
+
+            return sdkErrorDescriptions.Distinct().ToArray();
+        }
+
+        static VRTK_SDKManager()
+        {
+            PopulateAvailableScriptingDefineSymbolPredicateInfos();
+            PopulateAvailableAndInstalledSDKInfos();
+
+#if UNITY_EDITOR
+            //call AutoManageScriptingDefineSymbolsAndPopulateObjectReferences when the currently active scene changes
+            EditorApplication.hierarchyWindowChanged += () =>
+            {
+                string currentActiveScenePath = SceneManager.GetActiveScene().path;
+                if (currentActiveScenePath != PreviousActiveScenePath)
+                {
+                    PreviousActiveScenePath = currentActiveScenePath;
+                    AutoManageScriptingDefineSymbolsAndPopulateObjectReferences();
+                }
+            };
+#endif
         }
 
         protected virtual void Awake()
         {
             CreateInstance();
-            if (!VRTK_SharedMethods.IsEditTime())
+            SetupHeadset();
+            SetupControllers();
+            GetBoundariesSDK().InitBoundaries();
+        }
+
+        /// <summary>
+        /// Populates <see cref="AvailableScriptingDefineSymbolPredicateInfos"/> with all the available <see cref="SDK_ScriptingDefineSymbolPredicateAttribute"/>s and associated method infos.
+        /// </summary>
+        private static void PopulateAvailableScriptingDefineSymbolPredicateInfos()
+        {
+            var predicateInfos = new List<ScriptingDefineSymbolPredicateInfo>();
+
+            foreach (Type type in typeof(VRTK_SDKManager).Assembly.GetTypes())
             {
-                SetupHeadset();
-                SetupControllers();
-                GetBoundariesSDK().InitBoundaries();
+                for (var index = 0; index < type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Length; index++)
+                {
+                    MethodInfo methodInfo = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)[index];
+                    var predicateAttributes = (SDK_ScriptingDefineSymbolPredicateAttribute[])methodInfo.GetCustomAttributes(typeof(SDK_ScriptingDefineSymbolPredicateAttribute), false);
+                    if (predicateAttributes.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (methodInfo.ReturnType != typeof(bool) || methodInfo.GetParameters().Length != 0)
+                    {
+                        throw new InvalidOperationException(string.Format("The method '{0}' on '{1}' has '{2}' specified but its signature is wrong. The method must take no arguments and return bool.", methodInfo.Name, type, typeof(SDK_ScriptingDefineSymbolPredicateAttribute)));
+                    }
+
+                    predicateInfos.AddRange(predicateAttributes.Select(predicateAttribute => new ScriptingDefineSymbolPredicateInfo(predicateAttribute, methodInfo)));
+                }
+            }
+
+            predicateInfos.Sort((x, y) => string.Compare(x.attribute.symbol, y.attribute.symbol, StringComparison.Ordinal));
+
+            AvailableScriptingDefineSymbolPredicateInfos = predicateInfos.AsReadOnly();
+        }
+
+        /// <summary>
+        /// Populates the various lists of available and installed SDK infos.
+        /// </summary>
+        private static void PopulateAvailableAndInstalledSDKInfos()
+        {
+            List<string> symbolsOfInstalledSDKs = AvailableScriptingDefineSymbolPredicateInfos
+                .Where(predicateInfo => (bool)predicateInfo.methodInfo.Invoke(null, null))
+                .Select(predicateInfo => predicateInfo.attribute.symbol)
+                .ToList();
+
+            var availableSystemSDKInfos = new List<VRTK_SDKInfo>();
+            var availableBoundariesSDKInfos = new List<VRTK_SDKInfo>();
+            var availableHeadsetSDKInfos = new List<VRTK_SDKInfo>();
+            var availableControllerSDKInfos = new List<VRTK_SDKInfo>();
+
+            var installedSystemSDKInfos = new List<VRTK_SDKInfo>();
+            var installedBoundariesSDKInfos = new List<VRTK_SDKInfo>();
+            var installedHeadsetSDKInfos = new List<VRTK_SDKInfo>();
+            var installedControllerSDKInfos = new List<VRTK_SDKInfo>();
+
+            PopulateAvailableAndInstalledSDKInfos<SDK_BaseSystem, SDK_FallbackSystem>(availableSystemSDKInfos, installedSystemSDKInfos, symbolsOfInstalledSDKs);
+            PopulateAvailableAndInstalledSDKInfos<SDK_BaseBoundaries, SDK_FallbackBoundaries>(availableBoundariesSDKInfos, installedBoundariesSDKInfos, symbolsOfInstalledSDKs);
+            PopulateAvailableAndInstalledSDKInfos<SDK_BaseHeadset, SDK_FallbackHeadset>(availableHeadsetSDKInfos, installedHeadsetSDKInfos, symbolsOfInstalledSDKs);
+            PopulateAvailableAndInstalledSDKInfos<SDK_BaseController, SDK_FallbackController>(availableControllerSDKInfos, installedControllerSDKInfos, symbolsOfInstalledSDKs);
+
+            AvailableSystemSDKInfos = availableSystemSDKInfos.AsReadOnly();
+            AvailableBoundariesSDKInfos = availableBoundariesSDKInfos.AsReadOnly();
+            AvailableHeadsetSDKInfos = availableHeadsetSDKInfos.AsReadOnly();
+            AvailableControllerSDKInfos = availableControllerSDKInfos.AsReadOnly();
+
+            InstalledSystemSDKInfos = installedSystemSDKInfos.AsReadOnly();
+            InstalledBoundariesSDKInfos = installedBoundariesSDKInfos.AsReadOnly();
+            InstalledHeadsetSDKInfos = installedHeadsetSDKInfos.AsReadOnly();
+            InstalledControllerSDKInfos = installedControllerSDKInfos.AsReadOnly();
+        }
+
+        /// <summary>
+        /// Populates the lists of available and installed SDK infos for a specific SDK base type.
+        /// </summary>
+        /// <typeparam name="BaseType">The SDK base type of which to populate the lists for. Must be a subclass of <see cref="SDK_Base"/>.</typeparam>
+        /// <typeparam name="FallbackType">The SDK type to fall back on if problems occur. Must be a subclass of <typeparamref name="BaseType"/>.</typeparam>
+        /// <param name="availableSDKInfos">The list of available SDK infos to populate.</param>
+        /// <param name="installedSDKInfos">The list of installed SDK infos to populate.</param>
+        /// <param name="symbolsOfInstalledSDKs">The list of symbols of all the installed SDKs.</param>
+        private static void PopulateAvailableAndInstalledSDKInfos<BaseType, FallbackType>(List<VRTK_SDKInfo> availableSDKInfos, List<VRTK_SDKInfo> installedSDKInfos, ICollection<string> symbolsOfInstalledSDKs) where BaseType : SDK_Base where FallbackType : BaseType
+        {
+            Type baseType = typeof(BaseType);
+            Type fallbackType = SDKFallbackTypesByBaseType[baseType];
+
+            availableSDKInfos.Add(VRTK_SDKInfo.Create<BaseType, FallbackType, FallbackType>());
+            availableSDKInfos.AddRange(baseType.Assembly.GetExportedTypes()
+                .Where(type => type.IsSubclassOf(baseType) && type != fallbackType && !type.IsAbstract)
+                .Select<Type, VRTK_SDKInfo>(VRTK_SDKInfo.Create<BaseType, FallbackType>));
+            availableSDKInfos.Sort((x, y) => x.description.prettyName == "Fallback"
+                ? -1 //the fallback SDK should always be the first SDK in the list
+                : string.Compare(x.description.prettyName, y.description.prettyName, StringComparison.Ordinal));
+
+            installedSDKInfos.AddRange(availableSDKInfos.Where(info =>
+            {
+                string symbol = info.description.symbol;
+                return string.IsNullOrEmpty(symbol) || symbolsOfInstalledSDKs.Contains(symbol);
+            }));
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Calls <see cref="ManageScriptingDefineSymbols"/> and <see cref="PopulateObjectReferences"/> (both without forcing) at the appropriate times when in the editor.
+        /// </summary>
+        [DidReloadScripts]
+        private static void AutoManageScriptingDefineSymbolsAndPopulateObjectReferences()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                return;
+            }
+
+            RemoveLegacyScriptingDefineSymbols();
+
+            var sdkManager = FindObjectOfType<VRTK_SDKManager>();
+            if (sdkManager)
+            {
+                sdkManager.CreateInstance();
+            }
+
+            if (instance != null && !instance.ManageScriptingDefineSymbols(false, false))
+            {
+                instance.PopulateObjectReferences(false);
+            }
+
+            PreviousActiveScenePath = SceneManager.GetActiveScene().path;
+        }
+
+        /// <summary>
+        /// Removes scripting define symbols used by previous VRTK versions.
+        /// </summary>
+        private static void RemoveLegacyScriptingDefineSymbols()
+        {
+            string[] currentSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone)
+                .Split(';')
+                .Distinct()
+                .OrderBy(symbol => symbol, StringComparer.Ordinal)
+                .ToArray();
+            string[] newSymbols = currentSymbols.Where(symbol => !symbol.StartsWith("VRTK_SDK_", StringComparison.Ordinal)).ToArray();
+
+            if (!currentSymbols.SequenceEqual(newSymbols))
+            {
+                PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, string.Join(";", newSymbols));
+
+                string[] removedSymbols = currentSymbols.Except(newSymbols).ToArray();
+                if (removedSymbols.Length > 0)
+                {
+                    Debug.Log("Legacy (i.e. used by previous VRTK versions only) Scripting Define Symbols removed from [Project Settings->Player]: " + string.Join(", ", removedSymbols));
+                }
             }
         }
+#endif
 
         private void SetupHeadset()
         {
@@ -226,8 +655,7 @@ namespace VRTK
 
         private void SetupControllers()
         {
-            if (actualLeftController && 
-                !actualLeftController.GetComponent<VRTK_TrackedController>())
+            if (actualLeftController && !actualLeftController.GetComponent<VRTK_TrackedController>())
             {
                 actualLeftController.AddComponent<VRTK_TrackedController>();
             }
@@ -253,30 +681,125 @@ namespace VRTK
             if (instance == null)
             {
                 instance = this;
+
+                string sdkErrorDescriptions = string.Join("\n- ", GetSimplifiedSDKErrorDescriptions());
+                if (!string.IsNullOrEmpty(sdkErrorDescriptions))
+                {
+                    sdkErrorDescriptions = "- " + sdkErrorDescriptions;
+                    Debug.LogError("There are some errors because of the current SDK Manager setup:\n" + sdkErrorDescriptions);
+                }
+
+                if (persistOnLoad && !VRTK_SharedMethods.IsEditTime())
+                {
+                    DontDestroyOnLoad(gameObject);
+                }
             }
             else if (instance != this)
             {
                 Destroy(gameObject);
             }
+        }
 
-            if (persistOnLoad && !VRTK_SharedMethods.IsEditTime())
+        /// <summary>
+        /// Handles the various SDK getters by logging potential errors.
+        /// </summary>
+        /// <typeparam name="BaseType">The SDK base type of which to handle the getter for. Must be a subclass of <see cref="SDK_Base"/>.</typeparam>
+        /// <param name="prettyName">The pretty name of the base SDK to use when logging errors.</param>
+        /// <param name="info">The SDK info of which the SDK getter was called.</param>
+        /// <param name="installedInfos">The installed SDK infos of which the SDK getter was called.</param>
+        private static void HandleSDKGetter<BaseType>(string prettyName, VRTK_SDKInfo info, IEnumerable<VRTK_SDKInfo> installedInfos) where BaseType : SDK_Base
+        {
+            if (VRTK_SharedMethods.IsEditTime())
             {
-                DontDestroyOnLoad(gameObject);
+                return;
+            }
+
+            string sdkErrorDescription = GetSDKErrorDescription<BaseType>(prettyName, info, installedInfos);
+            if (!string.IsNullOrEmpty(sdkErrorDescription))
+            {
+                Debug.LogError(sdkErrorDescription);
             }
         }
-    }
 
-    public class VRTK_SDKDetails
-    {
-        public string defineSymbol;
-        public string prettyName;
-        public string checkType;
-
-        public VRTK_SDKDetails(string givenDefineSymbol, string givenPrettyName, string givenCheckType)
+        /// <summary>
+        /// Handles the various SDK info setters by making sure to automatically manage the scripting define symbols or populate the object references if the SDK Manager is set to do so.
+        /// </summary>
+        private void HandleSDKInfoSetter()
         {
-            defineSymbol = givenDefineSymbol;
-            prettyName = givenPrettyName;
-            checkType = givenCheckType;
+#if UNITY_EDITOR
+            if (!ManageScriptingDefineSymbols(false, false))
+            {
+                PopulateObjectReferences(false);
+            }
+#else
+            PopulateObjectReferences(false);
+#endif
+        }
+
+        /// <summary>
+        /// Returns an error description in case any of these are true for the current SDK info:
+        /// <list type="bullet">
+        /// <item> <description>Its type doesn't exist anymore.</description> </item>
+        /// <item> <description>It's a fallback SDK.</description> </item>
+        /// <item> <description>It doesn't have its scripting define symbols added.</description> </item>
+        /// <item> <description>It's missing its vendor SDK.</description> </item>
+        /// </list>
+        /// </summary>
+        /// <typeparam name="BaseType">The SDK base type of which to return the error description for. Must be a subclass of <see cref="SDK_Base"/>.</typeparam>
+        /// <param name="prettyName">The pretty name of the base SDK to use when returning error descriptions.</param>
+        /// <param name="info">The SDK info of which to return the error description for.</param>
+        /// <param name="installedInfos">The installed SDK infos.</param>
+        /// <returns>An error description if there is one, else <see langword="null"/>.</returns>
+        private static string GetSDKErrorDescription<BaseType>(string prettyName, VRTK_SDKInfo info, IEnumerable<VRTK_SDKInfo> installedInfos) where BaseType : SDK_Base
+        {
+            Type selectedType = info.type;
+            Type baseType = typeof(BaseType);
+            Type fallbackType = SDKFallbackTypesByBaseType[baseType];
+
+            if (selectedType == fallbackType)
+            {
+                return string.Format("The fallback {0} SDK is being used because there is no other {0} SDK set in the SDK Manager.", prettyName);
+            }
+
+            if (!baseType.IsAssignableFrom(selectedType) || fallbackType.IsAssignableFrom(selectedType))
+            {
+                string description = string.Format("The fallback {0} SDK is being used despite being set to '{1}'.", prettyName, selectedType.Name);
+
+                if (installedInfos.Select(installedInfo => installedInfo.type).Contains(selectedType))
+                {
+                    return description + " Its needed scripting define symbols are not added. You can click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and choose to automatically let the manager handle the scripting define symbols.";
+                }
+
+                return description + " The needed vendor SDK isn't installed.";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// A helper class that simply holds references to both the <see cref="SDK_ScriptingDefineSymbolPredicateAttribute"/> and the method info of the method the attribute is defined on.
+        /// </summary>
+        public sealed class ScriptingDefineSymbolPredicateInfo
+        {
+            /// <summary>
+            /// The predicate attribute.
+            /// </summary>
+            public readonly SDK_ScriptingDefineSymbolPredicateAttribute attribute;
+            /// <summary>
+            /// The method info of the method the attribute is defined on.
+            /// </summary>
+            public readonly MethodInfo methodInfo;
+
+            /// <summary>
+            /// Constructs a new instance with the specified predicate attribute and associated method info.
+            /// </summary>
+            /// <param name="attribute">The predicate attribute.</param>
+            /// <param name="methodInfo">The method info of the method the attribute is defined on.</param>
+            public ScriptingDefineSymbolPredicateInfo(SDK_ScriptingDefineSymbolPredicateAttribute attribute, MethodInfo methodInfo)
+            {
+                this.attribute = attribute;
+                this.methodInfo = methodInfo;
+            }
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -3,6 +3,9 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Reflection;
+#if UNITY_EDITOR
+    using UnityEditor;
+#endif
 
     /// <summary>
     /// The Shared Methods script is a collection of reusable static methods that are used across a range of different scripts.
@@ -164,7 +167,11 @@ namespace VRTK
         /// <returns>Returns true if Unity is in the Unity Editor and not in play mode.</returns>
         public static bool IsEditTime()
         {
-            return (Application.isEditor && !Application.isPlaying);
+#if UNITY_EDITOR
+            return !EditorApplication.isPlayingOrWillChangePlaymode;
+#else
+            return false;
+#endif
         }
 
         private static float ColorPercent(float value, float percent)


### PR DESCRIPTION
This is a part of #842.

---

The list of supported SDKs in VRTK is fixed because they are hard coded
into the SDK manager (and its editor). This change modifies the SDK
manager so it looks up the available SDKs by checking the code base for
classes that inherit from one of the base SDK classes. This allows to
create and use additional SDKs without touching the existing VRTK
codebase at all.

Sharing of SDK implementations in a private group of people (e.g. where
everyone signed an NDA) is now possible without needing to share patches
to the VRTK codebase. There is no reason anymore to keep up with changes
to the parts of VRTK one changed to use their own SDK implementations.

To allow for easy specifying of SDK implementations a new "SDK
description" attribute is added. Another "predicate" attribute allows to
mark a static method as a predicate for SDK purposes. The method signals
whether to add or remove the scripting define symbol that is specified
by the attribute by returning true or false respectively. Marking the
same method with multiple predicate attributes is allowed.

The existing SDK implementations have been updated to make use of both
attributes. Usage of the SteamVR plugin in VRTK is now simplified by
using the predicate attribute to add a scripting define symbol that
defines what version of the plugin is currently used in addition to
defining the generic SteamVR SDK symbol.

If a set SDK doesn't exist anymore (e.g. the SDK class was removed) the
SDK manager will use the corresponding fallback SDK instead and log an
error so the problem is known about. The editor shows that error, too,
but won't remove the set SDK from its list of selectable SDKs until the
user overrides it with another SDK. It shows the name of the missing
class in that case instead.

The SDK manager's editor is updated to allow selecting one of the
discovered SDKs. Logic that previously handled the scripting define
symbols is now moved to the SDK manager class itself in form of public
methods. This allows to build scripts that handle automatic building for
different stores as Oculus Home doesn't allow to include SteamVR/OpenVR
libraries, for example. The automatic populating of the SDK object
references like the Linked Objects and Alias Objects is moved from the
editor to a new setting on the SDK manager itself. This has a public
method to trigger manually, too.

Additionally the editor was changed to support undo/redo for all the
possible changes. Proper error messages and hints are now shown in the
editor if needed, too.

The existing auto-managing of the scripting define symbols is now done
whenever needed. This means loading a scene with an active SDK manager
in it will make sure to manage the symbols if the SDK managers setting
says to do so. The behavior for the auto-populating of the SDK object
references is the same with this change. The idea is to always make sure
the current setup is correct for a used SDK manager.

---

SDKs themselves:
- Now inherit from the new `public abstract class SDK_Base : ScriptableObject { }` to give some type safety for the various kinds of SDKs (system, boundaries, headset, controller).
- SDKs specify their "description" by adding a C# attribute called `SDK_DescriptionAttribute` to their class. The existing SDKs are updated to have this attribute. Each SDK has their own attribute because VRTK allows to implement an SDK without implementing all the other SDK kinds with it (e.g. it's possible to provide a controller SDK without a System, Boundaries or Headset SDK).

`VRTK_SDKManager`:
- doesn't need to run in the editor anymore now:
`PopulateAvailableAndInstalledSDKInfos` is added and is called in the editor and on build startup to make sure the public static fields `available*SDKInfos` and `installed*SDKInfos` are **always** up to date.
- now is able to be used in the build pipeline easily with the new method `ManageScriptingDefineSymbols`. This will make sure the current scripting define symbols are set for the current SDKs. This method is also used whenever something is changed using the inspector on the SDK manager.
- The SDKs to use are adjustable using new `*SDKInfo` properties like `systemSDKInfo`. They are of a new type called `SDKInfo<BaseType>`. You create one by providing the type of an SDK using `SDKInfo<BaseType>.FromType<ActualType>`. An example would be `SDKInfo.FromType<SDK_SteamVRController>`.
- `SDKInfo<BaseType>` is serialized using the `ActualType`'s [`FullName`](https://msdn.microsoft.com/en-us/library/system.type.fullname(v=vs.90).aspx). That allows to uniquely identify the SDK that is set. That's what `AvailableSDKInfo<BaseType>.FromTypeName<FallbackType>` is for.
- `SDK_DescriptionAttribute.Fallback` represents a fallback SDK (for all kinds of SDK endpoints).
- If a set SDK isn't available anymore the fallback SDK is automatically used and an error is logged. Additional errors are only logged when the fallback SDK is actually used (by the instantiation of the current set SDK via the `Get*SDK` methods). The set SDK that was serialized isn't changed to the fallback SDK and left as is in that case to allow for fixing stuff without changing the setup.
- All the SDK infos and SDKs themselves are now cached. The cache is invalidated whenever needed of course.

`VRTK_SDKManagerEditor`:
- is updated to allow to set SDKs by providing a list of the available ones.
- allows proper usage of undo/redo for all the features now (it even automatically switches the scripting define symbols according to the undo/redo!).
- explains why only a subset of all the SDKs is available in the Quick Select dropdown. It only shows this explanation when it's actually needed, i.e. there are some SDKs not available for all the endpoints/kinds (System, Boundaries, Headset, Controller).
- explains when a set SDK is not available and therefore tells you that it's falling back to the fallback SDK instead. It leaves the setting for that missing SDK alone, though. So the missing SDK can actually be seen by type name and is only removed from the SDK list after setting another SDK in its place.