### PR TITLE
fix(Climbing): scaled throw from climb

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
@@ -208,7 +208,11 @@ namespace VRTK
                     velocity = -VRTK_DeviceFinder.GetControllerVelocity(device);
                     if (usePlayerScale)
                     {
-                        velocity = Vector3.Scale(velocity, playArea.localScale);
+                        velocity = playArea.TransformVector(velocity);
+                    }
+                    else
+                    {
+                        velocity = playArea.TransformDirection(velocity);
                     }
                 }
 

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -168,7 +168,7 @@ namespace VRTK
             {
                 float gravityPush = -0.001f;
                 Vector3 appliedGravity = new Vector3(0f, gravityPush, 0f);
-                bodyRigidbody.velocity = playArea.TransformVector(velocity) + appliedGravity;
+                bodyRigidbody.velocity = velocity + appliedGravity;
                 if (applyMomentum)
                 {
                     float rigidBodyMagnitude = bodyRigidbody.velocity.magnitude;


### PR DESCRIPTION
When the play area is scaled, throwing yourself from a
hand hold resulted in a double scaled velocity. It was
being applied in VRTK_PlayerClimb as well as when transforming
the vector to world space in BodyPhysics. This fix removes the
scale from happening in BodyPhysics, thus keeping the input
parameter as a world space input, and changing the value
instead in PlayerClimb (to world space orientation) before
passing the velocity along.