### PR TITLE
fix(SnapDropZone): prevent highlight turning off when set to always on

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -326,7 +326,7 @@ namespace VRTK
                 if (currentIOCheck && currentIOCheck.GetStoredSnapDropZone() != null && currentIOCheck.GetStoredSnapDropZone() != gameObject)
                 {
                     currentValidSnapObject = null;
-                    if (isHighlighted && highlightObject)
+                    if (isHighlighted && highlightObject && !highlightAlwaysActive)
                     {
                         highlightObject.SetActive(false);
                     }


### PR DESCRIPTION
There was an issue where if 2 snap drop zones were next to each other
and highlighting always on was selected that when an object was dropped
into one of the snap drop zones the highlighter would turn off on the
other snap drop zone.