### PR TITLE
fix(Climbing): Jitter on second hand grab climb state

### DIFF
--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -380,6 +380,8 @@ namespace VRTK
             {
                 bodyCollider.isTrigger = !state;
             }
+
+            currentBodyCollisionsSetting = state;
         }
 
         private void CheckBodyCollisionsSetting()
@@ -388,7 +390,6 @@ namespace VRTK
             {
                 TogglePhysics(enableBodyCollisions);
             }
-            currentBodyCollisionsSetting = enableBodyCollisions;
         }
 
         private void CheckFalling()


### PR DESCRIPTION
When climbing, grabbing the same object with your other hand
would not put the PlayerClimb physics kinematic state in the
correct value. This came from the correct state not being stored
when the player velocity modifies the object. This would cause
heavy flickering of the Oculus touch controllers as physics was
fighting with the system to get the player area in the correct
spot.