### PR TITLE
fix(Interaction): prevent rotator track applying velocity on release

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_RotatorTrackGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_RotatorTrackGrabAttach.cs
@@ -15,6 +15,16 @@ namespace VRTK.GrabAttachMechanics
     public class VRTK_RotatorTrackGrabAttach : VRTK_TrackObjectGrabAttach
     {
         /// <summary>
+        /// The StopGrab method ends the grab of the current object and cleans up the state.
+        /// </summary>
+        /// <param name="applyGrabbingObjectVelocity">If true will apply the current velocity of the grabbing object to the grabbed object on release.</param>
+        public override void StopGrab(bool applyGrabbingObjectVelocity)
+        {
+            isReleasable = false;
+            base.StopGrab(applyGrabbingObjectVelocity);
+        }
+
+        /// <summary>
         /// The ProcessFixedUpdate method is run in every FixedUpdate method on the interactable object. It applies a force to the grabbed object to move it in the direction of the grabbing object.
         /// </summary>
         public override void ProcessFixedUpdate()

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_TrackObjectGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_TrackObjectGrabAttach.cs
@@ -19,13 +19,18 @@ namespace VRTK.GrabAttachMechanics
         [Tooltip("The maximum distance the grabbing controller is away from the object before it is automatically dropped.")]
         public float detachDistance = 1f;
 
+        protected bool isReleasable = true;
+
         /// <summary>
         /// The StopGrab method ends the grab of the current object and cleans up the state.
         /// </summary>
         /// <param name="applyGrabbingObjectVelocity">If true will apply the current velocity of the grabbing object to the grabbed object on release.</param>
         public override void StopGrab(bool applyGrabbingObjectVelocity)
         {
-            ReleaseObject(applyGrabbingObjectVelocity);
+            if (isReleasable)
+            {
+                ReleaseObject(applyGrabbingObjectVelocity);
+            }
             base.StopGrab(applyGrabbingObjectVelocity);
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3326,6 +3326,17 @@ This is ideal for hinged joints on items such as wheels or doors.
 
 ### Class Methods
 
+#### StopGrab/1
+
+  > `public override void StopGrab(bool applyGrabbingObjectVelocity)`
+
+  * Parameters
+   * `bool applyGrabbingObjectVelocity` - If true will apply the current velocity of the grabbing object to the grabbed object on release.
+  * Returns
+   * _none_
+
+The StopGrab method ends the grab of the current object and cleans up the state.
+
 #### ProcessFixedUpdate/0
 
   > `public override void ProcessFixedUpdate()`


### PR DESCRIPTION
The rotator track mechanic should not apply thrown velocity when the
interactable object is released otherwise it causes the joint to
bounce back.

The fix for this is to override the `StopGrab` method on the Track
Object and prevent it from doing the ReleaseObject method which
is what adds the velocity.