### PR TITLE
fix(Pointer): prevent flickering when activating an always on pointer

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
@@ -59,15 +59,12 @@ namespace VRTK
         protected GameObject actualInvalidLocationObject = null;
         protected Vector3 fixedForwardBeamForward;
 
-        protected bool tracerVisible;
-        protected bool cursorVisible;
-
         /// <summary>
         /// The UpdateRenderer method is used to run an Update routine on the pointer.
         /// </summary>
         public override void UpdateRenderer()
         {
-            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsTracerVisible() || IsCursorVisible())
+            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsVisible())
             {
                 Vector3 jointPosition = ProjectForwardBeam();
                 Vector3 downPosition = ProjectDownBeam(jointPosition);
@@ -81,7 +78,7 @@ namespace VRTK
         {
             TogglePointerCursor(pointerState, actualState);
             TogglePointerTracer(pointerState, actualState);
-            if (actualState)
+            if (actualState && tracerVisibility != VisibilityStates.AlwaysOn)
             {
                 ToggleRendererVisibility(actualTracer.gameObject, false);
                 AddVisibleRenderer(actualTracer.gameObject);
@@ -133,16 +130,6 @@ namespace VRTK
         {
             base.ChangeMaterial(givenColor);
             ChangeMaterialColor(actualCursor, givenColor);
-        }
-
-        protected virtual bool IsTracerVisible()
-        {
-            return (tracerVisibility == VisibilityStates.AlwaysOn || tracerVisible);
-        }
-
-        protected virtual bool IsCursorVisible()
-        {
-            return (cursorVisibility == VisibilityStates.AlwaysOn || cursorVisible);
         }
 
         protected virtual void CreateTracer()

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -38,8 +38,6 @@ namespace VRTK
         protected GameObject actualTracer;
         protected GameObject actualCursor;
 
-        protected bool tracerVisible;
-        protected bool cursorVisible;
         protected Vector3 cursorOriginalScale = Vector3.one;
 
         /// <summary>
@@ -47,7 +45,7 @@ namespace VRTK
         /// </summary>
         public override void UpdateRenderer()
         {
-            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsTracerVisible() || IsCursorVisible())
+            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsVisible())
             {
                 float tracerLength = CastRayForward();
                 SetPointerAppearance(tracerLength);
@@ -100,16 +98,6 @@ namespace VRTK
             {
                 objectInteractor.transform.position = actualCursor.transform.position;
             }
-        }
-
-        protected virtual bool IsTracerVisible()
-        {
-            return (tracerVisibility == VisibilityStates.AlwaysOn || tracerVisible);
-        }
-
-        protected virtual bool IsCursorVisible()
-        {
-            return (cursorVisibility == VisibilityStates.AlwaysOn || cursorVisible);
         }
 
         protected virtual void CreateTracer()

--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -6,7 +6,6 @@ namespace VRTK
 #if UNITY_5_5_OR_NEWER
     using UnityEngine.AI;
 #endif
-    using System;
 
     /// <summary>
     /// This abstract class provides any game pointer the ability to know the state of the implemented pointer.
@@ -32,9 +31,6 @@ namespace VRTK
             Always_Off
         }
 
-        /// <summary>
-        /// Specifies the smoothing to be applied to the pointer.
-        /// </summary>
         [Serializable]
         public sealed class PointerOriginSmoothingSettings
         {

--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -128,6 +128,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsActive method returns whether the play area cursor game object is active or not.
+        /// </summary>
+        /// <returns>Returns true if the play area cursor GameObject is active.</returns>
+        public virtual bool IsActive()
+        {
+            return playAreaCursor.activeInHierarchy;
+        }
+
+        /// <summary>
         /// The GetPlayAreaContainer method returns the created game object that holds the play area cursor representation.
         /// </summary>
         /// <returns>The GameObject that is the container of the play area cursor.</returns>
@@ -297,9 +306,17 @@ namespace VRTK
             targetListPolicy = list;
         }
 
+        protected virtual void OnDisable()
+        {
+            if (parent)
+            {
+                parent.SetPlayAreaCursorCollision(false);
+            }
+        }
+
         protected virtual void OnTriggerStay(Collider collider)
         {
-            if (parent.enabled && parent.gameObject.activeInHierarchy && ValidTarget(collider))
+            if (parent && parent.enabled && parent.gameObject.activeInHierarchy && ValidTarget(collider))
             {
                 parent.SetPlayAreaCursorCollision(true);
             }
@@ -307,7 +324,7 @@ namespace VRTK
 
         protected virtual void OnTriggerExit(Collider collider)
         {
-            if (ValidTarget(collider))
+            if (parent && ValidTarget(collider))
             {
                 parent.SetPlayAreaCursorCollision(false);
             }

--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -175,8 +175,8 @@ namespace VRTK
                 pointerRenderer.UpdateRenderer();
                 if (!IsPointerActive())
                 {
-                    bool interactionState = (pointerRenderer.tracerVisibility == VRTK_BasePointerRenderer.VisibilityStates.AlwaysOn || pointerRenderer.cursorVisibility == VRTK_BasePointerRenderer.VisibilityStates.AlwaysOn);
-                    pointerRenderer.ToggleInteraction(interactionState);
+                    bool currentPointerVisibility = pointerRenderer.IsVisible();
+                    pointerRenderer.ToggleInteraction(currentPointerVisibility);
                 }
             }
         }

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
@@ -1,4 +1,5 @@
-﻿namespace VRTK
+﻿// Rigidbody Follow|Utilities|90061
+namespace VRTK
 {
     using UnityEngine;
 

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
@@ -1,4 +1,5 @@
-﻿namespace VRTK
+﻿// Transform Follow|Utilities|90062
+namespace VRTK
 {
     using UnityEngine;
 


### PR DESCRIPTION
If the tracer or cursor was set to always on and the activation button
was pressed then the cursor would be set to disable renderers and
re-enable next frame which would cause the flickering.

This has now been resolved by only calling the disable if the pointer
isn't using always on.

Another issue has been fixed with the play area cursor not coming on
and staying on at the right times. It should always come on when the
cursor is active as it's an extension of the cursor.

The documentation has also been generated, which includes the docs
for the pointer smoothing work as well.