### PR TITLE
fix(SDKManager): enable auto populate button at all times

### DIFF
--- a/Assets/VRTK/Editor/VRTK_SDKManagerEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_SDKManagerEditor.cs
@@ -32,7 +32,6 @@
                 sdkManager.PopulateObjectReferences(false);
             }
 
-            EditorGUI.BeginDisabledGroup(sdkManager.autoPopulateObjectReferences);
             const string populateNowDescription = "Populate Now";
             var populateNowGUIContent = new GUIContent(populateNowDescription, "Set the SDK object references to the objects of the selected SDKs.");
             if (GUILayout.Button(populateNowGUIContent, GUILayout.MaxHeight(GUI.skin.label.CalcSize(populateNowGUIContent).y)))
@@ -40,7 +39,6 @@
                 Undo.RecordObject(sdkManager, populateNowDescription);
                 sdkManager.PopulateObjectReferences(true);
             }
-            EditorGUI.EndDisabledGroup();
 
             EditorGUILayout.EndHorizontal();
 


### PR DESCRIPTION
The inspector for the SDK Manager doesn't allow clicking the auto
populate button if the manager is set up to populate the object
references automatically. Since the auto-populating only occurs whenever
an SDK selection is changed this lead to a problem when changing any of
the objects to reference.

To allow populating the object references manually this fix makes sure
to enable the button at all times.