### PR TITLE
feat(DestinationPoint): emit on enter and exit destination marker event

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
@@ -175,6 +175,7 @@ namespace VRTK
                 isActive = true;
                 ToggleCursor(sender, false);
                 EnablePoint();
+                OnDestinationMarkerEnter(SetDestinationMarkerEvent(0f, e.raycastHit.transform, e.raycastHit, e.raycastHit.transform.position, e.controllerIndex));
             }
         }
 
@@ -185,6 +186,7 @@ namespace VRTK
                 isActive = false;
                 ToggleCursor(sender, true);
                 ResetPoint();
+                OnDestinationMarkerExit(SetDestinationMarkerEvent(0f, e.raycastHit.transform, e.raycastHit, e.raycastHit.transform.position, e.controllerIndex));
             }
         }
 


### PR DESCRIPTION
The Destination Point is a Destination Marker yet it only implemented
the Destination Set event. Now it also implements the Destination Enter
and Destination Exit event so it's possible to know when something
is hovering over the destination point.