### PR TITLE
fix(Interaction): only set force dropped when stop grabbing

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -715,7 +715,7 @@ namespace VRTK
         {
             if (gameObject.activeInHierarchy)
             {
-                transform.parent = previousParent;
+                transform.SetParent(previousParent);
                 forcedDropped = false;
             }
             if (interactableRigidbody)
@@ -962,7 +962,6 @@ namespace VRTK
                 if (touchingObject.activeInHierarchy || forceDisabled)
                 {
                     touchingObject.GetComponent<VRTK_InteractTouch>().ForceStopTouching();
-                    forcedDropped = true;
                 }
             }
         }
@@ -985,7 +984,6 @@ namespace VRTK
             {
                 usingObject.GetComponent<VRTK_InteractTouch>().ForceStopTouching();
                 usingObject.GetComponent<VRTK_InteractUse>().ForceStopUsing();
-                forcedDropped = true;
             }
         }
 


### PR DESCRIPTION
Previously, the `forceDropped` was set to true when stop touching and
stop using was called. This would cause issues when an object was
disabled and re-enabled as the previous state would be loaded even
though it hasn't currently been saved.

There is no reason to set `forceDropped` to true on stop touch or
stop use as it's only relevant when an object is being grabbed because
this is the only way it can be force dropped.