### PR TITLE
fix(Teleporter): ensure listener coroutine is not run if disabled - fixes #884

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -57,6 +57,7 @@ namespace VRTK
         private float fadeInTime = 0f;
         private float maxBlinkTransitionSpeed = 1.5f;
         private float maxBlinkDistance = 33f;
+        private Coroutine initaliseListeners;
 
         /// <summary>
         /// The InitDestinationSetListener method is used to register the teleport script to listen to events from the given game object that is used to generate destination markers. Any destination set event emitted by a registered game object will initiate the teleport to the given destination location.
@@ -132,12 +133,16 @@ namespace VRTK
         {
             adjustYForTerrain = false;
             enableTeleport = true;
-            StartCoroutine(InitListenersAtEndOfFrame());
+            initaliseListeners = StartCoroutine(InitListenersAtEndOfFrame());
             VRTK_ObjectCache.registeredTeleporters.Add(this);
         }
 
         protected virtual void OnDisable()
         {
+            if (initaliseListeners != null)
+            {
+                StopCoroutine(initaliseListeners);
+            }
             InitDestinationMarkerListeners(false);
             VRTK_ObjectCache.registeredTeleporters.Remove(this);
         }
@@ -231,7 +236,10 @@ namespace VRTK
         private IEnumerator InitListenersAtEndOfFrame()
         {
             yield return new WaitForEndOfFrame();
-            InitDestinationMarkerListeners(true);
+            if (enabled)
+            {
+                InitDestinationMarkerListeners(true);
+            }
         }
 
         private void InitDestinationMarkerListeners(bool state)


### PR DESCRIPTION
The Teleporter script runs a co-routine at the end of the frame to
register any destination markers. However, if the script is disabled
within the first frame then the co-routine is still executed and
registers the listeners even if they're not required.

This fix only registers the listeners if the teleporter script is
enabled and the co-routine is also cancelled when the script is
disabled.