### PR TITLE
refactor(ControllerEvents & friends) Flexible interactions

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerActions.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerActions.cs
@@ -6,6 +6,8 @@ namespace VRTK
     using System.Collections.Generic;
     using Highlighters;
 
+    using Hands = SDK_BaseController.ControllerHand;
+
     [System.Serializable]
     public class VRTK_ControllerModelElementPaths
     {
@@ -63,6 +65,9 @@ namespace VRTK
     /// </example>
     public class VRTK_ControllerActions : MonoBehaviour
     {
+        [Tooltip("The hand of the controller to provide the helper methods for. If this is set to None the game object this script is attached to will be used.")]
+        public Hands trackedHand = Hands.None;
+
         [Tooltip("A collection of strings that determine the path to the controller model sub elements for identifying the model parts at runtime. If the paths are left empty they will default to the model element paths of the selected SDK Bridge.\n\n"
          + "* The available model sub elements are:\n\n"
          + " * `Body Model Path`: The overall shape of the controller.\n"
@@ -123,6 +128,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The ControllerAlias property is useful for getting the script alias for the currently set trackedHand.
+        /// </summary>
+        /// <returns>Returns the current script alias GameObject for the currently set trackedHand.
+        public GameObject ControllerAlias 
+        {
+            get 
+            { 
+                return VRTK_DeviceFinder.GetScriptAliasByHand(trackedHand, gameObject); 
+            }
+        }
+
+        /// <summary>
         /// The IsControllerVisible method returns true if the controller is currently visible by whether the renderers on the controller are enabled.
         /// </summary>
         /// <returns>Is true if the controller model has the renderers that are attached to it are enabled.</returns>
@@ -146,7 +163,7 @@ namespace VRTK
             ToggleModelRenderers(modelContainer, state, grabbedChildObject);
 
             controllerVisible = state;
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(ControllerAlias);
             if (state)
             {
                 OnControllerModelVisible(SetActionEvent(controllerIndex));
@@ -367,7 +384,7 @@ namespace VRTK
             {
                 CancelHapticPulse();
                 var hapticPulseStrength = Mathf.Clamp(strength, 0f, 1f);
-                VRTK_SDK_Bridge.HapticPulseOnIndex(VRTK_DeviceFinder.GetControllerIndex(gameObject), hapticPulseStrength);
+                VRTK_SDK_Bridge.HapticPulseOnIndex(VRTK_DeviceFinder.GetControllerIndex(ControllerAlias), hapticPulseStrength);
             }
         }
 
@@ -395,14 +412,14 @@ namespace VRTK
         {
             highlighterOptions = new Dictionary<string, object>();
             highlighterOptions.Add("resetMainTexture", true);
-            VRTK_BaseHighlighter objectHighlighter = VRTK_BaseHighlighter.GetActiveHighlighter(gameObject);
+            VRTK_BaseHighlighter objectHighlighter = VRTK_BaseHighlighter.GetActiveHighlighter(ControllerAlias);
 
             if (objectHighlighter == null)
             {
                 objectHighlighter = gameObject.AddComponent<VRTK_MaterialColorSwapHighlighter>();
             }
 
-            var controllerHand = VRTK_DeviceFinder.GetControllerHand(gameObject);
+            var controllerHand = VRTK_DeviceFinder.GetControllerHand(ControllerAlias);
 
             objectHighlighter.Initialise(null, highlighterOptions);
             AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.ButtonOne, controllerHand)), objectHighlighter, elementHighlighterOverrides.buttonOne);
@@ -420,7 +437,7 @@ namespace VRTK
         {
             cachedElements = new Dictionary<string, Transform>();
 
-            var controllerHand = VRTK_DeviceFinder.GetControllerHand(gameObject);
+            var controllerHand = VRTK_DeviceFinder.GetControllerHand(ControllerAlias);
 
             if (modelElementPaths.bodyModelPath.Trim() == "")
             {
@@ -462,7 +479,7 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            modelContainer = (!modelContainer ? VRTK_DeviceFinder.GetModelAliasController(gameObject) : modelContainer);
+            modelContainer = (!modelContainer ? VRTK_DeviceFinder.GetModelAliasController(ControllerAlias) : modelContainer);
             StartCoroutine(WaitForModel());
         }
 
@@ -503,7 +520,7 @@ namespace VRTK
 
             while (duration > 0)
             {
-                VRTK_SDK_Bridge.HapticPulseOnIndex(VRTK_DeviceFinder.GetControllerIndex(gameObject), hapticPulseStrength);
+                VRTK_SDK_Bridge.HapticPulseOnIndex(VRTK_DeviceFinder.GetControllerIndex(ControllerAlias), hapticPulseStrength);
                 yield return new WaitForSeconds(pulseInterval);
                 duration -= pulseInterval;
             }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -4,6 +4,8 @@ namespace VRTK
     using UnityEngine;
     using System;
 
+    using Hands = SDK_BaseController.ControllerHand;
+
     /// <summary>
     /// Event Payload
     /// </summary>
@@ -79,6 +81,9 @@ namespace VRTK
             Button_Two_Press,
             Start_Menu_Press
         }
+
+        [Tooltip("The hand of the controller to propagate events for. If this is set to None the game object this script is attached to will be used.")]
+        public Hands trackedHand = Hands.None;
 
         [Header("Action Alias Buttons")]
 
@@ -820,13 +825,25 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The ControllerAlias property is useful for getting the script alias for the currently set trackedHand.
+        /// </summary>
+        /// <returns>Returns the current script alias GameObject for the currently set trackedHand.
+        public GameObject ControllerAlias 
+        { 
+            get 
+            { 
+                return VRTK_DeviceFinder.GetScriptAliasByHand(trackedHand, gameObject); 
+            } 
+        }
+
+        /// <summary>
         /// The GetVelocity method is useful for getting the current velocity of the physical game controller. This can be useful to determine the speed at which the controller is being swung or the direction it is being moved in.
         /// </summary>
         /// <returns>A 3 dimensional vector containing the current real world physical controller velocity.</returns>
         [Obsolete("`VRTK_ControllerEvents.GetVelocity()` has been replaced with `VRTK_DeviceFinder.GetControllerVelocity(givenController)`. This method will be removed in a future version of VRTK.")]
         public Vector3 GetVelocity()
         {
-            return VRTK_DeviceFinder.GetControllerVelocity(gameObject);
+            return VRTK_DeviceFinder.GetControllerVelocity(ControllerAlias);
         }
 
         /// <summary>
@@ -836,7 +853,7 @@ namespace VRTK
         [Obsolete("`VRTK_ControllerEvents.GetAngularVelocity()` has been replaced with `VRTK_DeviceFinder.GetControllerAngularVelocity(givenController)`. This method will be removed in a future version of VRTK.")]
         public Vector3 GetAngularVelocity()
         {
-            return VRTK_DeviceFinder.GetControllerAngularVelocity(gameObject);
+            return VRTK_DeviceFinder.GetControllerAngularVelocity(ControllerAlias);
         }
 
         /// <summary>
@@ -969,7 +986,7 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
+            var actualController = VRTK_DeviceFinder.GetActualController(ControllerAlias);
             if (actualController)
             {
                 var controllerTracker = actualController.GetComponent<VRTK_TrackedController>();
@@ -985,7 +1002,7 @@ namespace VRTK
         protected virtual void OnDisable()
         {
             Invoke("DisableEvents", 0f);
-            var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
+            var actualController = VRTK_DeviceFinder.GetActualController(ControllerAlias);
             if (actualController)
             {
                 var controllerTracker = actualController.GetComponent<VRTK_TrackedController>();
@@ -999,7 +1016,7 @@ namespace VRTK
 
         protected virtual void Update()
         {
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(ControllerAlias);
 
             //Only continue if the controller index has been set to a sensible number
             if (controllerIndex >= uint.MaxValue)
@@ -1617,7 +1634,7 @@ namespace VRTK
 
         private ControllerInteractionEventArgs SetButtonEvent(ref bool buttonBool, bool value, float buttonPressure)
         {
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(ControllerAlias);
             buttonBool = value;
             ControllerInteractionEventArgs e;
             e.controllerIndex = controllerIndex;
@@ -1841,7 +1858,7 @@ namespace VRTK
             gripAxisChanged = false;
             touchpadAxisChanged = false;
 
-            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(gameObject);
+            var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(ControllerAlias);
 
             if (controllerIndex < uint.MaxValue)
             {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -26,9 +26,16 @@ namespace VRTK
     ///
     /// `VRTK/Examples/014_Controller_SnappingObjectsOnGrab` demonstrates the different mechanisms for snapping a grabbed object to the controller.
     /// </example>
-    [RequireComponent(typeof(VRTK_InteractTouch)), RequireComponent(typeof(VRTK_ControllerEvents))]
     public class VRTK_InteractGrab : MonoBehaviour
     {
+
+        [Tooltip("The controller events instance to use. If this is left empty the game object this script is attached to will be searched for an instance of VRTK_ControllerEvents.")]
+        public VRTK_ControllerEvents controllerEvents;
+        [Tooltip("The controller actions instance to use. If this is left empty the game object this script is attached to will be searched for an instance of VRTK_ControllerActions.")]
+        public VRTK_ControllerActions controllerActions;
+        [Tooltip("The touch interaction instance to use. If this is left empty the game object this script is attached to will be searched for an instance of VRTK_InteractTouch.")]
+        public VRTK_InteractTouch interactTouch;
+
         [Tooltip("The rigidbody point on the controller model to snap the grabbed object to. If blank it will be set to the SDK default.")]
         public Rigidbody controllerAttachPoint = null;
         [Tooltip("An amount of time between when the grab button is pressed to when the controller is touching something to grab it. For example, if an object is falling at a fast rate, then it is very hard to press the grab button in time to catch the object due to human reaction times. A higher number here will mean the grab button can be pressed before the controller touches the object and when the collision takes place, if the grab button is still being held down then the grab action will be successful.")]
@@ -49,9 +56,6 @@ namespace VRTK
 
         private GameObject grabbedObject = null;
         private bool influencingGrabbedObject = false;
-        private VRTK_InteractTouch interactTouch;
-        private VRTK_ControllerActions controllerActions;
-        private VRTK_ControllerEvents controllerEvents;
         private int grabEnabledState = 0;
         private float grabPrecognitionTimer = 0f;
         private GameObject undroppableGrabbedObject;
@@ -100,9 +104,30 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            interactTouch = GetComponent<VRTK_InteractTouch>();
-            controllerActions = GetComponent<VRTK_ControllerActions>();
-            controllerEvents = GetComponent<VRTK_ControllerEvents>();
+            if (controllerEvents == null)
+            {
+                controllerEvents = GetComponent<VRTK_ControllerEvents>();
+            }
+            if (controllerEvents == null)
+            {
+                throw new System.Exception("InteractGrab requires a non-null VRTK_ControllerEvents instance. The field controllerEvents isn't set and there was no instance found on gameObject.");
+            }
+            if (controllerActions == null)
+            {
+                controllerActions = GetComponent<VRTK_ControllerActions>();
+            }
+            if (controllerActions == null)
+            {
+                throw new System.Exception("InteractGrab requires non-null VRTK_ControllerActions instance. The field controllerActions isn't set and there was no instance found on gameObject.");
+            }
+            if (interactTouch == null)
+            {
+                interactTouch = GetComponent<VRTK_InteractTouch>();
+            }
+            if (interactTouch == null)
+            {
+                throw new System.Exception("InteractGrab requires non-null VRTK_InteractTouch instance. The field interactTouch isn't set and there was no instance found on gameObject.");
+            }
         }
 
         protected virtual void OnEnable()
@@ -161,7 +186,7 @@ namespace VRTK
 
         private void SetControllerAttachPoint()
         {
-            var modelController = VRTK_DeviceFinder.GetModelAliasController(gameObject);
+            var modelController = VRTK_DeviceFinder.GetModelAliasController(controllerEvents.ControllerAlias);
             //If no attach point has been specified then just use the tip of the controller
             if (modelController && controllerAttachPoint == null)
             {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -23,6 +23,13 @@ namespace VRTK
     [RequireComponent(typeof(VRTK_InteractTouch)), RequireComponent(typeof(VRTK_ControllerEvents))]
     public class VRTK_InteractUse : MonoBehaviour
     {
+        [Tooltip("The controller events instance to use. If this is left empty the game object this script is attached to will be searched for an instance of VRTK_ControllerEvents.")]
+        public VRTK_ControllerEvents controllerEvents;
+        [Tooltip("The controller actions instance to use. If this is left empty the game object this script is attached to will be searched for an instance of VRTK_ControllerActions.")]
+        public VRTK_ControllerActions controllerActions;
+        [Tooltip("The touch interaction instance to use. If this is left empty the game object this script is attached to will be searched for an instance of VRTK_InteractTouch.")]
+        public VRTK_InteractTouch interactTouch;
+
         /// <summary>
         /// Emitted when a valid object starts being used.
         /// </summary>
@@ -33,9 +40,7 @@ namespace VRTK
         public event ObjectInteractEventHandler ControllerUnuseInteractableObject;
 
         private GameObject usingObject = null;
-        private VRTK_InteractTouch interactTouch;
-        private VRTK_ControllerActions controllerActions;
-        private VRTK_ControllerEvents controllerEvents;
+
 
         public virtual void OnControllerUseInteractableObject(ObjectInteractEventArgs e)
         {
@@ -86,9 +91,30 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            interactTouch = GetComponent<VRTK_InteractTouch>();
-            controllerActions = GetComponent<VRTK_ControllerActions>();
-            controllerEvents = GetComponent<VRTK_ControllerEvents>();
+            if (controllerEvents == null)
+            {
+                controllerEvents = GetComponent<VRTK_ControllerEvents>();
+            }
+            if (controllerEvents == null)
+            {
+                throw new System.Exception("Interactuse requires a non-null VRTK_ControllerEvents instance. The field controllerEvents isn't set and there was no instance found on gameObject.");
+            }
+            if (controllerActions == null)
+            {
+                controllerActions = GetComponent<VRTK_ControllerActions>();
+            }
+            if (controllerActions == null)
+            {
+                throw new System.Exception("InteractUse requires non-null VRTK_ControllerActions instance. The field controllerActions isn't set and there was no instance found on gameObject.");
+            }
+            if (interactTouch == null)
+            {
+                interactTouch = GetComponent<VRTK_InteractTouch>();
+            }
+            if (interactTouch == null)
+            {
+                throw new System.Exception("InteractUse requires non-null VRTK_InteractTouch instance. The field interactTouch isn't set and there was no instance found on gameObject.");
+            }
         }
 
         protected virtual void OnEnable()

--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -238,6 +238,29 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetScriptAliasByHand method will attempt to get the object that contains the scripts for the specified hand.
+        /// </summary>
+        /// <param name="hand">The SDK_BaseController.ControllerHand of the desired script alias.</param>
+        /// <returns>The GameObject that is the alias controller containing the scripts of the desired hand.</returns>
+        public static GameObject GetScriptAliasByHand(SDK_BaseController.ControllerHand hand, GameObject defaultTo)
+        {
+            if (VRTK_SDKManager.instance == null)
+            {
+                return defaultTo;
+            }
+
+            switch (hand)
+            {
+                case SDK_BaseController.ControllerHand.Left:
+                    return VRTK_SDKManager.instance.scriptAliasLeftController;
+                case SDK_BaseController.ControllerHand.Right:
+                    return VRTK_SDKManager.instance.scriptAliasRightController;
+                default:
+                    return defaultTo;
+            }
+        }
+
+        /// <summary>
         /// The GetModelAliasController method will attempt to get the object that contains the model for the controller.
         /// </summary>
         /// <param name="givenController">The GameObject of the controller.</param>


### PR DESCRIPTION
These changes, described further in the commit messages, attempt to decouple the core interaction scripts from the objects assigned as the current script aliases, and from having to share a GameObject parent.

To accomplish this, public fields that are inspector editable have been added so that the dependencies between these scripts can be organized in arbitrary ways. In the cases that the new fields are left null, they will assume the local GameObject parent as before.

Most noteworthy, the two core interaction scripts `ControllerEvents` and `ControllerActions` now feature an `SDK_BaseController.ControllerHands` typed field denoting which controller they should poll events for. The default of `ControllerHands.None` will cause them to use the local parent GameObject as before.