### PR TITLE
fix(Pointer): ensure visibility and interaction states are toggled

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -99,9 +99,18 @@ namespace VRTK
                 controllingPointer.ResetActivationTimer();
                 PointerExit(destinationHit);
             }
-            ToggleObjectInteraction(pointerState);
+            ToggleInteraction(pointerState);
             TogglePlayArea(pointerState, actualState);
             ToggleRenderer(pointerState, actualState);
+        }
+
+        /// <summary>
+        /// The ToggleInteraction method is used to enable or disable the controller extension interactions.
+        /// </summary>
+        /// <param name="state">If true then the object interactor will be enabled.</param>
+        public virtual void ToggleInteraction(bool state)
+        {
+            ToggleObjectInteraction(state);
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
@@ -67,7 +67,7 @@ namespace VRTK
         /// </summary>
         public override void UpdateRenderer()
         {
-            if ((controllingPointer && controllingPointer.IsPointerActive()) || tracerVisible || cursorVisible)
+            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsTracerVisible() || IsCursorVisible())
             {
                 Vector3 jointPosition = ProjectForwardBeam();
                 Vector3 downPosition = ProjectDownBeam(jointPosition);
@@ -133,6 +133,16 @@ namespace VRTK
         {
             base.ChangeMaterial(givenColor);
             ChangeMaterialColor(actualCursor, givenColor);
+        }
+
+        protected virtual bool IsTracerVisible()
+        {
+            return (tracerVisibility == VisibilityStates.AlwaysOn || tracerVisible);
+        }
+
+        protected virtual bool IsCursorVisible()
+        {
+            return (cursorVisibility == VisibilityStates.AlwaysOn || cursorVisible);
         }
 
         protected virtual void CreateTracer()

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -47,7 +47,7 @@ namespace VRTK
         /// </summary>
         public override void UpdateRenderer()
         {
-            if ((controllingPointer && controllingPointer.IsPointerActive()) || tracerVisible || cursorVisible)
+            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsTracerVisible() || IsCursorVisible())
             {
                 float tracerLength = CastRayForward();
                 SetPointerAppearance(tracerLength);
@@ -100,6 +100,16 @@ namespace VRTK
             {
                 objectInteractor.transform.position = actualCursor.transform.position;
             }
+        }
+
+        protected virtual bool IsTracerVisible()
+        {
+            return (tracerVisibility == VisibilityStates.AlwaysOn || tracerVisible);
+        }
+
+        protected virtual bool IsCursorVisible()
+        {
+            return (cursorVisibility == VisibilityStates.AlwaysOn || cursorVisible);
         }
 
         protected virtual void CreateTracer()

--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -173,6 +173,11 @@ namespace VRTK
             {
                 pointerRenderer.InitalizePointer(this, invalidListPolicy, navMeshCheckDistance, headsetPositionCompensation);
                 pointerRenderer.UpdateRenderer();
+                if (!IsPointerActive())
+                {
+                    bool interactionState = (pointerRenderer.tracerVisibility == VRTK_BasePointerRenderer.VisibilityStates.AlwaysOn || pointerRenderer.cursorVisibility == VRTK_BasePointerRenderer.VisibilityStates.AlwaysOn);
+                    pointerRenderer.ToggleInteraction(interactionState);
+                }
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -905,6 +905,17 @@ The InitalizePointer method is used to set up the state of the pointer renderer.
 
 The Toggle Method is used to enable or disable the pointer renderer.
 
+#### ToggleInteraction/1
+
+  > `public virtual void ToggleInteraction(bool state)`
+
+  * Parameters
+   * `bool state` - If true then the object interactor will be enabled.
+  * Returns
+   * _none_
+
+The ToggleInteraction method is used to enable or disable the controller extension interactions.
+
 #### UpdateRenderer/0
 
   > `public virtual void UpdateRenderer()`


### PR DESCRIPTION
There was an issue where the cursor and tracer visibility could not
be toggled to always visible unless a toggle event was called.

There was another issue where if the tracer or cursor was active
that the interaction object would not be enabled until the pointer
activation button was pressed.

This has now been fixed by ensuring the correct state of the tracer
and cursor visibility is checked taking into account the visibility
state. Also, if the tracer or cursor is visible even when the
pointer activation button hasn't been pressed then the object
interactor will be activate.