### PR TITLE
feat(Interaction): allow sub colliders to be ignored on interactables - fixes #870

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -74,6 +74,8 @@ namespace VRTK
         public Color touchHighlightColor = Color.clear;
         [Tooltip("Determines which controller can initiate a touch action.")]
         public AllowedController allowedTouchControllers = AllowedController.Both;
+        [Tooltip("An array of colliders on the object to ignore when being touched.")]
+        public Collider[] ignoredColliders;
 
         [Header("Grab Options", order = 2)]
 
@@ -181,6 +183,7 @@ namespace VRTK
         protected bool snappedInSnapDropZone = false;
         protected VRTK_SnapDropZone storedSnapDropZone;
         protected Vector3 previousLocalScale = Vector3.zero;
+        protected List<GameObject> currentIgnoredColliders = new List<GameObject>();
 
         public virtual void OnInteractableObjectTouched(InteractableObjectEventArgs e)
         {
@@ -280,6 +283,7 @@ namespace VRTK
         /// <param name="currentTouchingObject">The game object that is currently touching this object.</param>
         public virtual void StartTouching(GameObject currentTouchingObject)
         {
+            IgnoreColliders(currentTouchingObject);
             if (!touchingObjects.Contains(currentTouchingObject))
             {
                 ToggleEnableState(true);
@@ -634,6 +638,14 @@ namespace VRTK
             return (!GetSecondaryGrabbingObject() && secondaryGrabActionScript ? secondaryGrabActionScript.IsActionable() : false);
         }
 
+        /// <summary>
+        /// The ResetIgnoredColliders method is used to clear any stored ignored colliders in case the `Ignored Colliders` array parameter is changed at runtime. This needs to be called manually if changes are made at runtime.
+        /// </summary>
+        public virtual void ResetIgnoredColliders()
+        {
+            currentIgnoredColliders.Clear();
+        }
+
         protected virtual void Awake()
         {
             interactableRigidbody = GetComponent<Rigidbody>();
@@ -740,6 +752,29 @@ namespace VRTK
                     objectHighlighter = gameObject.AddComponent<VRTK_MaterialColorSwapHighlighter>();
                 }
                 objectHighlighter.Initialise(touchHighlightColor);
+            }
+        }
+
+        protected virtual void IgnoreColliders(GameObject touchingObject)
+        {
+            if (!currentIgnoredColliders.Contains(touchingObject))
+            {
+                Debug.Log("test");
+                bool objectIgnored = false;
+                Collider[] touchingColliders = touchingObject.GetComponentsInChildren<Collider>();
+                for (int i = 0; i < ignoredColliders.Length; i++)
+                {
+                    for (int j = 0; j < touchingColliders.Length; j++)
+                    {
+                        Physics.IgnoreCollision(touchingColliders[j], ignoredColliders[i]);
+                        objectIgnored = true;
+                    }
+                }
+
+                if (objectIgnored)
+                {
+                    currentIgnoredColliders.Add(touchingObject);
+                }
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2214,6 +2214,7 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
  * **Disable When Idle:** If this is checked then the interactable object script will be disabled when the object is not being interacted with. This will eliminate the potential number of calls the interactable objects make each frame.
  * **Touch Highlight Color:** The colour to highlight the object when it is touched. This colour will override any globally set colour (for instance on the `VRTK_InteractTouch` script).
  * **Allowed Touch Controllers:** Determines which controller can initiate a touch action.
+ * **Ignored Colliders:** An array of colliders on the object to ignore when being touched.
  * **Is Grabbable:** Determines if the object can be grabbed.
  * **Hold Button To Grab:** If this is checked then the grab button on the controller needs to be continually held down to keep grabbing. If this is unchecked the grab button toggles the grab action with one button press to grab and another to release.
  * **Stay Grabbed On Teleport:** If this is checked then the object will stay grabbed to the controller when a teleport occurs. If it is unchecked then the object will be released when a teleport occurs.
@@ -2610,6 +2611,17 @@ The IsSwappable method returns whether the object can be grabbed with one contro
    * `bool` - Returns true if the obejct has a secondary action, returns false if it has no secondary action or is swappable.
 
 The PerformSecondaryAction method returns whether the object has a secondary action that can be performed when grabbing the object with a secondary controller.
+
+#### ResetIgnoredColliders/0
+
+  > `public virtual void ResetIgnoredColliders()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * _none_
+
+The ResetIgnoredColliders method is used to clear any stored ignored colliders in case the `Ignored Colliders` array parameter is changed at runtime. This needs to be called manually if changes are made at runtime.
 
 ### Example
 


### PR DESCRIPTION
A new parameter has been added to the Interactable Object script that
allows an array of colliders to be provided that will be ignored
when the controller touches the Interactable Object.

This is useful if an object has a collection of child colliders but
not all of those should react to the touch events.

Example: A sword will have a collider on the blade and hilt, but the
user will only want to be able to pick the sword up by the hilt so
the blade collider will be added to the ignore list.

If the Ignored Colliders parameter is changed at runtime then the
ResetIgnoredColliders() method also needs to be called as the
ignored controller objects get cached so the colliders are not
continually iterated through on every touch event.