### PR TITLE
fix(Interaction): scale of the outline highlighter cloned object - fixes #828, #850

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -145,10 +145,11 @@ namespace VRTK.Highlighters
             }
 
             highlightModel = new GameObject(name + "_HighlightModel");
+            highlightModel.transform.SetParent(copyModel.transform.parent, false);
+            highlightModel.transform.localPosition = copyModel.transform.localPosition;
+            highlightModel.transform.localRotation = copyModel.transform.localRotation;
+            highlightModel.transform.localScale = copyModel.transform.localScale;
             highlightModel.transform.SetParent(transform);
-            highlightModel.transform.position = copyModel.transform.position;
-            highlightModel.transform.rotation = copyModel.transform.rotation;
-            highlightModel.transform.localScale = Vector3.one;
 
             foreach (var component in copyModel.GetComponents<Component>())
             {


### PR DESCRIPTION
Change the way the transform of the OutlineObjectCopyHighlighter cloned
object is computed.

First set the same parent as the original object, copy the local
transform, then set the parent to `transform`, the owner of the
OutlineObjectCopyHighlighter component, as it was before this commit.

This resolves both PR #828 and PR #850.

The PR #828 still causes problems with a hierarchy of game objects with
different scaling (e.g customOutlineModel with its own scaling as child
of the game object with its own scaling, holding the
OutlineObjectCopyHighlighter component).

The PR #850 broke the Outline Highlighter setting it as the parent,
preventing the outline to follow the object around.