### PR TITLE
feat(Editor): Add warning messages for missing VRTK_Interact* scripts

### DIFF
--- a/Assets/VRTK/Editor/VRTK_ControllerActionsEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_ControllerActionsEditor.cs
@@ -1,0 +1,82 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using UnityEditor;
+    using System;
+    using ControllerHand = SDK_BaseController.ControllerHand;
+    using AllowedController = VRTK_InteractableObject.AllowedController;
+
+    [CustomEditor(typeof(VRTK_ControllerActions), true)]
+    public class VRTK_ControllerActionsEditor : Editor
+    {
+        protected GameObject controller;
+
+        private void OnEnable()
+        {
+            controller = ((VRTK_ControllerActions)target).gameObject;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            // Only check for interactable objects that apply to this controller hand
+            var hand = VRTK_DeviceFinder.GetControllerHand(controller);
+            Func<AllowedController, bool> isHand = (AllowedController allowedController) =>
+            {
+                if (allowedController == AllowedController.Both)
+                {
+                    return true;
+                }
+                if (hand == ControllerHand.Left && allowedController == AllowedController.Left_Only)
+                {
+                    return true;
+                }
+                if (hand == ControllerHand.Right && allowedController == AllowedController.Right_Only)
+                {
+                    return true;
+                }
+                return false;
+            };
+
+            if (controller.GetComponent<VRTK_InteractTouch>() == null
+                && DoesSceneContainInteractableObjects((interactableObject) => isHand(interactableObject.allowedTouchControllers)))
+            {
+                EditorGUILayout.HelpBox("VRTK_InteractTouch is missing, controller will be unable to touch interactable objects", MessageType.Warning);
+            }
+
+            if (controller.GetComponent<VRTK_InteractGrab>() == null
+                && DoesSceneContainInteractableObjects((interactableObject) => interactableObject.isGrabbable && isHand(interactableObject.allowedGrabControllers)))
+            {
+                EditorGUILayout.HelpBox("VRTK_InteractGrab is missing, controller will be unable to grab interactable objects", MessageType.Warning);
+            }
+
+            if (controller.GetComponent<VRTK_InteractUse>() == null
+                && DoesSceneContainInteractableObjects((interactableObject) => interactableObject.isUsable && isHand(interactableObject.allowedUseControllers)))
+            {
+                EditorGUILayout.HelpBox("VRTK_InteractUse is missing, controller will be unable to use interactable objects", MessageType.Warning);
+            }
+
+            DrawDefaultInspector();
+        }
+
+        /// <summary>
+        /// Check the scene for the presence of any `VRTK_InteractableObject` components.
+        /// </summary>
+        /// <param name="filter">A lambda that may return false to exclude an interactable object from the search</param>
+        /// <returns>Whether the scene contains any objects that are interactable and pass the filter</returns>
+        protected bool DoesSceneContainInteractableObjects(Func<VRTK_InteractableObject, bool> filter)
+        {
+            VRTK_InteractableObject[] interactableObjects = FindObjectsOfType<VRTK_InteractableObject>();
+            foreach (var interactableObject in interactableObjects)
+            {
+                if (!filter(interactableObject))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_ControllerActionsEditor.cs.meta
+++ b/Assets/VRTK/Editor/VRTK_ControllerActionsEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 595bbdcb22cf76142aa4c47fe62393ef
+timeCreated: 1487785177
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs
@@ -1,0 +1,120 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using UnityEditor;
+    using AllowedController = VRTK_InteractableObject.AllowedController;
+
+    [CustomEditor(typeof(VRTK_InteractableObject), true)]
+    public class VRTK_InteractableObjectEditor : Editor
+    {
+        private SerializedProperty isGrabbable;
+        private SerializedProperty isUsable;
+        private SerializedProperty allowedTouchControllers;
+        private SerializedProperty allowedGrabControllers;
+        private SerializedProperty allowedUseControllers;
+
+        protected VRTK_InteractableObject interactableObject;
+
+        private void OnEnable()
+        {
+            interactableObject = (VRTK_InteractableObject)target;
+
+            isGrabbable = serializedObject.FindProperty("isGrabbable");
+            isUsable = serializedObject.FindProperty("isUsable");
+            allowedTouchControllers = serializedObject.FindProperty("allowedTouchControllers");
+            allowedGrabControllers = serializedObject.FindProperty("allowedGrabControllers");
+            allowedUseControllers = serializedObject.FindProperty("allowedUseControllers");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            // Check for issues with the ability to touch objects
+            RequireInteractScriptOnController<VRTK_InteractTouch>(
+                allowedControllers: (AllowedController)allowedTouchControllers.intValue,
+                noControllersMessage: "Controller aliases cannot be found in the current scene, make sure prefabs use the VRTK_InteractTouch script",
+                missingComponentsMessage: "VRTK_InteractTouch is missing from the controller aliases, they will be unable to touch this object",
+                missingOneComponentMessage: "VRTK_InteractTouch is missing from the \"{0}\" controller alias, it will be unable to touch this object"
+            );
+
+            // Check for issues with the ability to grab objects
+            if (isGrabbable.boolValue)
+            {
+                RequireInteractScriptOnController<VRTK_InteractGrab>(
+                    allowedControllers: (AllowedController)allowedGrabControllers.intValue,
+                    noControllersMessage: "Controller aliases cannot be found in the current scene, make sure prefabs use the VRTK_InteractGrab script",
+                    missingComponentsMessage: "VRTK_InteractGrab is missing from the controller aliases, they will be unable to grab this object",
+                    missingOneComponentMessage: "VRTK_InteractGrab is missing from the \"{0}\" controller alias, it will be unable to grab this object"
+                );
+            }
+
+            // Check for issues with the ability to use objects
+            if (isUsable.boolValue)
+            {
+                RequireInteractScriptOnController<VRTK_InteractUse>(
+                    allowedControllers: (AllowedController)allowedUseControllers.intValue,
+                    noControllersMessage: "Controller aliases cannot be found in the current scene, make sure prefabs use the VRTK_InteractUse script",
+                    missingComponentsMessage: "VRTK_InteractUse is missing from the controller aliases, they will be unable to use this object",
+                    missingOneComponentMessage: "VRTK_InteractUse is missing from the \"{0}\" controller alias, it will be unable to use this object"
+                );
+            }
+
+            DrawDefaultInspector();
+        }
+
+        /// <summary>
+        /// Ensure that the controller aliases contain a VRTK_Interact* script
+        /// </summary>
+        /// <typeparam name="T">The VRTK_Interact* script type</typeparam>
+        /// <param name="allowedControllers">The AllowedControllers value for this type of interaction</param>
+        /// <param name="noControllersMessage">The message to use when required controllers are not present in the scene</param>
+        /// <param name="missingComponentsMessage">The message to use when both controllers are missing the script</param>
+        /// <param name="missingOneComponentMessage">The message to use when one controller is missing the script</param>
+        protected void RequireInteractScriptOnController<T>(AllowedController allowedControllers, string noControllersMessage, string missingComponentsMessage, string missingOneComponentMessage) where T : MonoBehaviour
+        {
+            GameObject leftController = VRTK_DeviceFinder.GetControllerLeftHand();
+            GameObject rightController = VRTK_DeviceFinder.GetControllerRightHand();
+
+            bool areControllersMissing = false;
+
+            switch (allowedControllers)
+            {
+                case AllowedController.Left_Only:
+                    areControllersMissing = leftController == null;
+                    rightController = null;
+                    break;
+                case AllowedController.Right_Only:
+                    areControllersMissing = rightController == null;
+                    leftController = null;
+                    break;
+                default:
+                    areControllersMissing = leftController == null && rightController == null;
+                    break;
+            }
+
+            if (areControllersMissing)
+            {
+                // If there are no "Controllers" they may be inserted from prefabs or another scene
+                EditorGUILayout.HelpBox(noControllersMessage, MessageType.Info);
+                return;
+            }
+
+            // Valid = Does not require script or has script
+            bool isLeftControllerValid = leftController == null || leftController.GetComponent<T>() != null;
+            bool isRightControllerValid = rightController == null || rightController.GetComponent<T>() != null;
+
+            // If a "Controller" exists but no Interact* scripts can be found it was probably forgotten
+            if (!isLeftControllerValid && !isRightControllerValid)
+            {
+                // Both controllers are missing the interaction script
+                EditorGUILayout.HelpBox(missingComponentsMessage, MessageType.Warning);
+            }
+            else if (!isLeftControllerValid || !isRightControllerValid)
+            {
+                // One required controller is missing the interaction script
+                string missingOnHand = isLeftControllerValid ? "right" : "left";
+                string message = string.Format(missingOneComponentMessage, missingOnHand);
+                EditorGUILayout.HelpBox(message, MessageType.Warning);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs.meta
+++ b/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9fd2985922b33fe489c0262b0c3e7c68
+timeCreated: 1487727090
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- For touch, grab, and use on the `VRTK_InteractableObject` inspector
  if a controller object is present but missing the necessary script
  a warning will be displayed.
  <img width="242" alt="interactable object warning" src="https://cloud.githubusercontent.com/assets/53399/23238830/bc0082d0-f918-11e6-9446-7882ed805ca8.png">
  <img width="246" alt="interactable object left warning" src="https://cloud.githubusercontent.com/assets/53399/23238829/bc00508a-f918-11e6-8d46-02a04ea4b11b.png">
- If the controller alias is missing, an info message reminding to add
  the necessary script to any prefabs will be displayed.
  <img width="248" alt="interactable object prefab controllers" src="https://cloud.githubusercontent.com/assets/53399/23238831/bc00bffc-f918-11e6-806b-2d57a29a6269.png">
- The `VRTK_ControllerActions` inspector on a controller for each of
  VRTK_Interact{Touch,Grab,Use} will display a warning if the script is
  missing and there are interactable objects present in the scene that require it.
  <img width="241" alt="controller actions warning" src="https://cloud.githubusercontent.com/assets/53399/23238832/bc017898-f918-11e6-8394-2416c2526f14.png">
- Also fix `VRTK_SDKManager` so that `instance` is not null after a
  script reload where Unity restores a serialized instance and does not
  call Awake.
