### PR TITLE
fix(UIPointer): react to SteamVR index change

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -876,13 +876,32 @@ namespace VRTK
             var sdkManager = VRTK_SDKManager.instance;
             if (sdkManager != null)
             {
+                var updatePointers = false;
+
                 if (cachedLeftTrackedObject == null && sdkManager.actualLeftController)
                 {
                     cachedLeftTrackedObject = sdkManager.actualLeftController.GetComponent<SteamVR_TrackedObject>();
+                    updatePointers = true;
                 }
                 if (cachedRightTrackedObject == null && sdkManager.actualRightController)
                 {
                     cachedRightTrackedObject = sdkManager.actualRightController.GetComponent<SteamVR_TrackedObject>();
+                    updatePointers = true;
+                }
+
+                if (updatePointers && !VRTK_SharedMethods.IsEditTime())
+                {
+                    VRTK_UIPointer[] pointers = FindObjectsOfType<VRTK_UIPointer>();
+                    for (var i = 0; i < pointers.Length; i++)
+                    {
+                        VRTK_UIPointer pointer = pointers[i];
+                        UnityEngine.EventSystems.PointerEventData pointerEventData = pointer.pointerEventData;
+
+                        if (pointerEventData != null)
+                        {
+                            pointerEventData.pointerId = (int)GetControllerIndex(pointer.controller.gameObject);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The UIPointer uses the controller index for its event data. SteamVR will
change the index sometimes, which results in the UI canvases not
reacting correctly anymore after an index change. This fix makes sure to
change the used index for the UIPointer event data whenever SteamVR
changes the indexes.