### PR TITLE
fix(Highlighters): Added option to merge submeshes on copy

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -1,4 +1,4 @@
-﻿// Outline Object Copy|Highlighters|40030
+// Outline Object Copy|Highlighters|40030
 namespace VRTK.Highlighters
 {
     using UnityEngine;
@@ -21,6 +21,8 @@ namespace VRTK.Highlighters
         public GameObject customOutlineModel;
         [Tooltip("A path to a GameObject to find at runtime, if the GameObject doesn't exist at edit time.")]
         public string customOutlineModelPath = "";
+        [Tooltip("If your mesh has multiple submeshes you wish to highlight, you'll want to check this otherwise only the first mesh will be highlighted")]
+        public bool enableSubmeshHighlight = false;
 
         private Material stencilOutline;
         private GameObject highlightModel;
@@ -163,7 +165,25 @@ namespace VRTK.Highlighters
             var highlightMesh = highlightModel.GetComponent<MeshFilter>();
             if (highlightMesh)
             {
-                highlightModel.GetComponent<MeshFilter>().mesh = copyMesh.mesh;
+                if (enableSubmeshHighlight)
+                {
+                    List<CombineInstance> combine = new List<CombineInstance>();
+
+                    for (int i = 0; i < copyMesh.mesh.subMeshCount; i++)
+                    {
+                        CombineInstance ci = new CombineInstance();
+                        ci.mesh = copyMesh.mesh;
+                        ci.subMeshIndex = i;
+                        ci.transform = copyMesh.transform.localToWorldMatrix;
+                        combine.Add(ci);
+                    }
+
+                    highlightMesh.mesh = new Mesh();
+                    highlightMesh.CombineMeshes(combine.ToArray(), true, false);
+                } else {
+                    highlightMesh.mesh = copyMesh.mesh;
+                }
+
                 highlightModel.GetComponent<Renderer>().material = stencilOutline;
             }
             highlightModel.SetActive(false);

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -21,7 +21,7 @@ namespace VRTK.Highlighters
         public GameObject customOutlineModel;
         [Tooltip("A path to a GameObject to find at runtime, if the GameObject doesn't exist at edit time.")]
         public string customOutlineModelPath = "";
-        [Tooltip("If your mesh has multiple submeshes you wish to highlight, you'll want to check this otherwise only the first mesh will be highlighted")]
+        [Tooltip("If the mesh has multiple sub-meshes to highlight then this should be checked, otherwise only the first mesh will be highlighted.")]
         public bool enableSubmeshHighlight = false;
 
         private Material stencilOutline;
@@ -180,7 +180,9 @@ namespace VRTK.Highlighters
 
                     highlightMesh.mesh = new Mesh();
                     highlightMesh.CombineMeshes(combine.ToArray(), true, false);
-                } else {
+                }
+                else
+                {
                     highlightMesh.mesh = copyMesh.mesh;
                 }
 


### PR DESCRIPTION
Previously was only highlighting the first submesh found, rather than
the whole mesh. Added as a bool option to avoid any unforeseen
consequences for current users

Not to be confused with multiple MeshRenderers/objects,
that's a different problem altogether.