### PR TITLE
fix(Pointer): update interactor collider in FixedUpdate - fixes #911

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -156,6 +156,10 @@ namespace VRTK
 
         protected virtual void Update()
         {
+        }
+
+        protected virtual void FixedUpdate()
+        {
             if (interactWithObjects && objectInteractor && objectInteractor.activeInHierarchy)
             {
                 UpdateObjectInteractor();


### PR DESCRIPTION
The interactor collider is updated to match the current pointer
position. Previously, it was done in the Update method but this meant
that the interactor collider would lag behind the pointer tip causing
issues.

Putting the update of the interactor collider in the FixedUpdate
method means it is updated more frequently and therefore it has a
higher level of fidelity removing any glitches that were previously
showing up.