### PR TITLE
fix(PositionRewind): reset play area velocity on rewind.

### DIFF
--- a/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
@@ -21,6 +21,7 @@ namespace VRTK
 
         private Transform headset;
         private Transform playArea;
+        protected Rigidbody playareaRigidbody;
 
         private VRTK_HeadsetCollision headsetCollision;
 
@@ -38,6 +39,7 @@ namespace VRTK
             lastGoodPositionSet = false;
             headset = VRTK_DeviceFinder.HeadsetTransform();
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
+            playareaRigidbody = playArea.GetComponent<Rigidbody>();
             headsetCollision = GetComponent<VRTK_HeadsetCollision>();
             ManageHeadsetListeners(true);
             if (!playArea)
@@ -123,6 +125,11 @@ namespace VRTK
                 var finalPosition = resetPosition + (pushbackDistance * pushbackPosition);
 
                 playArea.position = finalPosition;
+                if (playareaRigidbody)
+                {
+                    playareaRigidbody.velocity = Vector3.zero;
+                    playareaRigidbody.angularVelocity = Vector3.zero;
+                }
             }
         }
 


### PR DESCRIPTION
If any play area velocity is being applied prior to the rewind then
it will be applied to the play area when the rewind happens.

This fix checks to see if the play area has a rigidbody and force
resets the velocity to zero on rewind.