### PR TITLE
fix(UnityEvents): ensure all unity event helpers initialise event.

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the Teleporting class event.
         /// </summary>
-        public UnityObjectEvent OnTeleporting;
+        public UnityObjectEvent OnTeleporting = new UnityObjectEvent();
         /// <summary>
         /// Emits the Teleported class event.
         /// </summary>
-        public UnityObjectEvent OnTeleported;
+        public UnityObjectEvent OnTeleported = new UnityObjectEvent();
 
         private void SetBasicTeleport()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
@@ -14,27 +14,27 @@
         /// <summary>
         /// Emits the StartFalling class event.
         /// </summary>
-        public UnityObjectEvent OnStartFalling;
+        public UnityObjectEvent OnStartFalling = new UnityObjectEvent();
         /// <summary>
         /// Emits the StopFalling class event.
         /// </summary>
-        public UnityObjectEvent OnStopFalling;
+        public UnityObjectEvent OnStopFalling = new UnityObjectEvent();
         /// <summary>
         /// Emits the StartMoving class event.
         /// </summary>
-        public UnityObjectEvent OnStartMoving;
+        public UnityObjectEvent OnStartMoving = new UnityObjectEvent();
         /// <summary>
         /// Emits the StopMoving class event.
         /// </summary>
-        public UnityObjectEvent OnStopMoving;
+        public UnityObjectEvent OnStopMoving = new UnityObjectEvent();
         /// <summary>
         /// Emits the StartColliding class event.
         /// </summary>
-        public UnityObjectEvent OnStartColliding;
+        public UnityObjectEvent OnStartColliding = new UnityObjectEvent();
         /// <summary>
         /// Emits the StopColliding class event.
         /// </summary>
-        public UnityObjectEvent OnStopColliding;
+        public UnityObjectEvent OnStopColliding = new UnityObjectEvent();
 
         private void SetBodyPhysics()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the ControllerModelVisible class event.
         /// </summary>
-        public UnityObjectEvent OnControllerModelVisible;
+        public UnityObjectEvent OnControllerModelVisible = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerModelInvisible class event.
         /// </summary>
-        public UnityObjectEvent OnControllerModelInvisible;
+        public UnityObjectEvent OnControllerModelInvisible = new UnityObjectEvent();
 
         private void SetControllerAction()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -14,197 +14,197 @@
         /// <summary>
         /// Emits the TriggerPressed class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerPressed;
+        public UnityObjectEvent OnTriggerPressed = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerReleased class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerReleased;
+        public UnityObjectEvent OnTriggerReleased = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerTouchStart class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerTouchStart;
+        public UnityObjectEvent OnTriggerTouchStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerTouchEnd class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerTouchEnd;
+        public UnityObjectEvent OnTriggerTouchEnd = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerHairlineStart class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerHairlineStart;
+        public UnityObjectEvent OnTriggerHairlineStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerHairlineEnd class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerHairlineEnd;
+        public UnityObjectEvent OnTriggerHairlineEnd = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerClicked class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerClicked;
+        public UnityObjectEvent OnTriggerClicked = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerUnclicked class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerUnclicked;
+        public UnityObjectEvent OnTriggerUnclicked = new UnityObjectEvent();
         /// <summary>
         /// Emits the TriggerAxisChanged class event.
         /// </summary>
-        public UnityObjectEvent OnTriggerAxisChanged;
+        public UnityObjectEvent OnTriggerAxisChanged = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the GripPressed class event.
         /// </summary>
-        public UnityObjectEvent OnGripPressed;
+        public UnityObjectEvent OnGripPressed = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripReleased class event.
         /// </summary>
-        public UnityObjectEvent OnGripReleased;
+        public UnityObjectEvent OnGripReleased = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripTouchStart class event.
         /// </summary>
-        public UnityObjectEvent OnGripTouchStart;
+        public UnityObjectEvent OnGripTouchStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripTouchEnd class event.
         /// </summary>
-        public UnityObjectEvent OnGripTouchEnd;
+        public UnityObjectEvent OnGripTouchEnd = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripHairlineStart class event.
         /// </summary>
-        public UnityObjectEvent OnGripHairlineStart;
+        public UnityObjectEvent OnGripHairlineStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripHairlineEnd class event.
         /// </summary>
-        public UnityObjectEvent OnGripHairlineEnd;
+        public UnityObjectEvent OnGripHairlineEnd = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripClicked class event.
         /// </summary>
-        public UnityObjectEvent OnGripClicked;
+        public UnityObjectEvent OnGripClicked = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripUnclicked class event.
         /// </summary>
-        public UnityObjectEvent OnGripUnclicked;
+        public UnityObjectEvent OnGripUnclicked = new UnityObjectEvent();
         /// <summary>
         /// Emits the GripAxisChanged class event.
         /// </summary>
-        public UnityObjectEvent OnGripAxisChanged;
+        public UnityObjectEvent OnGripAxisChanged = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the TouchpadPressed class event.
         /// </summary>
-        public UnityObjectEvent OnTouchpadPressed;
+        public UnityObjectEvent OnTouchpadPressed = new UnityObjectEvent();
         /// <summary>
         /// Emits the TouchpadReleased class event.
         /// </summary>
-        public UnityObjectEvent OnTouchpadReleased;
+        public UnityObjectEvent OnTouchpadReleased = new UnityObjectEvent();
         /// <summary>
         /// Emits the TouchpadTouchStart class event.
         /// </summary>
-        public UnityObjectEvent OnTouchpadTouchStart;
+        public UnityObjectEvent OnTouchpadTouchStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the TouchpadTouchEnd class event.
         /// </summary>
-        public UnityObjectEvent OnTouchpadTouchEnd;
+        public UnityObjectEvent OnTouchpadTouchEnd = new UnityObjectEvent();
         /// <summary>
         /// Emits the TouchpadAxisChanged class event.
         /// </summary>
-        public UnityObjectEvent OnTouchpadAxisChanged;
+        public UnityObjectEvent OnTouchpadAxisChanged = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the ButtonOnePressed class event.
         /// </summary>
-        public UnityObjectEvent OnButtonOnePressed;
+        public UnityObjectEvent OnButtonOnePressed = new UnityObjectEvent();
         /// <summary>
         /// Emits the ButtonOneReleased class event.
         /// </summary>
-        public UnityObjectEvent OnButtonOneReleased;
+        public UnityObjectEvent OnButtonOneReleased = new UnityObjectEvent();
         /// <summary>
         /// Emits the ButtonOneTouchStart class event.
         /// </summary>
-        public UnityObjectEvent OnButtonOneTouchStart;
+        public UnityObjectEvent OnButtonOneTouchStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the ButtonOneTouchEnd class event.
         /// </summary>
-        public UnityObjectEvent OnButtonOneTouchEnd;
+        public UnityObjectEvent OnButtonOneTouchEnd = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the ButtonTwoPressed class event.
         /// </summary>
-        public UnityObjectEvent OnButtonTwoPressed;
+        public UnityObjectEvent OnButtonTwoPressed = new UnityObjectEvent();
         /// <summary>
         /// Emits the ButtonTwoReleased class event.
         /// </summary>
-        public UnityObjectEvent OnButtonTwoReleased;
+        public UnityObjectEvent OnButtonTwoReleased = new UnityObjectEvent();
         /// <summary>
         /// Emits the ButtonTwoTouchStart class event.
         /// </summary>
-        public UnityObjectEvent OnButtonTwoTouchStart;
+        public UnityObjectEvent OnButtonTwoTouchStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the ButtonTwoTouchEnd class event.
         /// </summary>
-        public UnityObjectEvent OnButtonTwoTouchEnd;
+        public UnityObjectEvent OnButtonTwoTouchEnd = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the StartMenuPressed class event.
         /// </summary>
-        public UnityObjectEvent OnStartMenuPressed;
+        public UnityObjectEvent OnStartMenuPressed = new UnityObjectEvent();
         /// <summary>
         /// Emits the StartMenuReleased class event.
         /// </summary>
-        public UnityObjectEvent OnStartMenuReleased;
+        public UnityObjectEvent OnStartMenuReleased = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the AliasPointerOn class event.
         /// </summary>
-        public UnityObjectEvent OnAliasPointerOn;
+        public UnityObjectEvent OnAliasPointerOn = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasPointerOff class event.
         /// </summary>
-        public UnityObjectEvent OnAliasPointerOff;
+        public UnityObjectEvent OnAliasPointerOff = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasPointerSet class event.
         /// </summary>
-        public UnityObjectEvent OnAliasPointerSet;
+        public UnityObjectEvent OnAliasPointerSet = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasGrabOn class event.
         /// </summary>
-        public UnityObjectEvent OnAliasGrabOn;
+        public UnityObjectEvent OnAliasGrabOn = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasGrabOff class event.
         /// </summary>
-        public UnityObjectEvent OnAliasGrabOff;
+        public UnityObjectEvent OnAliasGrabOff = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasUseOn class event.
         /// </summary>
-        public UnityObjectEvent OnAliasUseOn;
+        public UnityObjectEvent OnAliasUseOn = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasUseOff class event.
         /// </summary>
-        public UnityObjectEvent OnAliasUseOff;
+        public UnityObjectEvent OnAliasUseOff = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasMenuOn class event.
         /// </summary>
-        public UnityObjectEvent OnAliasUIClickOn;
+        public UnityObjectEvent OnAliasUIClickOn = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasMenuOff class event.
         /// </summary>
-        public UnityObjectEvent OnAliasUIClickOff;
+        public UnityObjectEvent OnAliasUIClickOff = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasUIClickOn class event.
         /// </summary>
-        public UnityObjectEvent OnAliasMenuOn;
+        public UnityObjectEvent OnAliasMenuOn = new UnityObjectEvent();
         /// <summary>
         /// Emits the AliasUIClickOff class event.
         /// </summary>
-        public UnityObjectEvent OnAliasMenuOff;
+        public UnityObjectEvent OnAliasMenuOff = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerEnabled class event.
         /// </summary>
-        public UnityObjectEvent OnControllerEnabled;
+        public UnityObjectEvent OnControllerEnabled = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerDisabled class event.
         /// </summary>
-        public UnityObjectEvent OnControllerDisabled;
+        public UnityObjectEvent OnControllerDisabled = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerIndexChanged class event.
         /// </summary>
-        public UnityObjectEvent OnControllerIndexChanged;
+        public UnityObjectEvent OnControllerIndexChanged = new UnityObjectEvent();
 
         private void SetControllerEvents()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the WillDashThruObjects class event.
         /// </summary>
-        public UnityObjectEvent OnWillDashThruObjects;
+        public UnityObjectEvent OnWillDashThruObjects = new UnityObjectEvent();
         /// <summary>
         /// Emits the DashedThruObjects class event.
         /// </summary>
-        public UnityObjectEvent OnDashedThruObjects;
+        public UnityObjectEvent OnDashedThruObjects = new UnityObjectEvent();
 
         private void SetDashTeleport()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
@@ -14,15 +14,15 @@
         /// <summary>
         /// Emits the DestinationMarkerEnter class event.
         /// </summary>
-        public UnityObjectEvent OnDestinationMarkerEnter;
+        public UnityObjectEvent OnDestinationMarkerEnter = new UnityObjectEvent();
         /// <summary>
         /// Emits the DestinationMarkerExit class event.
         /// </summary>
-        public UnityObjectEvent OnDestinationMarkerExit;
+        public UnityObjectEvent OnDestinationMarkerExit = new UnityObjectEvent();
         /// <summary>
         /// Emits the DestinationMarkerSet class event.
         /// </summary>
-        public UnityObjectEvent OnDestinationMarkerSet;
+        public UnityObjectEvent OnDestinationMarkerSet = new UnityObjectEvent();
 
         private void SetDestinationMarker()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the HeadsetCollisionDetect class event.
         /// </summary>
-        public UnityObjectEvent OnHeadsetCollisionDetect;
+        public UnityObjectEvent OnHeadsetCollisionDetect = new UnityObjectEvent();
         /// <summary>
         /// Emits the HeadsetCollisionEnded class event.
         /// </summary>
-        public UnityObjectEvent OnHeadsetCollisionEnded;
+        public UnityObjectEvent OnHeadsetCollisionEnded = new UnityObjectEvent();
 
         private void SetHeadsetCollision()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
@@ -14,20 +14,20 @@
         /// <summary>
         /// Emits the ControllerObscured class event.
         /// </summary>
-        public UnityObjectEvent OnControllerObscured;
+        public UnityObjectEvent OnControllerObscured = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerUnobscured class event.
         /// </summary>
-        public UnityObjectEvent OnControllerUnobscured;
+        public UnityObjectEvent OnControllerUnobscured = new UnityObjectEvent();
 
         /// <summary>
         /// Emits the ControllerGlanceEnter class event.
         /// </summary>
-        public UnityObjectEvent OnControllerGlanceEnter;
+        public UnityObjectEvent OnControllerGlanceEnter = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerGlanceExit class event.
         /// </summary>
-        public UnityObjectEvent OnControllerGlanceExit;
+        public UnityObjectEvent OnControllerGlanceExit = new UnityObjectEvent();
 
         private void SetHeadsetControllerAware()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
@@ -14,19 +14,19 @@
         /// <summary>
         /// Emits the HeadsetFadeStart class event.
         /// </summary>
-        public UnityObjectEvent OnHeadsetFadeStart;
+        public UnityObjectEvent OnHeadsetFadeStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the HeadsetFadeComplete class event.
         /// </summary>
-        public UnityObjectEvent OnHeadsetFadeComplete;
+        public UnityObjectEvent OnHeadsetFadeComplete = new UnityObjectEvent();
         /// <summary>
         /// Emits the HeadsetUnfadeStart class event.
         /// </summary>
-        public UnityObjectEvent OnHeadsetUnfadeStart;
+        public UnityObjectEvent OnHeadsetUnfadeStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the HeadsetUnfadeComplete class event.
         /// </summary>
-        public UnityObjectEvent OnHeadsetUnfadeComplete;
+        public UnityObjectEvent OnHeadsetUnfadeComplete = new UnityObjectEvent();
 
         private void SetHeadsetFade()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the ControllerGrabInteractableObject class event.
         /// </summary>
-        public UnityObjectEvent OnControllerGrabInteractableObject;
+        public UnityObjectEvent OnControllerGrabInteractableObject = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerUngrabInteractableObject class event.
         /// </summary>
-        public UnityObjectEvent OnControllerUngrabInteractableObject;
+        public UnityObjectEvent OnControllerUngrabInteractableObject = new UnityObjectEvent();
 
         private void SetInteractGrab()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the ControllerTouchInteractableObject class event.
         /// </summary>
-        public UnityObjectEvent OnControllerTouchInteractableObject;
+        public UnityObjectEvent OnControllerTouchInteractableObject = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerUntouchInteractableObject class event.
         /// </summary>
-        public UnityObjectEvent OnControllerUntouchInteractableObject;
+        public UnityObjectEvent OnControllerUntouchInteractableObject = new UnityObjectEvent();
 
         private void SetInteractTouch()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the ControllerUseInteractableObject class event.
         /// </summary>
-        public UnityObjectEvent OnControllerUseInteractableObject;
+        public UnityObjectEvent OnControllerUseInteractableObject = new UnityObjectEvent();
         /// <summary>
         /// Emits the ControllerUnuseInteractableObject class event.
         /// </summary>
-        public UnityObjectEvent OnControllerUnuseInteractableObject;
+        public UnityObjectEvent OnControllerUnuseInteractableObject = new UnityObjectEvent();
 
         private void SetInteractUse()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -14,27 +14,27 @@
         /// <summary>
         /// Emits the InteractableObjectTouched class event.
         /// </summary>
-        public UnityObjectEvent OnTouch;
+        public UnityObjectEvent OnTouch = new UnityObjectEvent();
         /// <summary>
         /// Emits the InteractableObjectUntouched class event.
         /// </summary>
-        public UnityObjectEvent OnUntouch;
+        public UnityObjectEvent OnUntouch = new UnityObjectEvent();
         /// <summary>
         /// Emits the InteractableObjectGrabbed class event.
         /// </summary>
-        public UnityObjectEvent OnGrab;
+        public UnityObjectEvent OnGrab = new UnityObjectEvent();
         /// <summary>
         /// Emits the InteractableObjectUngrabbed class event.
         /// </summary>
-        public UnityObjectEvent OnUngrab;
+        public UnityObjectEvent OnUngrab = new UnityObjectEvent();
         /// <summary>
         /// Emits the InteractableObjectUsed class event.
         /// </summary>
-        public UnityObjectEvent OnUse;
+        public UnityObjectEvent OnUse = new UnityObjectEvent();
         /// <summary>
         /// Emits the InteractableObjectUnused class event.
         /// </summary>
-        public UnityObjectEvent OnUnuse;
+        public UnityObjectEvent OnUnuse = new UnityObjectEvent();
 
         private void SetInteractableObject()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// Emits the PlayerClimbStarted class event.
         /// </summary>
-        public UnityObjectEvent OnPlayerClimbStarted;
+        public UnityObjectEvent OnPlayerClimbStarted = new UnityObjectEvent();
         /// <summary>
         /// Emits the PlayerClimbEnded class event.
         /// </summary>
-        public UnityObjectEvent OnPlayerClimbEnded;
+        public UnityObjectEvent OnPlayerClimbEnded = new UnityObjectEvent();
 
         private void SetPlayerClimb()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_SnapDropZone_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_SnapDropZone_UnityEvents.cs
@@ -14,19 +14,19 @@
         /// <summary>
         /// Emits the ObjectEnteredSnapDropZone class event.
         /// </summary>
-        public UnityObjectEvent OnObjectEnteredSnapDropZone;
+        public UnityObjectEvent OnObjectEnteredSnapDropZone = new UnityObjectEvent();
         /// <summary>
         /// Emits the ObjectExitedSnapDropZone class event.
         /// </summary>
-        public UnityObjectEvent OnObjectExitedSnapDropZone;
+        public UnityObjectEvent OnObjectExitedSnapDropZone = new UnityObjectEvent();
         /// <summary>
         /// Emits the ObjectSnappedToDropZone class event.
         /// </summary>
-        public UnityObjectEvent OnObjectSnappedToDropZone;
+        public UnityObjectEvent OnObjectSnappedToDropZone = new UnityObjectEvent();
         /// <summary>
         /// Emits the ObjectUnsnappedFromDropZone class event.
         /// </summary>
-        public UnityObjectEvent OnObjectUnsnappedFromDropZone;
+        public UnityObjectEvent OnObjectUnsnappedFromDropZone = new UnityObjectEvent();
 
         private void SetSnapDropZone()
         {

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIPointer_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIPointer_UnityEvents.cs
@@ -14,23 +14,23 @@
         /// <summary>
         /// Emits the UIPointerElementEnter class event.
         /// </summary>
-        public UnityObjectEvent OnUIPointerElementEnter;
+        public UnityObjectEvent OnUIPointerElementEnter = new UnityObjectEvent();
         /// <summary>
         /// Emits the UIPointerElementExit class event.
         /// </summary>
-        public UnityObjectEvent OnUIPointerElementExit;
+        public UnityObjectEvent OnUIPointerElementExit = new UnityObjectEvent();
         /// <summary>
         /// Emits the UIPointerElementClick class event.
         /// </summary>
-        public UnityObjectEvent OnUIPointerElementClick;
+        public UnityObjectEvent OnUIPointerElementClick = new UnityObjectEvent();
         /// <summary>
         /// Emits the UIPointerElementDragStart class event.
         /// </summary>
-        public UnityObjectEvent OnUIPointerElementDragStart;
+        public UnityObjectEvent OnUIPointerElementDragStart = new UnityObjectEvent();
         /// <summary>
         /// Emits the UIPointerElementDragEnd class event.
         /// </summary>
-        public UnityObjectEvent OnUIPointerElementDragEnd;
+        public UnityObjectEvent OnUIPointerElementDragEnd = new UnityObjectEvent();
 
         private void SetUIPointer()
         {


### PR DESCRIPTION
Previously, the Unity Event Helper scripts were not initialising the
event parameters meaning that if the events were used via script then
they would throw a null reference error. They would work in the editor
as Unity would provide a default state for them.

This fix ensures that all events set up a default event and are
no longer null.