### PR TITLE
refactor(ObjectFollow): change attached game object by default

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -474,7 +474,6 @@ namespace VRTK
             pointerOriginTransformFollowGameObject = new GameObject(string.Format("[{0}]BasePointerRenderer_Origin_Smoothed", gameObject.name));
             pointerOriginTransformFollow = pointerOriginTransformFollowGameObject.AddComponent<VRTK_TransformFollow>();
             pointerOriginTransformFollow.enabled = false;
-            pointerOriginTransformFollow.gameObjectToChange = pointerOriginTransformFollowGameObject;
             pointerOriginTransformFollow.followsScale = false;
         }
 

--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -460,7 +460,6 @@ namespace VRTK
             pointerOriginTransformFollowGameObject = new GameObject(string.Format("[{0}]BasePointer_Origin_Smoothed", gameObject.name));
             pointerOriginTransformFollowGameObject.SetActive(false);
             pointerOriginTransformFollow = pointerOriginTransformFollowGameObject.AddComponent<VRTK_TransformFollow>();
-            pointerOriginTransformFollow.gameObjectToChange = pointerOriginTransformFollowGameObject;
             pointerOriginTransformFollow.followsScale = false;
             UpdatePointerOriginTransformFollow();
         }

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
@@ -10,7 +10,7 @@ namespace VRTK
     {
         [Tooltip("The game object to follow. The followed property values will be taken from this one.")]
         public GameObject gameObjectToFollow;
-        [Tooltip("The game object to change the property values of. If left empty no game object will be changed.")]
+        [Tooltip("The game object to change the property values of. If left empty the game object this script is attached to will be changed.")]
         public GameObject gameObjectToChange;
 
         [Tooltip("Whether to follow the position of the given game object.")]
@@ -67,6 +67,11 @@ namespace VRTK
             }
         }
 
+        protected virtual void OnEnable()
+        {
+            gameObjectToChange = gameObjectToChange ?? gameObject;
+        }
+
         protected virtual void OnValidate()
         {
             maxAllowedPerFrameDistanceDifference = Mathf.Max(0.0001f, maxAllowedPerFrameDistanceDifference);
@@ -108,11 +113,7 @@ namespace VRTK
             }
 
             targetPosition = newPosition;
-
-            if (gameObjectToChange)
-            {
-                SetPositionOnGameObject(newPosition);
-            }
+            SetPositionOnGameObject(newPosition);
         }
 
         private void FollowRotation()
@@ -131,11 +132,7 @@ namespace VRTK
             }
 
             targetRotation = newRotation;
-
-            if (gameObjectToChange)
-            {
-                SetRotationOnGameObject(newRotation);
-            }
+            SetRotationOnGameObject(newRotation);
         }
 
         private void FollowScale()
@@ -154,11 +151,7 @@ namespace VRTK
             }
 
             targetScale = newScale;
-
-            if (gameObjectToChange)
-            {
-                SetScaleOnGameObject(newScale);
-            }
+            SetScaleOnGameObject(newScale);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
@@ -27,19 +27,17 @@ namespace VRTK
         private Rigidbody rigidbodyToFollow;
         private Rigidbody rigidbodyToChange;
 
-        protected virtual void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
+
             if (gameObjectToFollow == null)
             {
                 return;
             }
 
             rigidbodyToFollow = gameObjectToFollow.GetComponent<Rigidbody>();
-
-            if (gameObjectToChange)
-            {
-                rigidbodyToChange = gameObjectToChange.GetComponent<Rigidbody>();
-            }
+            rigidbodyToChange = gameObjectToChange.GetComponent<Rigidbody>();
         }
 
         protected virtual void OnDisable()

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
@@ -28,19 +28,17 @@ namespace VRTK
         private Transform transformToChange;
         private bool isListeningToOnPreRender;
 
-        protected virtual void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
+
             if (gameObjectToFollow == null)
             {
                 return;
             }
 
             transformToFollow = gameObjectToFollow.transform;
-
-            if (gameObjectToChange)
-            {
-                transformToChange = gameObjectToChange.transform;
-            }
+            transformToChange = gameObjectToChange.transform;
 
             if (moment == FollowMoment.OnPreRender)
             {


### PR DESCRIPTION
The object follow script is changed so the game object it is attached to
is used for `gameObjectToChange` if none is set. This simplifies usage
of the object follow scripts.

Additionally an issue with the Oculus Avatar SDK is fixed: The OculusVR
boundaries SDK wasn't correctly setting up the transform follow script
to change the game object the OVRAvatar is attached to. This resulted in
the avatar not moving at all.