### PR TITLE
fix(SteamSDK): support SteamVR plugin 1.2.1

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -824,15 +824,26 @@ namespace VRTK
 
             if (eventClass == null)
             {
-                //SteamVR plugin >= 1.2.0
                 eventClass = executingAssembly.GetType("SteamVR_Events");
                 MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
-                object steamVREventInstance = systemMethod.Invoke(null, new object[] { "TrackedDeviceRoleChanged" });
+
+                object steamVREventInstance;
+                if (systemMethod.GetParameters()[0].ParameterType == typeof(string))
+                {
+                    //SteamVR plugin == 1.2.0
+                    steamVREventInstance = systemMethod.Invoke(null, new object[] { "TrackedDeviceRoleChanged" });
+                }
+                else
+                {
+                    //SteamVR plugin >= 1.2.1
+                    steamVREventInstance = systemMethod.Invoke(null, new object[] { EVREventType.VREvent_TrackedDeviceRoleChanged });
+                }
+
                 MethodInfo listenMethod = steamVREventInstance.GetType().GetMethod("Listen", BindingFlags.Public | BindingFlags.Instance);
                 Type listenMethodParameterType = listenMethod.GetParameters()[0].ParameterType;
 
                 targetMethod = targetMethod.MakeGenericMethod(listenMethodParameterType.GetGenericArguments()[0]);
-                var targetMethodDelegate = Delegate.CreateDelegate(listenMethodParameterType, this, targetMethod);
+                Delegate targetMethodDelegate = Delegate.CreateDelegate(listenMethodParameterType, this, targetMethod);
                 listenMethod.Invoke(steamVREventInstance, new object[] { targetMethodDelegate });
             }
             else


### PR DESCRIPTION
The SteamVR plugin was updated to version 1.2.1. This fix makes sure to
adapt to the changes done to the `SteamVR_Events.System` method.