### PR TITLE
feat(Locomotion): add new generic touchpad control script

### DIFF
--- a/Assets/VRTK/Examples/017_CameraRig_TouchpadWalking.unity
+++ b/Assets/VRTK/Examples/017_CameraRig_TouchpadWalking.unity
@@ -260,6 +260,9 @@ GameObject:
   - 114: {fileID: 146687109}
   - 114: {fileID: 146687108}
   - 114: {fileID: 146687107}
+  - 114: {fileID: 146687113}
+  - 114: {fileID: 146687112}
+  - 114: {fileID: 146687111}
   m_Layer: 0
   m_Name: LeftController
   m_TagString: Untagged
@@ -381,6 +384,60 @@ MonoBehaviour:
   usePressed: 0
   uiClickPressed: 0
   menuPressed: 0
+--- !u!114 &146687111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 146687105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  axisDescription: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  decelerationDeadzone: 0.01
+  speedMultiplier: 2
+--- !u!114 &146687112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 146687105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  axisDescription: 0
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  decelerationDeadzone: 0.01
+  speedMultiplier: 2
+--- !u!114 &146687113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 146687105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 018581a6a9040b34d83404b882e892a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  primaryActivationButton: 9
+  actionModifierButton: 10
+  deviceForDirection: 0
+  axisDeadzone: {x: 0, y: 0}
+  xAxisActionScript: {fileID: 146687112}
+  yAxisActionScript: {fileID: 146687111}
+  disableOtherControlsOnActive: 1
+  affectOnFalling: 0
+  controlOverrideObject: {fileID: 0}
 --- !u!1 &202006652
 GameObject:
   m_ObjectHideFlags: 0
@@ -393,6 +450,9 @@ GameObject:
   - 114: {fileID: 202006656}
   - 114: {fileID: 202006655}
   - 114: {fileID: 202006654}
+  - 114: {fileID: 202006660}
+  - 114: {fileID: 202006659}
+  - 114: {fileID: 202006658}
   m_Layer: 0
   m_Name: RightController
   m_TagString: Untagged
@@ -514,6 +574,60 @@ MonoBehaviour:
   usePressed: 0
   uiClickPressed: 0
   menuPressed: 0
+--- !u!114 &202006658
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 202006652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  axisDescription: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  decelerationDeadzone: 0.01
+  speedMultiplier: 2
+--- !u!114 &202006659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 202006652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  axisDescription: 0
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  decelerationDeadzone: 0.01
+  speedMultiplier: 2
+--- !u!114 &202006660
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 202006652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 018581a6a9040b34d83404b882e892a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  primaryActivationButton: 9
+  actionModifierButton: 10
+  deviceForDirection: 0
+  axisDeadzone: {x: 0, y: 0}
+  xAxisActionScript: {fileID: 202006659}
+  yAxisActionScript: {fileID: 202006658}
+  disableOtherControlsOnActive: 1
+  affectOnFalling: 0
+  controlOverrideObject: {fileID: 0}
 --- !u!1 &320626006
 GameObject:
   m_ObjectHideFlags: 0
@@ -995,163 +1109,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 699233777}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &757465267
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 0.65, y: 0, z: 0.65}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: 0000003f0ad7233c000000bf000000000000803f0000803f0000803f0000000000000000000000bf0ad7233c000000bf000000000000803f0000803f0000803f0000803f00000000000000bf0ad7233c0000003f000000000000803f0000803f0000803f00000000000000000000003f0ad7233c0000003f000000000000803f0000803f0000803f0000803f000000006666263f0ad7233c666626bf000000000000803f0000803f00000000000000000000803f666626bf0ad7233c666626bf000000000000803f0000803f000000000000803f0000803f666626bf0ad7233c6666263f000000000000803f0000803f00000000000000000000803f6666263f0ad7233c6666263f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 0.65, y: 0, z: 0.65}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
---- !u!21 &759745680
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  m_SavedProperties:
-    serializedVersion: 2
-    m_TexEnvs:
-    - first:
-        name: _MainTex
-      second:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - first:
-        name: PixelSnap
-      second: 0
-    m_Colors:
-    - first:
-        name: _Color
-      second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &818107832
 GameObject:
   m_ObjectHideFlags: 0
@@ -1675,14 +1632,14 @@ MonoBehaviour:
   size: 0
   color: {r: 0, g: 1, b: 1, a: 1}
   vertices:
-  - {x: 0.5, y: 0.01, z: -0.5}
-  - {x: -0.5, y: 0.01, z: -0.5}
-  - {x: -0.5, y: 0.01, z: 0.5}
-  - {x: 0.5, y: 0.01, z: 0.5}
-  - {x: 0.65, y: 0.01, z: -0.65}
-  - {x: -0.65, y: 0.01, z: -0.65}
-  - {x: -0.65, y: 0.01, z: 0.65}
-  - {x: 0.65, y: 0.01, z: 0.65}
+  - {x: 1.0500001, y: 0.01, z: -0.90000015}
+  - {x: -1.0500001, y: 0.01, z: -0.90000015}
+  - {x: -1.0500001, y: 0.01, z: 0.90000015}
+  - {x: 1.0500001, y: 0.01, z: 0.90000015}
+  - {x: 1.2, y: 0.01, z: -1.0500002}
+  - {x: -1.2, y: 0.01, z: -1.0500002}
+  - {x: -1.2, y: 0.01, z: 1.0500002}
+  - {x: 1.2, y: 0.01, z: 1.0500002}
 --- !u!33 &1023151223
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1690,7 +1647,7 @@ MeshFilter:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1023151202}
-  m_Mesh: {fileID: 757465267}
+  m_Mesh: {fileID: 1724828798}
 --- !u!23 &1023151224
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1705,7 +1662,7 @@ MeshRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_Materials:
-  - {fileID: 759745680}
+  - {fileID: 1150889366}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -2139,6 +2096,35 @@ Transform:
   - {fileID: 2004032047}
   m_Father: {fileID: 1907973909}
   m_RootOrder: 7
+--- !u!21 &1150889366
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: PixelSnap
+      second: 0
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1214114803
 GameObject:
   m_ObjectHideFlags: 0
@@ -2589,7 +2575,6 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 1665733686}
-  - 114: {fileID: 1665733693}
   - 114: {fileID: 1665733692}
   - 114: {fileID: 1665733691}
   - 114: {fileID: 1665733690}
@@ -2715,25 +2700,6 @@ MonoBehaviour:
   gravityFallYThreshold: 0.15
   blinkYThreshold: 0.15
   floorHeightTolerance: 0.001
---- !u!114 &1665733693
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1665733685}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b0a3634ed0880214bb405386bdad8e93, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  leftController: 1
-  rightController: 1
-  maxWalkSpeed: 3
-  deceleration: 0.1
-  moveOnButtonPress: 9
-  deviceForDirection: 0
-  speedMultiplierButton: 0
-  speedMultiplier: 1
 --- !u!114 &1665733694
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2827,6 +2793,134 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1689166978}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!43 &1724828798
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 6766863f0ad7233c696666bf000000000000803f0000803f0000803f0000000000000000676686bf0ad7233c696666bf000000000000803f0000803f0000803f0000803f00000000676686bf0ad7233c6966663f000000000000803f0000803f0000803f00000000000000006766863f0ad7233c6966663f000000000000803f0000803f0000803f0000803f000000009a99993f0ad7233c686686bf000000000000803f0000803f00000000000000000000803f9a9999bf0ad7233c686686bf000000000000803f0000803f000000000000803f0000803f9a9999bf0ad7233c6866863f000000000000803f0000803f00000000000000000000803f9a99993f0ad7233c6866863f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &1907973908
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/017_CameraRig_TouchpadWalking.unity
+++ b/Assets/VRTK/Examples/017_CameraRig_TouchpadWalking.unity
@@ -169,6 +169,135 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 51027536}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &58768449
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 58768450}
+  - 114: {fileID: 58768452}
+  - 114: {fileID: 58768451}
+  m_Layer: 0
+  m_Name: XAxis = Slide  -  YAxis = Slide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &58768450
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58768449}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 0
+--- !u!114 &58768451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58768449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!114 &58768452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58768449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!1 &63906191
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 63906192}
+  - 114: {fileID: 63906194}
+  - 114: {fileID: 63906193}
+  m_Layer: 0
+  m_Name: XAxis = SnapRotate  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &63906192
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 63906191}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 5
+--- !u!114 &63906193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 63906191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &63906194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 63906191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11c28f695996f534b8a8e4935ae2a651, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  anglePerSnap: 30
+  angleMultiplier: 1.5
+  snapDelay: 0.5
+  blinkTransitionSpeed: 0.6
 --- !u!1 &101068864
 GameObject:
   m_ObjectHideFlags: 0
@@ -256,13 +385,11 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 146687106}
+  - 114: {fileID: 146687113}
   - 114: {fileID: 146687110}
   - 114: {fileID: 146687109}
   - 114: {fileID: 146687108}
   - 114: {fileID: 146687107}
-  - 114: {fileID: 146687113}
-  - 114: {fileID: 146687112}
-  - 114: {fileID: 146687111}
   m_Layer: 0
   m_Name: LeftController
   m_TagString: Untagged
@@ -280,7 +407,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 1437563318}
   m_Father: {fileID: 595461345}
   m_RootOrder: 2
 --- !u!114 &146687107
@@ -384,40 +512,6 @@ MonoBehaviour:
   usePressed: 0
   uiClickPressed: 0
   menuPressed: 0
---- !u!114 &146687111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 146687105}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  axisDescription: 1
-  maximumSpeed: 3
-  deceleration: 0.1
-  fallingDeceleration: 0.01
-  decelerationDeadzone: 0.01
-  speedMultiplier: 2
---- !u!114 &146687112
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 146687105}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  axisDescription: 0
-  maximumSpeed: 3
-  deceleration: 0.1
-  fallingDeceleration: 0.01
-  decelerationDeadzone: 0.01
-  speedMultiplier: 2
 --- !u!114 &146687113
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -432,9 +526,7 @@ MonoBehaviour:
   primaryActivationButton: 9
   actionModifierButton: 10
   deviceForDirection: 0
-  axisDeadzone: {x: 0, y: 0}
-  xAxisActionScript: {fileID: 146687112}
-  yAxisActionScript: {fileID: 146687111}
+  axisDeadzone: {x: 0.2, y: 0.2}
   disableOtherControlsOnActive: 1
   affectOnFalling: 0
   controlOverrideObject: {fileID: 0}
@@ -446,13 +538,11 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 202006653}
+  - 114: {fileID: 202006660}
   - 114: {fileID: 202006657}
   - 114: {fileID: 202006656}
   - 114: {fileID: 202006655}
   - 114: {fileID: 202006654}
-  - 114: {fileID: 202006660}
-  - 114: {fileID: 202006659}
-  - 114: {fileID: 202006658}
   m_Layer: 0
   m_Name: RightController
   m_TagString: Untagged
@@ -470,7 +560,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 267134380}
   m_Father: {fileID: 595461345}
   m_RootOrder: 3
 --- !u!114 &202006654
@@ -574,40 +665,6 @@ MonoBehaviour:
   usePressed: 0
   uiClickPressed: 0
   menuPressed: 0
---- !u!114 &202006658
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 202006652}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  axisDescription: 1
-  maximumSpeed: 3
-  deceleration: 0.1
-  fallingDeceleration: 0.01
-  decelerationDeadzone: 0.01
-  speedMultiplier: 2
---- !u!114 &202006659
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 202006652}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  axisDescription: 0
-  maximumSpeed: 3
-  deceleration: 0.1
-  fallingDeceleration: 0.01
-  decelerationDeadzone: 0.01
-  speedMultiplier: 2
 --- !u!114 &202006660
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -622,12 +679,45 @@ MonoBehaviour:
   primaryActivationButton: 9
   actionModifierButton: 10
   deviceForDirection: 0
-  axisDeadzone: {x: 0, y: 0}
-  xAxisActionScript: {fileID: 202006659}
-  yAxisActionScript: {fileID: 202006658}
+  axisDeadzone: {x: 0.2, y: 0.2}
   disableOtherControlsOnActive: 1
   affectOnFalling: 0
   controlOverrideObject: {fileID: 0}
+--- !u!1 &267134379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 267134380}
+  m_Layer: 0
+  m_Name: TouchpadControlOptions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &267134380
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 267134379}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 58768450}
+  - {fileID: 1383646738}
+  - {fileID: 1723481865}
+  - {fileID: 1654489344}
+  - {fileID: 1913963095}
+  - {fileID: 63906192}
+  - {fileID: 1957207987}
+  m_Father: {fileID: 202006653}
+  m_RootOrder: 0
 --- !u!1 &320626006
 GameObject:
   m_ObjectHideFlags: 0
@@ -893,6 +983,71 @@ Camera:
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
   m_StereoMirrorMode: 0
+--- !u!1 &558308553
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 558308554}
+  - 114: {fileID: 558308556}
+  - 114: {fileID: 558308555}
+  m_Layer: 0
+  m_Name: XAxis = Slide  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &558308554
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 558308553}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 1
+--- !u!114 &558308555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 558308553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &558308556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 558308553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
 --- !u!1 &595461344
 GameObject:
   m_ObjectHideFlags: 0
@@ -951,6 +1106,72 @@ MonoBehaviour:
   modelAliasRightController: {fileID: 2094929985}
   scriptAliasLeftController: {fileID: 146687105}
   scriptAliasRightController: {fileID: 202006652}
+--- !u!1 &675370632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 675370633}
+  - 114: {fileID: 675370635}
+  - 114: {fileID: 675370634}
+  m_Layer: 0
+  m_Name: XAxis = Warp  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &675370633
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 675370632}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 6
+--- !u!114 &675370634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 675370632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &675370635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 675370632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
 --- !u!1 &678749675
 GameObject:
   m_ObjectHideFlags: 0
@@ -1149,6 +1370,35 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c63141da60241d14394f8f3b547531f0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!21 &883684593
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: PixelSnap
+      second: 0
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &884550209
 GameObject:
   m_ObjectHideFlags: 0
@@ -1647,7 +1897,7 @@ MeshFilter:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1023151202}
-  m_Mesh: {fileID: 1724828798}
+  m_Mesh: {fileID: 1334353326}
 --- !u!23 &1023151224
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1662,7 +1912,7 @@ MeshRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_Materials:
-  - {fileID: 1150889366}
+  - {fileID: 883684593}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -2096,35 +2346,68 @@ Transform:
   - {fileID: 2004032047}
   m_Father: {fileID: 1907973909}
   m_RootOrder: 7
---- !u!21 &1150889366
-Material:
-  serializedVersion: 6
+--- !u!1 &1150037483
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  m_SavedProperties:
-    serializedVersion: 2
-    m_TexEnvs:
-    - first:
-        name: _MainTex
-      second:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - first:
-        name: PixelSnap
-      second: 0
-    m_Colors:
-    - first:
-        name: _Color
-      second: {r: 1, g: 1, b: 1, a: 1}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1150037484}
+  - 114: {fileID: 1150037486}
+  - 114: {fileID: 1150037485}
+  m_Layer: 0
+  m_Name: XAxis = Rotate  -  YAxis = Slide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1150037484
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1150037483}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 2
+--- !u!114 &1150037485
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1150037483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!114 &1150037486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1150037483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cf039de547880c4d9e49bf7eed59df5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  maximumRotationSpeed: 3
+  rotationMultiplier: 1.5
 --- !u!1 &1214114803
 GameObject:
   m_ObjectHideFlags: 0
@@ -2204,6 +2487,134 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1214114803}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!43 &1334353326
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 6766863f0ad7233c696666bf000000000000803f0000803f0000803f0000000000000000676686bf0ad7233c696666bf000000000000803f0000803f0000803f0000803f00000000676686bf0ad7233c6966663f000000000000803f0000803f0000803f00000000000000006766863f0ad7233c6966663f000000000000803f0000803f0000803f0000803f000000009a99993f0ad7233c686686bf000000000000803f0000803f00000000000000000000803f9a9999bf0ad7233c686686bf000000000000803f0000803f000000000000803f0000803f9a9999bf0ad7233c6866863f000000000000803f0000803f00000000000000000000803f9a99993f0ad7233c6866863f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &1368096404
 GameObject:
   m_ObjectHideFlags: 0
@@ -2283,6 +2694,71 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1368096404}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1383646737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1383646738}
+  - 114: {fileID: 1383646740}
+  - 114: {fileID: 1383646739}
+  m_Layer: 0
+  m_Name: XAxis = Slide  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1383646738
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1383646737}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 1
+--- !u!114 &1383646739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1383646737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &1383646740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1383646737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
 --- !u!1 &1387858999
 GameObject:
   m_ObjectHideFlags: 0
@@ -2409,6 +2885,41 @@ MonoBehaviour:
   verbose: 0
   createComponents: 1
   updateDynamically: 1
+--- !u!1 &1437563317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1437563318}
+  m_Layer: 0
+  m_Name: TouchpadControlOptions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1437563318
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1437563317}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1842972675}
+  - {fileID: 558308554}
+  - {fileID: 1150037484}
+  - {fileID: 1725682351}
+  - {fileID: 1913117362}
+  - {fileID: 2090022821}
+  - {fileID: 675370633}
+  m_Father: {fileID: 146687106}
+  m_RootOrder: 0
 --- !u!1 &1470633476
 GameObject:
   m_ObjectHideFlags: 0
@@ -2567,6 +3078,69 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1519789927}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1654489343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1654489344}
+  - 114: {fileID: 1654489346}
+  - 114: {fileID: 1654489345}
+  m_Layer: 0
+  m_Name: XAxis = Rotate  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1654489344
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1654489343}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 3
+--- !u!114 &1654489345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1654489343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &1654489346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1654489343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cf039de547880c4d9e49bf7eed59df5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  maximumRotationSpeed: 3
+  rotationMultiplier: 1.5
 --- !u!1 &1665733685
 GameObject:
   m_ObjectHideFlags: 0
@@ -2793,134 +3367,195 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1689166978}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &1724828798
-Mesh:
+--- !u!1 &1723481864
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1723481865}
+  - 114: {fileID: 1723481866}
+  - 114: {fileID: 1723481867}
+  m_Layer: 0
+  m_Name: XAxis = Rotate  -  YAxis = Slide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1723481865
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1723481864}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 2
+--- !u!114 &1723481866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1723481864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cf039de547880c4d9e49bf7eed59df5, type: 3}
   m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.2, y: 0, z: 1.0500002}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: 6766863f0ad7233c696666bf000000000000803f0000803f0000803f0000000000000000676686bf0ad7233c696666bf000000000000803f0000803f0000803f0000803f00000000676686bf0ad7233c6966663f000000000000803f0000803f0000803f00000000000000006766863f0ad7233c6966663f000000000000803f0000803f0000803f0000803f000000009a99993f0ad7233c686686bf000000000000803f0000803f00000000000000000000803f9a9999bf0ad7233c686686bf000000000000803f0000803f000000000000803f0000803f9a9999bf0ad7233c6866863f000000000000803f0000803f00000000000000000000803f9a99993f0ad7233c6866863f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.2, y: 0, z: 1.0500002}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  maximumRotationSpeed: 3
+  rotationMultiplier: 1.5
+--- !u!114 &1723481867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1723481864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!1 &1725682350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1725682351}
+  - 114: {fileID: 1725682353}
+  - 114: {fileID: 1725682352}
+  m_Layer: 0
+  m_Name: XAxis = Rotate  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1725682351
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1725682350}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 3
+--- !u!114 &1725682352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1725682350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &1725682353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1725682350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cf039de547880c4d9e49bf7eed59df5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  maximumRotationSpeed: 3
+  rotationMultiplier: 1.5
+--- !u!1 &1842972674
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1842972675}
+  - 114: {fileID: 1842972677}
+  - 114: {fileID: 1842972676}
+  m_Layer: 0
+  m_Name: XAxis = Slide  -  YAxis = Slide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1842972675
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1842972674}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 0
+--- !u!114 &1842972676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1842972674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!114 &1842972677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1842972674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
 --- !u!1 &1907973908
 GameObject:
   m_ObjectHideFlags: 0
@@ -2960,6 +3595,200 @@ Transform:
   - {fileID: 392710204}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+--- !u!1 &1913117361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1913117362}
+  - 114: {fileID: 1913117364}
+  - 114: {fileID: 1913117363}
+  m_Layer: 0
+  m_Name: XAxis = SnapRotate  -  YAxis = Slide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1913117362
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1913117361}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 4
+--- !u!114 &1913117363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1913117361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!114 &1913117364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1913117361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11c28f695996f534b8a8e4935ae2a651, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  anglePerSnap: 30
+  angleMultiplier: 1.5
+  snapDelay: 0.5
+  blinkTransitionSpeed: 0.6
+--- !u!1 &1913963094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1913963095}
+  - 114: {fileID: 1913963097}
+  - 114: {fileID: 1913963096}
+  m_Layer: 0
+  m_Name: XAxis = SnapRotate  -  YAxis = Slide
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1913963095
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1913963094}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 4
+--- !u!114 &1913963096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1913963094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1227828337a634aa0ff434d6bbd019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  maximumSpeed: 3
+  deceleration: 0.1
+  fallingDeceleration: 0.01
+  speedMultiplier: 1.5
+--- !u!114 &1913963097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1913963094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11c28f695996f534b8a8e4935ae2a651, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  anglePerSnap: 30
+  angleMultiplier: 1.5
+  snapDelay: 0.5
+  blinkTransitionSpeed: 0.6
+--- !u!1 &1957207986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1957207987}
+  - 114: {fileID: 1957207989}
+  - 114: {fileID: 1957207988}
+  m_Layer: 0
+  m_Name: XAxis = Warp  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1957207987
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957207986}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 267134380}
+  m_RootOrder: 6
+--- !u!114 &1957207988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957207986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &1957207989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957207986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 202006660}
+  listenOnAxisChange: 0
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
 --- !u!1 &2004032046
 GameObject:
   m_ObjectHideFlags: 0
@@ -3118,6 +3947,71 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2027617613}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2090022820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 2090022821}
+  - 114: {fileID: 2090022823}
+  - 114: {fileID: 2090022822}
+  m_Layer: 0
+  m_Name: XAxis = SnapRotate  -  YAxis = Warp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2090022821
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2090022820}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1437563318}
+  m_RootOrder: 5
+--- !u!114 &2090022822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2090022820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79201badbabbe254a978b37a86ac828c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 1
+  warpDistance: 1
+  warpMultiplier: 2
+  warpDelay: 0.5
+  floorHeightTolerance: 1
+  blinkTransitionSpeed: 0.6
+--- !u!114 &2090022823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2090022820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11c28f695996f534b8a8e4935ae2a651, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchpadControlScript: {fileID: 146687113}
+  listenOnAxisChange: 0
+  anglePerSnap: 30
+  angleMultiplier: 1.5
+  snapDelay: 0.5
+  blinkTransitionSpeed: 0.6
 --- !u!1 &2094929985
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions.meta
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a999084ae9c6eec449e4451099362aea
+folderAsset: yes
+timeCreated: 1485940894
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_BaseTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_BaseTouchpadControlAction.cs
@@ -1,0 +1,35 @@
+﻿// Base Touchpad Control Action|TouchpadControlActions|25000
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Base Touchpad Control Action script is an abstract class that all touchpad control action scripts inherit.
+    /// </summary>
+    /// <remarks>
+    /// As this is an abstract class, it cannot be applied directly to a game object and performs no logic.
+    /// </remarks>
+    public abstract class VRTK_BaseTouchpadControlAction : MonoBehaviour
+    {
+        public enum AxisDescriptions
+        {
+            XAxis,
+            YAxis
+        }
+
+        [Tooltip("A helper parameter to easily identify which axis this Touchpad Control Action is for.")]
+        public AxisDescriptions axisDescription;
+
+        /// <summary>
+        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+        /// </summary>
+        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
+        /// <param name="directionDevice">The device that is used for the direction.</param>
+        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
+        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
+        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
+        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
+        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
+        public abstract void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive);
+    }
+}

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_BaseTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_BaseTouchpadControlAction.cs
@@ -20,6 +20,13 @@ namespace VRTK
         [Tooltip("A helper parameter to easily identify which axis this Touchpad Control Action is for.")]
         public AxisDescriptions axisDescription;
 
+        protected Collider centerCollider;
+        protected Vector3 colliderCenter = Vector3.zero;
+        protected float colliderRadius = 0f;
+        protected float colliderHeight = 0f;
+        protected Transform controlledTransform;
+        protected Transform playArea;
+
         /// <summary>
         /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
         /// </summary>
@@ -31,5 +38,73 @@ namespace VRTK
         /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
         /// <param name="modifierActive">Whether the modifier button is pressed.</param>
         public abstract void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive);
+
+        protected virtual void OnEnable()
+        {
+            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+        }
+
+        protected virtual void RotateAroundPlayer(GameObject controlledGameObject, float angle)
+        {
+            Vector3 objectCenter = GetObjectCenter(controlledGameObject.transform);
+            Vector3 objectPosition = controlledGameObject.transform.TransformPoint(objectCenter);
+            controlledGameObject.transform.Rotate(Vector3.up, angle);
+            objectPosition -= controlledGameObject.transform.TransformPoint(objectCenter);
+            controlledGameObject.transform.position += objectPosition;
+        }
+
+        protected virtual void Blink(float blinkSpeed)
+        {
+            if (blinkSpeed > 0f)
+            {
+                VRTK_SDK_Bridge.HeadsetFade(Color.black, 0);
+                ReleaseBlink(blinkSpeed);
+            }
+        }
+
+        protected virtual void ReleaseBlink(float blinkSpeed)
+        {
+            VRTK_SDK_Bridge.HeadsetFade(Color.clear, blinkSpeed);
+        }
+
+        protected virtual Vector3 GetObjectCenter(Transform checkObject)
+        {
+            if (centerCollider == null || checkObject != controlledTransform)
+            {
+                controlledTransform = checkObject;
+
+                if (checkObject == playArea)
+                {
+                    CapsuleCollider playAreaCollider = playArea.GetComponent<CapsuleCollider>();
+                    centerCollider = playAreaCollider;
+                    colliderRadius = playAreaCollider.radius;
+                    colliderHeight = playAreaCollider.height;
+                    colliderCenter = playAreaCollider.center;
+                }
+                else
+                {
+                    centerCollider = checkObject.GetComponent<Collider>();
+                    colliderRadius = 0.1f;
+                    colliderHeight = 0.1f;
+                }
+            }
+
+            return colliderCenter;
+        }
+
+        protected virtual int GetAxisDirection(float axis)
+        {
+            int axisDirection = 0;
+            if (axis < 0)
+            {
+                axisDirection = -1;
+            }
+            else if (axis > 0)
+            {
+                axisDirection = 1;
+            }
+
+            return axisDirection;
+        }
     }
 }

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_BaseTouchpadControlAction.cs.meta
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_BaseTouchpadControlAction.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b213e640d58958f46ab00fc323a69e89
+timeCreated: 1485940924
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs
@@ -9,6 +9,11 @@ namespace VRTK
     /// <remarks>
     /// The effect is a smooth rotation to simulate turning.
     /// </remarks>
+    /// <example>
+    /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+    ///
+    /// To enable the Rotate Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Rotate` control script active.
+    /// </example>
     public class VRTK_RotateTouchpadControlAction : VRTK_BaseTouchpadControlAction
     {
         [Tooltip("The maximum speed the controlled object can be rotated based on the position of the touchpad axis.")]
@@ -16,17 +21,7 @@ namespace VRTK
         [Tooltip("The rotation multiplier to be applied when the modifier button is pressed.")]
         public float rotationMultiplier = 1.5f;
 
-        /// <summary>
-        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
-        /// </summary>
-        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
-        /// <param name="directionDevice">The device that is used for the direction.</param>
-        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
-        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
-        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
-        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
-        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
-        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
             float angle = Rotate(axis, modifierActive);
             if (angle != 0f)

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs
@@ -16,10 +16,6 @@ namespace VRTK
         [Tooltip("The rotation multiplier to be applied when the modifier button is pressed.")]
         public float rotationMultiplier = 1.5f;
 
-        private Collider centerCollider;
-        private Transform controlledTransform;
-        private Transform playArea;
-
         /// <summary>
         /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
         /// </summary>
@@ -39,44 +35,9 @@ namespace VRTK
             }
         }
 
-        protected virtual void OnEnable()
-        {
-            playArea = VRTK_DeviceFinder.PlayAreaTransform();
-        }
-
-        protected virtual void RotateAroundPlayer(GameObject controlledGameObject, float angle)
-        {
-            Vector3 objectCenter = GetObjectCenter(controlledGameObject.transform);
-            Vector3 objectPosition = controlledGameObject.transform.TransformPoint(objectCenter);
-            controlledGameObject.transform.Rotate(Vector3.up, angle);
-            objectPosition -= controlledGameObject.transform.TransformPoint(objectCenter);
-            controlledGameObject.transform.position += objectPosition;
-        }
-
         protected virtual float Rotate(float axis, bool modifierActive)
         {
             return axis * maximumRotationSpeed * Time.deltaTime * (modifierActive ? rotationMultiplier : 1) * 10;
-        }
-
-        protected virtual Vector3 GetObjectCenter(Transform checkObject)
-        {
-            if (centerCollider == null || checkObject != controlledTransform)
-            {
-                controlledTransform = checkObject;
-
-                if (checkObject == playArea)
-                {
-                    CapsuleCollider playAreaCollider = playArea.GetComponent<CapsuleCollider>();
-                    centerCollider = playAreaCollider;
-                    return playAreaCollider.center;
-                }
-                else
-                {
-                    centerCollider = checkObject.GetComponent<Collider>();
-                }
-            }
-
-            return Vector3.zero;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs
@@ -1,0 +1,82 @@
+﻿// Rotate Touchpad Control Action|TouchpadControlActions|25020
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Rotate Touchpad Control Action script is used to rotate the controlled GameObject around the up vector when changing the touchpad axis.
+    /// </summary>
+    /// <remarks>
+    /// The effect is a smooth rotation to simulate turning.
+    /// </remarks>
+    public class VRTK_RotateTouchpadControlAction : VRTK_BaseTouchpadControlAction
+    {
+        [Tooltip("The maximum speed the controlled object can be rotated based on the position of the touchpad axis.")]
+        public float maximumRotationSpeed = 3f;
+        [Tooltip("The rotation multiplier to be applied when the modifier button is pressed.")]
+        public float rotationMultiplier = 1.5f;
+
+        private Collider centerCollider;
+        private Transform controlledTransform;
+        private Transform playArea;
+
+        /// <summary>
+        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+        /// </summary>
+        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
+        /// <param name="directionDevice">The device that is used for the direction.</param>
+        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
+        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
+        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
+        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
+        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
+        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        {
+            float angle = Rotate(axis, modifierActive);
+            if (angle != 0f)
+            {
+                RotateAroundPlayer(controlledGameObject, angle);
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+        }
+
+        protected virtual void RotateAroundPlayer(GameObject controlledGameObject, float angle)
+        {
+            Vector3 objectCenter = GetObjectCenter(controlledGameObject.transform);
+            Vector3 objectPosition = controlledGameObject.transform.TransformPoint(objectCenter);
+            controlledGameObject.transform.Rotate(Vector3.up, angle);
+            objectPosition -= controlledGameObject.transform.TransformPoint(objectCenter);
+            controlledGameObject.transform.position += objectPosition;
+        }
+
+        protected virtual float Rotate(float axis, bool modifierActive)
+        {
+            return axis * maximumRotationSpeed * Time.deltaTime * (modifierActive ? rotationMultiplier : 1) * 10;
+        }
+
+        protected virtual Vector3 GetObjectCenter(Transform checkObject)
+        {
+            if (centerCollider == null || checkObject != controlledTransform)
+            {
+                controlledTransform = checkObject;
+
+                if (checkObject == playArea)
+                {
+                    CapsuleCollider playAreaCollider = playArea.GetComponent<CapsuleCollider>();
+                    centerCollider = playAreaCollider;
+                    return playAreaCollider.center;
+                }
+                else
+                {
+                    centerCollider = checkObject.GetComponent<Collider>();
+                }
+            }
+
+            return Vector3.zero;
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs.meta
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_RotateTouchpadControlAction.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8cf039de547880c4d9e49bf7eed59df5
+timeCreated: 1485955148
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SlideTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SlideTouchpadControlAction.cs
@@ -1,0 +1,95 @@
+﻿// Slide Touchpad Control Action|TouchpadControlActions|25010
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Slide Touchpad Controll Action script is used to slide the controlled GameObject around the scene when changing the touchpad axis.
+    /// </summary>
+    /// <remarks>
+    /// The effect is a smooth sliding motion in forward and sideways directions to simulate touchpad walking.
+    /// </remarks>
+    /// <example>
+    /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+    /// </example>
+    public class VRTK_SlideTouchpadControlAction : VRTK_BaseTouchpadControlAction
+    {
+        [Tooltip("The maximum speed the controlled object can be moved in based on the position of the touchpad axis.")]
+        public float maximumSpeed = 3f;
+        [Tooltip("The rate of speed deceleration when the touchpad is no longer being touched.")]
+        public float deceleration = 0.1f;
+        [Tooltip("The rate of speed deceleration when the touchpad is no longer being touched and the object is falling.")]
+        public float fallingDeceleration = 0.01f;
+        [Tooltip("The speed multiplier to be applied when the modifier button is pressed.")]
+        public float speedMultiplier = 1.5f;
+
+        private float currentSpeed = 0f;
+
+        /// <summary>
+        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+        /// </summary>
+        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
+        /// <param name="directionDevice">The device that is used for the direction.</param>
+        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
+        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
+        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
+        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
+        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
+        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        {
+            currentSpeed = CalculateSpeed(axis, currentlyFalling, modifierActive);
+            Move(controlledGameObject, directionDevice, axisDirection);
+        }
+
+        protected virtual float CalculateSpeed(float inputValue, bool currentlyFalling, bool modifierActive)
+        {
+            float speed = currentSpeed;
+            if (inputValue != 0f)
+            {
+                speed = (maximumSpeed * inputValue);
+                speed = (modifierActive ? (speed * speedMultiplier) : speed);
+            }
+            else
+            {
+                speed = Decelerate(speed, currentlyFalling);
+            }
+
+            return speed;
+        }
+
+        protected virtual float Decelerate(float speed, bool currentlyFalling)
+        {
+            float decelerationSpeed = (currentlyFalling ? fallingDeceleration : deceleration);
+            if (speed > 0)
+            {
+                speed -= Mathf.Lerp(decelerationSpeed, maximumSpeed, 0f);
+            }
+            else if (speed < 0)
+            {
+                speed += Mathf.Lerp(decelerationSpeed, -maximumSpeed, 0f);
+            }
+            else
+            {
+                speed = 0;
+            }
+
+            if (speed < decelerationSpeed && speed > -decelerationSpeed)
+            {
+                speed = 0;
+            }
+
+            return speed;
+        }
+
+        protected virtual void Move(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection)
+        {
+            if (directionDevice && directionDevice.gameObject.activeInHierarchy && controlledGameObject.activeInHierarchy)
+            {
+                float storeYPosition = controlledGameObject.transform.position.y;
+                Vector3 updatedPosition = axisDirection * currentSpeed * Time.deltaTime;
+                controlledGameObject.transform.position += updatedPosition;
+                controlledGameObject.transform.position = new Vector3(controlledGameObject.transform.position.x, storeYPosition, controlledGameObject.transform.position.z);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SlideTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SlideTouchpadControlAction.cs
@@ -4,13 +4,15 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
-    /// The Slide Touchpad Controll Action script is used to slide the controlled GameObject around the scene when changing the touchpad axis.
+    /// The Slide Touchpad Control Action script is used to slide the controlled GameObject around the scene when changing the touchpad axis.
     /// </summary>
     /// <remarks>
     /// The effect is a smooth sliding motion in forward and sideways directions to simulate touchpad walking.
     /// </remarks>
     /// <example>
     /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+    ///
+    /// To enable the Slide Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Slide` control script active.
     /// </example>
     public class VRTK_SlideTouchpadControlAction : VRTK_BaseTouchpadControlAction
     {
@@ -25,17 +27,7 @@ namespace VRTK
 
         private float currentSpeed = 0f;
 
-        /// <summary>
-        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
-        /// </summary>
-        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
-        /// <param name="directionDevice">The device that is used for the direction.</param>
-        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
-        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
-        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
-        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
-        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
-        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
             currentSpeed = CalculateSpeed(axis, currentlyFalling, modifierActive);
             Move(controlledGameObject, directionDevice, axisDirection);

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SlideTouchpadControlAction.cs.meta
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SlideTouchpadControlAction.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2e1227828337a634aa0ff434d6bbd019
+timeCreated: 1485942885
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
@@ -20,9 +20,6 @@ namespace VRTK
         [Tooltip("The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.")]
         public float blinkTransitionSpeed = 0.6f;
 
-        private Collider centerCollider;
-        private Transform controlledTransform;
-        private Transform playArea;
         private float snapDelayTimer = 0f;
 
         /// <summary>
@@ -42,74 +39,17 @@ namespace VRTK
                 float angle = Rotate(axis, modifierActive);
                 if (angle != 0f)
                 {
-                    Blink();
+                    Blink(blinkTransitionSpeed);
                     RotateAroundPlayer(controlledGameObject, angle);
                 }
             }
         }
 
-        protected virtual void OnEnable()
-        {
-            playArea = VRTK_DeviceFinder.PlayAreaTransform();
-        }
-
-        protected virtual void RotateAroundPlayer(GameObject controlledGameObject, float angle)
-        {
-            Vector3 objectCenter = GetObjectCenter(controlledGameObject.transform);
-            Vector3 objectPosition = controlledGameObject.transform.TransformPoint(objectCenter);
-            controlledGameObject.transform.Rotate(Vector3.up, angle);
-            objectPosition -= controlledGameObject.transform.TransformPoint(objectCenter);
-            controlledGameObject.transform.position += objectPosition;
-        }
-
         protected virtual float Rotate(float axis, bool modifierActive)
         {
             snapDelayTimer = Time.timeSinceLevelLoad + snapDelay;
-            int axisDirection = 0;
-            if (axis < 0)
-            {
-                axisDirection = -1;
-            }
-            else if (axis > 0)
-            {
-                axisDirection = 1;
-            }
-            return (anglePerSnap * (modifierActive ? angleMultiplier : 1)) * axisDirection;
-        }
-
-        protected virtual void Blink()
-        {
-            if (blinkTransitionSpeed > 0f)
-            {
-                VRTK_SDK_Bridge.HeadsetFade(Color.black, 0);
-                Invoke("ReleaseBlink", 0.01f);
-            }
-        }
-
-        protected virtual void ReleaseBlink()
-        {
-            VRTK_SDK_Bridge.HeadsetFade(Color.clear, blinkTransitionSpeed);
-        }
-
-        protected virtual Vector3 GetObjectCenter(Transform checkObject)
-        {
-            if (centerCollider == null || checkObject != controlledTransform)
-            {
-                controlledTransform = checkObject;
-
-                if (checkObject == playArea)
-                {
-                    CapsuleCollider playAreaCollider = playArea.GetComponent<CapsuleCollider>();
-                    centerCollider = playAreaCollider;
-                    return playAreaCollider.center;
-                }
-                else
-                {
-                    centerCollider = checkObject.GetComponent<Collider>();
-                }
-            }
-
-            return Vector3.zero;
+            int directionMultiplier = GetAxisDirection(axis);
+            return (anglePerSnap * (modifierActive ? angleMultiplier : 1)) * directionMultiplier;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
@@ -9,6 +9,11 @@ namespace VRTK
     /// <remarks>
     /// The effect is a immediate snap rotation to quickly face in a new direction.
     /// </remarks>
+    /// <example>
+    /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+    ///
+    /// To enable the Snap Rotate Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Snap Rotate` control script active.
+    /// </example>
     public class VRTK_SnapRotateTouchpadControlAction : VRTK_BaseTouchpadControlAction
     {
         [Tooltip("The angle to rotate for each snap.")]
@@ -22,17 +27,7 @@ namespace VRTK
 
         private float snapDelayTimer = 0f;
 
-        /// <summary>
-        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
-        /// </summary>
-        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
-        /// <param name="directionDevice">The device that is used for the direction.</param>
-        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
-        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
-        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
-        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
-        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
-        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
             if (snapDelayTimer < Time.timeSinceLevelLoad)
             {

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
@@ -1,0 +1,115 @@
+﻿// Snap Rotate Touchpad Control Action|TouchpadControlActions|25030
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Snap Rotate Touchpad Control Action script is used to snap rotate the controlled GameObject around the up vector when changing the touchpad axis.
+    /// </summary>
+    /// <remarks>
+    /// The effect is a immediate snap rotation to quickly face in a new direction.
+    /// </remarks>
+    public class VRTK_SnapRotateTouchpadControlAction : VRTK_BaseTouchpadControlAction
+    {
+        [Tooltip("The angle to rotate for each snap.")]
+        public float anglePerSnap = 30f;
+        [Tooltip("The snap angle multiplier to be applied when the modifier button is pressed.")]
+        public float angleMultiplier = 1.5f;
+        [Tooltip("The amount of time required to pass before another snap rotation can be carried out.")]
+        public float snapDelay = 0.5f;
+        [Tooltip("The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.")]
+        public float blinkTransitionSpeed = 0.6f;
+
+        private Collider centerCollider;
+        private Transform controlledTransform;
+        private Transform playArea;
+        private float snapDelayTimer = 0f;
+
+        /// <summary>
+        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+        /// </summary>
+        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
+        /// <param name="directionDevice">The device that is used for the direction.</param>
+        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
+        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
+        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
+        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
+        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
+        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        {
+            if (snapDelayTimer < Time.timeSinceLevelLoad)
+            {
+                float angle = Rotate(axis, modifierActive);
+                if (angle != 0f)
+                {
+                    Blink();
+                    RotateAroundPlayer(controlledGameObject, angle);
+                }
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+        }
+
+        protected virtual void RotateAroundPlayer(GameObject controlledGameObject, float angle)
+        {
+            Vector3 objectCenter = GetObjectCenter(controlledGameObject.transform);
+            Vector3 objectPosition = controlledGameObject.transform.TransformPoint(objectCenter);
+            controlledGameObject.transform.Rotate(Vector3.up, angle);
+            objectPosition -= controlledGameObject.transform.TransformPoint(objectCenter);
+            controlledGameObject.transform.position += objectPosition;
+        }
+
+        protected virtual float Rotate(float axis, bool modifierActive)
+        {
+            snapDelayTimer = Time.timeSinceLevelLoad + snapDelay;
+            int axisDirection = 0;
+            if (axis < 0)
+            {
+                axisDirection = -1;
+            }
+            else if (axis > 0)
+            {
+                axisDirection = 1;
+            }
+            return (anglePerSnap * (modifierActive ? angleMultiplier : 1)) * axisDirection;
+        }
+
+        protected virtual void Blink()
+        {
+            if (blinkTransitionSpeed > 0f)
+            {
+                VRTK_SDK_Bridge.HeadsetFade(Color.black, 0);
+                Invoke("ReleaseBlink", 0.01f);
+            }
+        }
+
+        protected virtual void ReleaseBlink()
+        {
+            VRTK_SDK_Bridge.HeadsetFade(Color.clear, blinkTransitionSpeed);
+        }
+
+        protected virtual Vector3 GetObjectCenter(Transform checkObject)
+        {
+            if (centerCollider == null || checkObject != controlledTransform)
+            {
+                controlledTransform = checkObject;
+
+                if (checkObject == playArea)
+                {
+                    CapsuleCollider playAreaCollider = playArea.GetComponent<CapsuleCollider>();
+                    centerCollider = playAreaCollider;
+                    return playAreaCollider.center;
+                }
+                else
+                {
+                    centerCollider = checkObject.GetComponent<Collider>();
+                }
+            }
+
+            return Vector3.zero;
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs
@@ -24,12 +24,15 @@ namespace VRTK
         public float snapDelay = 0.5f;
         [Tooltip("The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.")]
         public float blinkTransitionSpeed = 0.6f;
+        [Range(-1f, 1f)]
+        [Tooltip("The threshold the listened axis needs to exceed before the action occurs. This can be used to limit the snap rotate to a single axis direction (e.g. pull down to flip rotate). The threshold is ignored if it is 0.")]
+        public float axisThreshold = 0f;
 
         private float snapDelayTimer = 0f;
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
-            if (snapDelayTimer < Time.timeSinceLevelLoad)
+            if (snapDelayTimer < Time.timeSinceLevelLoad && ValidThreshold(axis))
             {
                 float angle = Rotate(axis, modifierActive);
                 if (angle != 0f)
@@ -38,6 +41,11 @@ namespace VRTK
                     RotateAroundPlayer(controlledGameObject, angle);
                 }
             }
+        }
+
+        protected virtual bool ValidThreshold(float axis)
+        {
+            return (axisThreshold == 0f || ((axisThreshold > 0f && axis >= axisThreshold) || (axisThreshold < 0f && axis <= axisThreshold)));
         }
 
         protected virtual float Rotate(float axis, bool modifierActive)

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs.meta
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_SnapRotateTouchpadControlAction.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 11c28f695996f534b8a8e4935ae2a651
+timeCreated: 1485957999
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_WarpTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_WarpTouchpadControlAction.cs
@@ -9,6 +9,11 @@ namespace VRTK
     /// <remarks>
     /// The effect is a immediate snap to a new position in the given direction.
     /// </remarks>
+    /// <example>
+    /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+    ///
+    /// To enable the Warp Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Warp` control script active.
+    /// </example>
     public class VRTK_WarpTouchpadControlAction : VRTK_BaseTouchpadControlAction
     {
         [Tooltip("The distance to warp in the facing direction.")]
@@ -25,19 +30,9 @@ namespace VRTK
         private float warpDelayTimer = 0f;
         private Transform headset;
 
-        /// <summary>
-        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
-        /// </summary>
-        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
-        /// <param name="directionDevice">The device that is used for the direction.</param>
-        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
-        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
-        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
-        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
-        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
-        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
-            if (warpDelayTimer < Time.timeSinceLevelLoad)
+            if (warpDelayTimer < Time.timeSinceLevelLoad && axis != 0f)
             {
                 Warp(controlledGameObject, directionDevice, axisDirection, axis, modifierActive);
             }

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_WarpTouchpadControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_WarpTouchpadControlAction.cs
@@ -1,0 +1,86 @@
+﻿// Warp Touchpad Control Action|TouchpadControlActions|25040
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Warp Touchpad Control Action script is used to warp the controlled GameObject a given distance when changing the touchpad axis.
+    /// </summary>
+    /// <remarks>
+    /// The effect is a immediate snap to a new position in the given direction.
+    /// </remarks>
+    public class VRTK_WarpTouchpadControlAction : VRTK_BaseTouchpadControlAction
+    {
+        [Tooltip("The distance to warp in the facing direction.")]
+        public float warpDistance = 1f;
+        [Tooltip("The multiplier to be applied to the warp when the modifier button is pressed.")]
+        public float warpMultiplier = 2f;
+        [Tooltip("The amount of time required to pass before another warp can be carried out.")]
+        public float warpDelay = 0.5f;
+        [Tooltip("The height different in floor allowed to be a valid warp.")]
+        public float floorHeightTolerance = 1f;
+        [Tooltip("The speed for the headset to fade out and back in. Having a blink between warps can reduce nausia.")]
+        public float blinkTransitionSpeed = 0.6f;
+
+        private float warpDelayTimer = 0f;
+        private Transform headset;
+
+        /// <summary>
+        /// The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+        /// </summary>
+        /// <param name="controlledGameObject">The GameObject that is going to be affected.</param>
+        /// <param name="directionDevice">The device that is used for the direction.</param>
+        /// <param name="axisDirection">The axis that is being affected from the touchpad.</param>
+        /// <param name="axis">The value of the current touchpad touch point based across the axis direction.</param>
+        /// <param name="deadzone">The value of the deadzone based across the axis direction.</param>
+        /// <param name="currentlyFalling">Whether the controlled GameObject is currently falling.</param>
+        /// <param name="modifierActive">Whether the modifier button is pressed.</param>
+        public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
+        {
+            if (warpDelayTimer < Time.timeSinceLevelLoad)
+            {
+                Warp(controlledGameObject, directionDevice, axisDirection, axis, modifierActive);
+            }
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            headset = VRTK_DeviceFinder.HeadsetTransform();
+        }
+
+        protected virtual void Warp(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, bool modifierActive)
+        {
+            Vector3 objectCenter = GetObjectCenter(controlledGameObject.transform);
+            Vector3 objectPosition = controlledGameObject.transform.TransformPoint(objectCenter);
+            float distance = warpDistance * (modifierActive ? warpMultiplier : 1);
+            int directionMultiplier = GetAxisDirection(axis);
+
+            Vector3 targetPosition = objectPosition + (axisDirection * distance * directionMultiplier);
+
+            float headMargin = 0.2f;
+            RaycastHit warpRaycastHit;
+
+            // direction raycast to stop near obstacles
+            Vector3 raycastDirection = directionMultiplier * axisDirection;
+            Vector3 startRayPosition = (controlledGameObject.transform == playArea ? headset.position : controlledGameObject.transform.position);
+
+            if (Physics.Raycast(startRayPosition + (Vector3.up * headMargin), raycastDirection, out warpRaycastHit, distance - colliderRadius))
+            {
+                targetPosition = warpRaycastHit.point - (raycastDirection * colliderRadius);
+            }
+
+            // vertical raycast for height position
+            if (Physics.Raycast(targetPosition + (Vector3.up * (floorHeightTolerance + headMargin)), Vector3.down, out warpRaycastHit, (floorHeightTolerance + headMargin) * 2))
+            {
+                targetPosition.y = warpRaycastHit.point.y + (colliderHeight / 2f);
+                Vector3 finalPosition = targetPosition - objectPosition + controlledGameObject.transform.position;
+
+                warpDelayTimer = Time.timeSinceLevelLoad + warpDelay;
+                controlledGameObject.transform.position = finalPosition;
+
+                Blink(blinkTransitionSpeed);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_WarpTouchpadControlAction.cs.meta
+++ b/Assets/VRTK/Scripts/Locomotion/TouchpadControlActions/VRTK_WarpTouchpadControlAction.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 79201badbabbe254a978b37a86ac828c
+timeCreated: 1485972540
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadControl.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadControl.cs
@@ -98,15 +98,20 @@ namespace VRTK
             CheckDirectionDevice();
             CheckFalling();
             ModifierButtonActive();
-            if (xAxisActionScript && xAxisActionScript.enabled)
+            if (xAxisActionScript && xAxisActionScript.enabled && OutsideDeadzone(touchpadAxis.x, axisDeadzone.x))
             {
                 xAxisActionScript.ProcessFixedUpdate(controlledGameObject, directionDevice, directionDevice.right, touchpadAxis.x, axisDeadzone.x, currentlyFalling, modifierActive);
             }
 
-            if (yAxisActionScript && yAxisActionScript.enabled)
+            if (yAxisActionScript && yAxisActionScript.enabled && OutsideDeadzone(touchpadAxis.y, axisDeadzone.y))
             {
                 yAxisActionScript.ProcessFixedUpdate(controlledGameObject, directionDevice, directionDevice.forward, touchpadAxis.y, axisDeadzone.y, currentlyFalling, modifierActive);
             }
+        }
+
+        protected virtual bool OutsideDeadzone(float axisValue, float deadzoneThreshold)
+        {
+            return (axisValue > deadzoneThreshold || axisValue < -deadzoneThreshold);
         }
 
         protected virtual void CheckSetupControlAction()

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadControl.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadControl.cs
@@ -1,0 +1,234 @@
+﻿// Touchpad Control|Locomotion|20058
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The ability to control an object with the touchpad based on the position of the finger on the touchpad axis.
+    /// </summary>
+    /// <remarks>
+    /// The Touchpad Control script forms the stub to allow for pre-defined actions to execute when the touchpad axis changes.
+    ///
+    /// This script is placed on the Script Alias of the Controller that is required to be affected by changes in the touchpad.
+    ///
+    /// If the controlled object is the play area and `VRTK_BodyPhysics` is also available, then additional logic is processed when the user is falling such as preventing the touchpad control from affecting a falling user.
+    /// </remarks>
+    /// <example>
+    /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+    /// </example>
+    [RequireComponent(typeof(VRTK_ControllerEvents))]
+    public class VRTK_TouchpadControl : MonoBehaviour
+    {
+        /// <summary>
+        /// Devices for providing direction.
+        /// </summary>
+        /// <param name="Headset">The headset device.</param>
+        /// <param name="LeftController">The left controller device.</param>
+        /// <param name="RightController">The right controller device.</param>
+        /// <param name="ControlledObject">The controlled object.</param>
+        public enum DirectionDevices
+        {
+            Headset,
+            LeftController,
+            RightController,
+            ControlledObject
+        }
+
+        [Tooltip("An optional button that has to be engaged to allow the touchpad control to activate.")]
+        public VRTK_ControllerEvents.ButtonAlias primaryActivationButton = VRTK_ControllerEvents.ButtonAlias.Touchpad_Touch;
+        [Tooltip("An optional button that when engaged will activate the modifier on the touchpad control action.")]
+        public VRTK_ControllerEvents.ButtonAlias actionModifierButton = VRTK_ControllerEvents.ButtonAlias.Touchpad_Press;
+        [Tooltip("The direction that will be moved in is the direction of this device.")]
+        public DirectionDevices deviceForDirection = DirectionDevices.Headset;
+        [Tooltip("Any input on the axis will be ignored if it is within this deadzone threshold. Between `0f` and `1f`.")]
+        public Vector2 axisDeadzone = new Vector2(0.2f, 0.2f);
+        [Tooltip("The action to perform when the X axis changes.")]
+        public VRTK_BaseTouchpadControlAction xAxisActionScript;
+        [Tooltip("The action to perform when the Y axis changes.")]
+        public VRTK_BaseTouchpadControlAction yAxisActionScript;
+        [Tooltip("If this is checked then whenever the touchpad axis on the attached controller is being changed, all other touchpad control scripts on other controllers will be disabled.")]
+        public bool disableOtherControlsOnActive = true;
+        [Tooltip("If a `VRTK_BodyPhysics` script is present and this is checked, then the touchpad control will affect the play area whilst it is falling.")]
+        public bool affectOnFalling = false;
+        [Tooltip("An optional game object to apply the touchpad control to. If this is blank then the PlayArea will be controlled.")]
+        public GameObject controlOverrideObject;
+
+        private VRTK_ControllerEvents controllerEvents;
+        private VRTK_BodyPhysics bodyPhysics;
+        private VRTK_TouchpadControl otherTouchpadControl;
+        private GameObject controlledGameObject;
+        private GameObject setControlOverrideObject;
+        private Transform directionDevice;
+        private DirectionDevices previousDeviceForDirection;
+        private Vector2 touchpadAxis;
+        private bool currentlyFalling = false;
+        private bool modifierActive = false;
+        private bool touchpadFirstChange;
+        private bool otherTouchpadControlEnabledState;
+
+        protected virtual void OnEnable()
+        {
+            touchpadAxis = Vector2.zero;
+            controllerEvents = GetComponent<VRTK_ControllerEvents>();
+            SetControlledObject();
+            bodyPhysics = (!controlOverrideObject ? FindObjectOfType<VRTK_BodyPhysics>() : null);
+            touchpadFirstChange = true;
+
+            CheckSetupControlAction();
+            directionDevice = GetDirectionDevice();
+            SetListeners(true);
+            otherTouchpadControl = GetOtherControl();
+        }
+
+        protected virtual void OnDisable()
+        {
+            SetListeners(false);
+        }
+
+        protected virtual void Update()
+        {
+            if (controlOverrideObject != setControlOverrideObject)
+            {
+                SetControlledObject();
+            }
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            CheckDirectionDevice();
+            CheckFalling();
+            ModifierButtonActive();
+            if (xAxisActionScript && xAxisActionScript.enabled)
+            {
+                xAxisActionScript.ProcessFixedUpdate(controlledGameObject, directionDevice, directionDevice.right, touchpadAxis.x, axisDeadzone.x, currentlyFalling, modifierActive);
+            }
+
+            if (yAxisActionScript && yAxisActionScript.enabled)
+            {
+                yAxisActionScript.ProcessFixedUpdate(controlledGameObject, directionDevice, directionDevice.forward, touchpadAxis.y, axisDeadzone.y, currentlyFalling, modifierActive);
+            }
+        }
+
+        protected virtual void CheckSetupControlAction()
+        {
+            if (xAxisActionScript && yAxisActionScript && xAxisActionScript.GetInstanceID() == yAxisActionScript.GetInstanceID())
+            {
+                Debug.LogError("The `X Axis Action Script` and `Y Axis Action Script` cannot be the same script instance. Create seperate scripts for each axis action.");
+                return;
+            }
+        }
+
+        protected virtual VRTK_TouchpadControl GetOtherControl()
+        {
+            GameObject foundController = (VRTK_DeviceFinder.IsControllerLeftHand(gameObject) ? VRTK_DeviceFinder.GetControllerRightHand(false) : VRTK_DeviceFinder.GetControllerLeftHand(false));
+            if (foundController)
+            {
+                return foundController.GetComponent<VRTK_TouchpadControl>();
+            }
+            return null;
+        }
+
+        protected virtual void SetControlledObject()
+        {
+            setControlOverrideObject = controlOverrideObject;
+            controlledGameObject = (controlOverrideObject ? controlOverrideObject : VRTK_DeviceFinder.PlayAreaTransform().gameObject);
+        }
+
+        protected virtual void CheckFalling()
+        {
+            if (bodyPhysics && bodyPhysics.IsFalling())
+            {
+                if (!affectOnFalling)
+                {
+                    touchpadAxis = Vector2.zero;
+                }
+                currentlyFalling = true;
+            }
+
+            if (bodyPhysics && !bodyPhysics.IsFalling() && currentlyFalling)
+            {
+                touchpadAxis = Vector2.zero;
+                currentlyFalling = false;
+            }
+        }
+
+        protected virtual Transform GetDirectionDevice()
+        {
+            switch (deviceForDirection)
+            {
+                case DirectionDevices.ControlledObject:
+                    return controlledGameObject.transform;
+                case DirectionDevices.Headset:
+                    return VRTK_DeviceFinder.HeadsetTransform();
+                case DirectionDevices.LeftController:
+                    return VRTK_DeviceFinder.GetControllerLeftHand(true).transform;
+                case DirectionDevices.RightController:
+                    return VRTK_DeviceFinder.GetControllerRightHand(true).transform;
+            }
+
+            return null;
+        }
+
+        protected virtual void CheckDirectionDevice()
+        {
+            if (previousDeviceForDirection != deviceForDirection)
+            {
+                directionDevice = GetDirectionDevice();
+            }
+
+            previousDeviceForDirection = deviceForDirection;
+        }
+
+        private void SetListeners(bool state)
+        {
+            if (controllerEvents)
+            {
+                if (state)
+                {
+                    controllerEvents.TouchpadAxisChanged += TouchpadAxisChanged;
+                    controllerEvents.TouchpadTouchEnd += TouchpadTouchEnd;
+                }
+                else
+                {
+                    controllerEvents.TouchpadAxisChanged -= TouchpadAxisChanged;
+                    controllerEvents.TouchpadTouchEnd -= TouchpadTouchEnd;
+                }
+            }
+        }
+
+        private bool ValidPrimaryButton()
+        {
+            return (controllerEvents && (primaryActivationButton == VRTK_ControllerEvents.ButtonAlias.Undefined || controllerEvents.IsButtonPressed(primaryActivationButton)));
+        }
+
+        private void ModifierButtonActive()
+        {
+            modifierActive = (controllerEvents && actionModifierButton != VRTK_ControllerEvents.ButtonAlias.Undefined && controllerEvents.IsButtonPressed(actionModifierButton));
+        }
+
+        private void TouchpadAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (touchpadFirstChange && otherTouchpadControl && disableOtherControlsOnActive && e.touchpadAxis != Vector2.zero)
+            {
+                otherTouchpadControlEnabledState = otherTouchpadControl.enabled;
+                otherTouchpadControl.enabled = false;
+            }
+            touchpadAxis = (ValidPrimaryButton() ? e.touchpadAxis : Vector2.zero);
+
+            if (touchpadAxis != Vector2.zero)
+            {
+                touchpadFirstChange = false;
+            }
+        }
+
+        private void TouchpadTouchEnd(object sender, ControllerInteractionEventArgs e)
+        {
+            if (otherTouchpadControl && disableOtherControlsOnActive)
+            {
+                otherTouchpadControl.enabled = otherTouchpadControlEnabledState;
+            }
+            touchpadAxis = Vector2.zero;
+            touchpadFirstChange = true;
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadControl.cs.meta
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadControl.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 018581a6a9040b34d83404b882e892a6
+timeCreated: 1485940207
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System;
 
     /// <summary>
     /// Event Payload
@@ -47,6 +48,7 @@ namespace VRTK
     /// Snap rotate and flip direction options can be useful with teleport scripts for seated experiences and for people using front facing camera setups(Oculus default, PSVR). 
     /// </remarks>
     [RequireComponent(typeof(VRTK_BodyPhysics))]
+    [Obsolete("`VRTK_TouchpadMovement` has been replaced with `VRTK_TouchpadControl`. This script will be removed in a future version of VRTK.")]
     public class VRTK_TouchpadMovement : MonoBehaviour
     {
         /// <summary>

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadWalking.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadWalking.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System;
 
     /// <summary>
     /// The ability to move the play area around the game world by sliding a finger over the touchpad is achieved using this script.
@@ -12,6 +13,7 @@ namespace VRTK
     /// <example>
     /// `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
     /// </example>
+    [Obsolete("`VRTK_TouchpadWalking` has been replaced with `VRTK_TouchpadControl`. This script will be removed in a future version of VRTK.")]
     public class VRTK_TouchpadWalking : MonoBehaviour
     {
         [Tooltip("If this is checked then the left controller touchpad will be enabled to move the play area.")]

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_TouchpadControl_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_TouchpadControl_UnityEvents.cs
@@ -1,0 +1,66 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+
+    [RequireComponent(typeof(VRTK_TouchpadControl))]
+    public class VRTK_TouchpadControl_UnityEvents : MonoBehaviour
+    {
+        private VRTK_TouchpadControl tc;
+
+        [System.Serializable]
+        public class UnityObjectEvent : UnityEvent<object, TouchpadControlEventArgs> { };
+
+        /// <summary>
+        /// Emits the XAxisChanged class event.
+        /// </summary>
+        public UnityObjectEvent OnXAxisChanged = new UnityObjectEvent();
+
+        /// <summary>
+        /// Emits the YAxisChanged class event.
+        /// </summary>
+        public UnityObjectEvent OnYAxisChanged = new UnityObjectEvent();
+
+        private void SetTouchpadControl()
+        {
+            if (tc == null)
+            {
+                tc = GetComponent<VRTK_TouchpadControl>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            SetTouchpadControl();
+            if (tc == null)
+            {
+                Debug.LogError("The VRTK_TouchpadControl_UnityEvents script requires to be attached to a GameObject that contains a VRTK_TouchpadControl script");
+                return;
+            }
+
+            tc.XAxisChanged += XAxisChanged;
+            tc.YAxisChanged += YAxisChanged;
+        }
+
+        private void XAxisChanged(object o, TouchpadControlEventArgs e)
+        {
+            OnXAxisChanged.Invoke(o, e);
+        }
+
+        private void YAxisChanged(object o, TouchpadControlEventArgs e)
+        {
+            OnYAxisChanged.Invoke(o, e);
+        }
+
+        private void OnDisable()
+        {
+            if (tc == null)
+            {
+                return;
+            }
+
+            tc.XAxisChanged -= XAxisChanged;
+            tc.YAxisChanged -= YAxisChanged;
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_TouchpadControl_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_TouchpadControl_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3a23f31d00ebd0d408e15889a23d682f
+timeCreated: 1486046482
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1282,6 +1282,7 @@ This directory contains scripts that are used to provide different actions when 
  * [Slide Touchpad Control Action](#slide-touchpad-control-action-vrtk_slidetouchpadcontrolaction)
  * [Rotate Touchpad Control Action](#rotate-touchpad-control-action-vrtk_rotatetouchpadcontrolaction)
  * [Snap Rotate Touchpad Control Action](#snap-rotate-touchpad-control-action-vrtk_snaprotatetouchpadcontrolaction)
+ * [Warp Touchpad Control Action](#warp-touchpad-control-action-vrtk_warptouchpadcontrolaction)
 
 ---
 
@@ -1409,6 +1410,44 @@ The effect is a immediate snap rotation to quickly face in a new direction.
  * **Angle Multiplier:** The snap angle multiplier to be applied when the modifier button is pressed.
  * **Snap Delay:** The amount of time required to pass before another snap rotation can be carried out.
  * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.
+
+### Class Methods
+
+#### ProcessFixedUpdate/7
+
+  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
+
+  * Parameters
+   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
+   * `Transform directionDevice` - The device that is used for the direction.
+   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
+   * `float axis` - The value of the current touchpad touch point based across the axis direction.
+   * `float deadzone` - The value of the deadzone based across the axis direction.
+   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
+   * `bool modifierActive` - Whether the modifier button is pressed.
+  * Returns
+   * _none_
+
+The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+
+---
+
+## Warp Touchpad Control Action (VRTK_WarpTouchpadControlAction)
+ > extends [VRTK_BaseTouchpadControlAction](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
+
+### Overview
+
+The Warp Touchpad Control Action script is used to warp the controlled GameObject a given distance when changing the touchpad axis.
+
+The effect is a immediate snap to a new position in the given direction.
+
+### Inspector Parameters
+
+ * **Warp Distance:** The distance to warp in the facing direction.
+ * **Warp Multiplier:** The multiplier to be applied to the warp when the modifier button is pressed.
+ * **Warp Delay:** The amount of time required to pass before another warp can be carried out.
+ * **Floor Height Tolerance:** The height different in floor allowed to be a valid warp.
+ * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between warps can reduce nausia.
 
 ### Class Methods
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1025,6 +1025,13 @@ If the controlled object is the play area and `VRTK_BodyPhysics` is also availab
  * `XAxisChanged` - Emitted when the touchpad X Axis Changes.
  * `YAxisChanged` - Emitted when the touchpad Y Axis Changes.
 
+### Unity Events
+
+Adding the `VRTK_TouchpadControl_UnityEvents` component to `VRTK_TouchpadControl` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * `OnXAxisChanged` - Emits the XAxisChanged class event.
+ * `OnYAxisChanged` - Emits the YAxisChanged class event.
+
 ### Event Payload
 
  * `GameObject controlledGameObject` - The GameObject that is going to be affected.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -997,6 +997,8 @@ The ability to control an object with the touchpad based on the position of the 
 
 The Touchpad Control script forms the stub to allow for pre-defined actions to execute when the touchpad axis changes.
 
+This is enabled by the Touchpad Control script emitting an event each time the X axis and Y Axis on the touchpad change and the corresponding Touchpad Control Action registers with the appropriate axis event. This means that multiple Touchpad Control Actions can be triggered per axis change.
+
 This script is placed on the Script Alias of the Controller that is required to be affected by changes in the touchpad.
 
 If the controlled object is the play area and `VRTK_BodyPhysics` is also available, then additional logic is processed when the user is falling such as preventing the touchpad control from affecting a falling user.
@@ -1006,8 +1008,6 @@ If the controlled object is the play area and `VRTK_BodyPhysics` is also availab
  * **Primary Activation Button:** An optional button that has to be engaged to allow the touchpad control to activate.
  * **Action Modifier Button:** An optional button that when engaged will activate the modifier on the touchpad control action.
  * **Device For Direction:** The direction that will be moved in is the direction of this device.
- * **X Axis Action Script:** The action to perform when the X axis changes.
- * **Y Axis Action Script:** The action to perform when the Y axis changes.
  * **Disable Other Controls On Active:** If this is checked then whenever the touchpad axis on the attached controller is being changed, all other touchpad control scripts on other controllers will be disabled.
  * **Affect On Falling:** If a `VRTK_BodyPhysics` script is present and this is checked, then the touchpad control will affect the play area whilst it is falling.
  * **Control Override Object:** An optional game object to apply the touchpad control to. If this is blank then the PlayArea will be controlled.
@@ -1019,6 +1019,21 @@ If the controlled object is the play area and `VRTK_BodyPhysics` is also availab
   * `LeftController` - The left controller device.
   * `RightController` - The right controller device.
   * `ControlledObject` - The controlled object.
+
+### Class Events
+
+ * `XAxisChanged` - Emitted when the touchpad X Axis Changes.
+ * `YAxisChanged` - Emitted when the touchpad Y Axis Changes.
+
+### Event Payload
+
+ * `GameObject controlledGameObject` - The GameObject that is going to be affected.
+ * `Transform directionDevice` - The device that is used for the direction.
+ * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
+ * `Vector3 axis` - The value of the current touchpad touch point based across the axis direction.
+ * `float deadzone` - The value of the deadzone based across the axis direction.
+ * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
+ * `bool modifierActive` - Whether the modifier button is pressed.
 
 ### Example
 
@@ -1296,26 +1311,8 @@ As this is an abstract class, it cannot be applied directly to a game object and
 
 ### Inspector Parameters
 
- * **Axis Description:** A helper parameter to easily identify which axis this Touchpad Control Action is for.
-
-### Class Methods
-
-#### ProcessFixedUpdate/7
-
-  > `public abstract void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive);`
-
-  * Parameters
-   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
-   * `Transform directionDevice` - The device that is used for the direction.
-   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
-   * `float axis` - The value of the current touchpad touch point based across the axis direction.
-   * `float deadzone` - The value of the deadzone based across the axis direction.
-   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
-   * `bool modifierActive` - Whether the modifier button is pressed.
-  * Returns
-   * _none_
-
-The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+ * **Touchpad Control Script:** The Touchpad Control script to receive axis change events from.
+ * **Listen On Axis Change:** Determines which Touchpad Control Axis event to listen to.
 
 ---
 
@@ -1324,7 +1321,7 @@ The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Contr
 
 ### Overview
 
-The Slide Touchpad Controll Action script is used to slide the controlled GameObject around the scene when changing the touchpad axis.
+The Slide Touchpad Control Action script is used to slide the controlled GameObject around the scene when changing the touchpad axis.
 
 The effect is a smooth sliding motion in forward and sideways directions to simulate touchpad walking.
 
@@ -1335,28 +1332,11 @@ The effect is a smooth sliding motion in forward and sideways directions to simu
  * **Falling Deceleration:** The rate of speed deceleration when the touchpad is no longer being touched and the object is falling.
  * **Speed Multiplier:** The speed multiplier to be applied when the modifier button is pressed.
 
-### Class Methods
-
-#### ProcessFixedUpdate/7
-
-  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
-
-  * Parameters
-   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
-   * `Transform directionDevice` - The device that is used for the direction.
-   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
-   * `float axis` - The value of the current touchpad touch point based across the axis direction.
-   * `float deadzone` - The value of the deadzone based across the axis direction.
-   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
-   * `bool modifierActive` - Whether the modifier button is pressed.
-  * Returns
-   * _none_
-
-The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
-
 ### Example
 
 `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+
+To enable the Slide Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Slide` control script active.
 
 ---
 
@@ -1374,24 +1354,11 @@ The effect is a smooth rotation to simulate turning.
  * **Maximum Rotation Speed:** The maximum speed the controlled object can be rotated based on the position of the touchpad axis.
  * **Rotation Multiplier:** The rotation multiplier to be applied when the modifier button is pressed.
 
-### Class Methods
+### Example
 
-#### ProcessFixedUpdate/7
+`VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
 
-  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
-
-  * Parameters
-   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
-   * `Transform directionDevice` - The device that is used for the direction.
-   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
-   * `float axis` - The value of the current touchpad touch point based across the axis direction.
-   * `float deadzone` - The value of the deadzone based across the axis direction.
-   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
-   * `bool modifierActive` - Whether the modifier button is pressed.
-  * Returns
-   * _none_
-
-The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+To enable the Rotate Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Rotate` control script active.
 
 ---
 
@@ -1411,24 +1378,11 @@ The effect is a immediate snap rotation to quickly face in a new direction.
  * **Snap Delay:** The amount of time required to pass before another snap rotation can be carried out.
  * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.
 
-### Class Methods
+### Example
 
-#### ProcessFixedUpdate/7
+`VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
 
-  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
-
-  * Parameters
-   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
-   * `Transform directionDevice` - The device that is used for the direction.
-   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
-   * `float axis` - The value of the current touchpad touch point based across the axis direction.
-   * `float deadzone` - The value of the deadzone based across the axis direction.
-   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
-   * `bool modifierActive` - Whether the modifier button is pressed.
-  * Returns
-   * _none_
-
-The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+To enable the Snap Rotate Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Snap Rotate` control script active.
 
 ---
 
@@ -1449,24 +1403,11 @@ The effect is a immediate snap to a new position in the given direction.
  * **Floor Height Tolerance:** The height different in floor allowed to be a valid warp.
  * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between warps can reduce nausia.
 
-### Class Methods
+### Example
 
-#### ProcessFixedUpdate/7
+`VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
 
-  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
-
-  * Parameters
-   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
-   * `Transform directionDevice` - The device that is used for the direction.
-   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
-   * `float axis` - The value of the current touchpad touch point based across the axis direction.
-   * `float deadzone` - The value of the deadzone based across the axis direction.
-   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
-   * `bool modifierActive` - Whether the modifier button is pressed.
-  * Returns
-   * _none_
-
-The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+To enable the Warp Touchpad Control Action, ensure one of the `TouchpadControlOptions` children (located under the Controller script alias) has the `Warp` control script active.
 
 ---
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5,6 +5,7 @@ This file provides documentation on how to use the included prefabs and scripts.
  * [Prefabs](#prefabs-vrtkprefabs)
  * [Pointers](#pointers-vrtkscriptspointers)
  * [Locomotion](#locomotion-vrtkscriptslocomotion)
+  * [Touchpad Control Actions](#touchpad-control-actions-vrtkscriptslocomotiontouchpadcontrolactions)
  * [Interactions](#interactions-vrtkscriptsinteractions)
   * [Highlighters](#highlighters-vrtkscriptsinteractionshighlighters)
   * [Grab Attach Mechanics](#grab-attach-mechanics-vrtkscriptsinteractionsgrabattachmechanics)
@@ -820,6 +821,7 @@ A collection of scripts that provide varying methods of moving the user around t
  * [Dash Teleport](#dash-teleport-vrtk_dashteleport)
  * [Teleport Disable On Headset Collision](#teleport-disable-on-headset-collision-vrtk_teleportdisableonheadsetcollision)
  * [Teleport Disable On Controller Obscured](#teleport-disable-on-controller-obscured-vrtk_teleportdisableoncontrollerobscured)
+ * [Touchpad Control](#touchpad-control-vrtk_touchpadcontrol)
  * [Touchpad Walking](#touchpad-walking-vrtk_touchpadwalking)
  * [Touchpad Movement](#touchpad-movement-vrtk_touchpadmovement)
  * [Move In Place](#move-in-place-vrtk_moveinplace)
@@ -984,6 +986,43 @@ The purpose of the Teleport Disable On Headset Collision script is to detect whe
 ### Overview
 
 The purpose of the Teleport Disable On Controller Obscured script is to detect when the headset does not have a line of sight to the controllers and prevent teleportation from working. This is to ensure that if a user is clipping their controllers through a wall then they cannot teleport to an area beyond the wall.
+
+---
+
+## Touchpad Control (VRTK_TouchpadControl)
+
+### Overview
+
+The ability to control an object with the touchpad based on the position of the finger on the touchpad axis.
+
+The Touchpad Control script forms the stub to allow for pre-defined actions to execute when the touchpad axis changes.
+
+This script is placed on the Script Alias of the Controller that is required to be affected by changes in the touchpad.
+
+If the controlled object is the play area and `VRTK_BodyPhysics` is also available, then additional logic is processed when the user is falling such as preventing the touchpad control from affecting a falling user.
+
+### Inspector Parameters
+
+ * **Primary Activation Button:** An optional button that has to be engaged to allow the touchpad control to activate.
+ * **Action Modifier Button:** An optional button that when engaged will activate the modifier on the touchpad control action.
+ * **Device For Direction:** The direction that will be moved in is the direction of this device.
+ * **X Axis Action Script:** The action to perform when the X axis changes.
+ * **Y Axis Action Script:** The action to perform when the Y axis changes.
+ * **Disable Other Controls On Active:** If this is checked then whenever the touchpad axis on the attached controller is being changed, all other touchpad control scripts on other controllers will be disabled.
+ * **Affect On Falling:** If a `VRTK_BodyPhysics` script is present and this is checked, then the touchpad control will affect the play area whilst it is falling.
+ * **Control Override Object:** An optional game object to apply the touchpad control to. If this is blank then the PlayArea will be controlled.
+
+### Class Variables
+
+ * `public enum DirectionDevices` - Devices for providing direction.
+  * `Headset` - The headset device.
+  * `LeftController` - The left controller device.
+  * `RightController` - The right controller device.
+  * `ControlledObject` - The controlled object.
+
+### Example
+
+`VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
 
 ---
 
@@ -1232,6 +1271,89 @@ There is an additional script `VRTK_RoomExtender_PlayAreaGizmo` which can be att
 ### Example
 
 `VRTK/Examples/028_CameraRig_RoomExtender` shows how the RoomExtender script is controlled by a VRTK_RoomExtender_Controller Example script located at both controllers. Pressing the `Touchpad` on the controller activates the Room Extender. The Additional Movement Multiplier is changed based on the touch distance to the centre of the touchpad.
+
+---
+
+# Touchpad Control Actions (VRTK/Scripts/Locomotion/TouchpadControlActions)
+
+This directory contains scripts that are used to provide different actions when using Touchpad Control.
+
+ * [Base Touchpad Control Action](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
+ * [Slide Touchpad Control Action](#slide-touchpad-control-action-vrtk_slidetouchpadcontrolaction)
+
+---
+
+## Base Touchpad Control Action (VRTK_BaseTouchpadControlAction)
+
+### Overview
+
+The Base Touchpad Control Action script is an abstract class that all touchpad control action scripts inherit.
+
+As this is an abstract class, it cannot be applied directly to a game object and performs no logic.
+
+### Inspector Parameters
+
+ * **Axis Description:** A helper parameter to easily identify which axis this Touchpad Control Action is for.
+
+### Class Methods
+
+#### ProcessFixedUpdate/7
+
+  > `public abstract void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive);`
+
+  * Parameters
+   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
+   * `Transform directionDevice` - The device that is used for the direction.
+   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
+   * `float axis` - The value of the current touchpad touch point based across the axis direction.
+   * `float deadzone` - The value of the deadzone based across the axis direction.
+   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
+   * `bool modifierActive` - Whether the modifier button is pressed.
+  * Returns
+   * _none_
+
+The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+
+---
+
+## Slide Touchpad Control Action (VRTK_SlideTouchpadControlAction)
+ > extends [VRTK_BaseTouchpadControlAction](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
+
+### Overview
+
+The Slide Touchpad Controll Action script is used to slide the controlled GameObject around the scene when changing the touchpad axis.
+
+The effect is a smooth sliding motion in forward and sideways directions to simulate touchpad walking.
+
+### Inspector Parameters
+
+ * **Maximum Speed:** The maximum speed the controlled object can be moved in based on the position of the touchpad axis.
+ * **Deceleration:** The rate of speed deceleration when the touchpad is no longer being touched.
+ * **Falling Deceleration:** The rate of speed deceleration when the touchpad is no longer being touched and the object is falling.
+ * **Speed Multiplier:** The speed multiplier to be applied when the modifier button is pressed.
+
+### Class Methods
+
+#### ProcessFixedUpdate/7
+
+  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
+
+  * Parameters
+   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
+   * `Transform directionDevice` - The device that is used for the direction.
+   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
+   * `float axis` - The value of the current touchpad touch point based across the axis direction.
+   * `float deadzone` - The value of the deadzone based across the axis direction.
+   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
+   * `bool modifierActive` - Whether the modifier button is pressed.
+  * Returns
+   * _none_
+
+The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+
+### Example
+
+`VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
 
 ---
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1280,6 +1280,7 @@ This directory contains scripts that are used to provide different actions when 
 
  * [Base Touchpad Control Action](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
  * [Slide Touchpad Control Action](#slide-touchpad-control-action-vrtk_slidetouchpadcontrolaction)
+ * [Rotate Touchpad Control Action](#rotate-touchpad-control-action-vrtk_rotatetouchpadcontrolaction)
 
 ---
 
@@ -1354,6 +1355,41 @@ The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Contr
 ### Example
 
 `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad. There is also an area that can only be traversed if the user is crouching.
+
+---
+
+## Rotate Touchpad Control Action (VRTK_RotateTouchpadControlAction)
+ > extends [VRTK_BaseTouchpadControlAction](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
+
+### Overview
+
+The Rotate Touchpad Control Action script is used to rotate the controlled GameObject around the up vector when changing the touchpad axis.
+
+The effect is a smooth rotation to simulate turning.
+
+### Inspector Parameters
+
+ * **Maximum Rotation Speed:** The maximum speed the controlled object can be rotated based on the position of the touchpad axis.
+ * **Rotation Multiplier:** The rotation multiplier to be applied when the modifier button is pressed.
+
+### Class Methods
+
+#### ProcessFixedUpdate/7
+
+  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
+
+  * Parameters
+   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
+   * `Transform directionDevice` - The device that is used for the direction.
+   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
+   * `float axis` - The value of the current touchpad touch point based across the axis direction.
+   * `float deadzone` - The value of the deadzone based across the axis direction.
+   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
+   * `bool modifierActive` - Whether the modifier button is pressed.
+  * Returns
+   * _none_
+
+The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
 
 ---
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1384,6 +1384,7 @@ The effect is a immediate snap rotation to quickly face in a new direction.
  * **Angle Multiplier:** The snap angle multiplier to be applied when the modifier button is pressed.
  * **Snap Delay:** The amount of time required to pass before another snap rotation can be carried out.
  * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.
+ * **Axis Threshold:** The threshold the listened axis needs to exceed before the action occurs. This can be used to limit the snap rotate to a single axis direction (e.g. pull down to flip rotate). The threshold is ignored if it is 0.
 
 ### Example
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1281,6 +1281,7 @@ This directory contains scripts that are used to provide different actions when 
  * [Base Touchpad Control Action](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
  * [Slide Touchpad Control Action](#slide-touchpad-control-action-vrtk_slidetouchpadcontrolaction)
  * [Rotate Touchpad Control Action](#rotate-touchpad-control-action-vrtk_rotatetouchpadcontrolaction)
+ * [Snap Rotate Touchpad Control Action](#snap-rotate-touchpad-control-action-vrtk_snaprotatetouchpadcontrolaction)
 
 ---
 
@@ -1371,6 +1372,43 @@ The effect is a smooth rotation to simulate turning.
 
  * **Maximum Rotation Speed:** The maximum speed the controlled object can be rotated based on the position of the touchpad axis.
  * **Rotation Multiplier:** The rotation multiplier to be applied when the modifier button is pressed.
+
+### Class Methods
+
+#### ProcessFixedUpdate/7
+
+  > `public override void ProcessFixedUpdate(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)`
+
+  * Parameters
+   * `GameObject controlledGameObject` - The GameObject that is going to be affected.
+   * `Transform directionDevice` - The device that is used for the direction.
+   * `Vector3 axisDirection` - The axis that is being affected from the touchpad.
+   * `float axis` - The value of the current touchpad touch point based across the axis direction.
+   * `float deadzone` - The value of the deadzone based across the axis direction.
+   * `bool currentlyFalling` - Whether the controlled GameObject is currently falling.
+   * `bool modifierActive` - Whether the modifier button is pressed.
+  * Returns
+   * _none_
+
+The ProcessFixedUpdate method is run for every FixedUpdate on the Touchpad Control script.
+
+---
+
+## Snap Rotate Touchpad Control Action (VRTK_SnapRotateTouchpadControlAction)
+ > extends [VRTK_BaseTouchpadControlAction](#base-touchpad-control-action-vrtk_basetouchpadcontrolaction)
+
+### Overview
+
+The Snap Rotate Touchpad Control Action script is used to snap rotate the controlled GameObject around the up vector when changing the touchpad axis.
+
+The effect is a immediate snap rotation to quickly face in a new direction.
+
+### Inspector Parameters
+
+ * **Angle Per Snap:** The angle to rotate for each snap.
+ * **Angle Multiplier:** The snap angle multiplier to be applied when the modifier button is pressed.
+ * **Snap Delay:** The amount of time required to pass before another snap rotation can be carried out.
+ * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between rotations can reduce nausia.
 
 ### Class Methods
 


### PR DESCRIPTION
The new Touchpad Control script is a more generic implementation of the
existing Touchpad Walking script and it allows for custom touchpad
control actions to be written and used in place. This feature makes
the touchpad control aspect more composable and easier to create custom
features.

There is currently only one provided touchpad control action which is
the Slide action and it replicates the same functionality as the
existing Touchpad Walking script.

Because of this duplication in features, the Touchpad Walking script
has now been deprecated and a warning message is shown in the inspector
panel on the script.

The TouchpadWalking example scene has been updated to use the new
Touchpad Control script to provide a demonstration of how to use it.