### PR TITLE
docs(Templates): add new template for code of conduct and issues

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Code of Conduct
+
+Contact: hello@vrtk.io
+
+## Why have a Code of Conduct?
+
+As contributors and maintainers of this project, we are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+
+The goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about VRTK effectively, productively, and respectfully, even in face of disagreements. The Code of Conduct also provides a mechanism for resolving conflicts in the community when they arise.
+
+## Our Values
+
+These are the values VRTK developers should aspire to:
+
+  * Be friendly and welcoming
+  * Be patient
+    * Remember that people have varying communication styles and that not everyone is using their native language. (Meaning and tone can be lost in translation.)
+  * Be thoughtful
+    * Productive communication requires effort. Think about how your words will be interpreted.
+    * Remember that sometimes it is best to refrain entirely from commenting.
+  * Be respectful
+    * In particular, respect differences of opinion. It is important that we resolve disagreements and differing views constructively.
+  * Avoid destructive behavior
+    * Derailing: stay on topic; if you want to talk about something else, start a new conversation.
+    * Unconstructive criticism: don't merely decry the current state of affairs; offer (or at least solicit) suggestions as to how things may be improved.
+    * Snarking (pithy, unproductive, sniping comments).
+
+The following actions are explicitly forbidden:
+
+  * Insulting, demeaning, hateful, or threatening remarks.
+  * Discrimination based on age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+  * Bullying or systematic harassment.
+  * Unwelcome sexual advances.
+  * Incitement to any of these.
+
+## Where does the Code of Conduct apply?
+
+If you participate in or contribute to the VRTK ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
+
+Explicit enforcement of the Code of Conduct applies to the official mediums operated by the VRTK project:
+
+* The official GitHub projects and code reviews.
+* The official VRTK slack channel.
+
+Other VRTK activities (such as conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Such groups must provide their own contact information.
+
+Project maintainers may remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing: hello@vrtk.io. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. **All reports will be kept confidential**.
+
+**The goal of the Code of Conduct is to resolve conflicts in the most harmonious way possible**. We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort. **Do not** post about the issue publicly or try to rally sentiment against a particular individual or group.
+
+## Acknowledgements
+
+This document was based on the Code of Conduct from the Elixir project.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+### Precheck
+
+ * Do not use the issues tracker for help or support (try VRTK Slack channel, Stack Overflow, etc.)
+ * For proposing a new feature, please check existing open and closed issues before creating a duplicate
+ * For bugs, do a quick search and make sure the bug has not yet been reported
+ * Finally, be excellent to each other, and party on dudes!
+
+### Environment
+
+ * Source of VRTK (Unity Asset Store or Github)
+ * Version of VRTK (Unity Asset Store/Github release number) (Github master commit hash)
+ * Version of Unity3D (e.g. Unity 5.4.4f1)
+
+### Steps to reproduce
+
+Attempt to recreate the issue in a VRTK example scene and provide steps to reproduce if possible. Include code samples, errors and stacktraces if appropriate.
+
+### Expected behavior
+
+Briefly describe what you expect should happen
+
+### Current behavior
+
+Briefly describe what is actually happening


### PR DESCRIPTION
New markdown files have been added to outline issue creation template
and to provide a concise code of conduct for the VRTK community to
aspire towards.