### PR TITLE
fix(SDKManager): handle scene reload

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -215,13 +215,6 @@ namespace VRTK
             { typeof(SDK_BaseController), typeof(SDK_FallbackController) }
         };
 
-#if UNITY_EDITOR
-        /// <summary>
-        /// The previously active scene's path. Used to call <see cref="AutoManageScriptingDefineSymbolsAndPopulateObjectReferences"/> when the currently active scene changes. See the static constructor for the usage.
-        /// </summary>
-        private static string PreviousActiveScenePath;
-#endif
-
         [SerializeField]
         private VRTK_SDKInfo cachedSystemSDKInfo = VRTK_SDKInfo.Create<SDK_BaseSystem, SDK_FallbackSystem, SDK_FallbackSystem>();
         [SerializeField]
@@ -476,15 +469,7 @@ namespace VRTK
 
 #if UNITY_EDITOR
             //call AutoManageScriptingDefineSymbolsAndPopulateObjectReferences when the currently active scene changes
-            EditorApplication.hierarchyWindowChanged += () =>
-            {
-                string currentActiveScenePath = SceneManager.GetActiveScene().path;
-                if (currentActiveScenePath != PreviousActiveScenePath)
-                {
-                    PreviousActiveScenePath = currentActiveScenePath;
-                    AutoManageScriptingDefineSymbolsAndPopulateObjectReferences();
-                }
-            };
+            EditorApplication.hierarchyWindowChanged += AutoManageScriptingDefineSymbolsAndPopulateObjectReferences;
 #endif
         }
 
@@ -616,8 +601,6 @@ namespace VRTK
             {
                 instance.PopulateObjectReferences(false);
             }
-
-            PreviousActiveScenePath = SceneManager.GetActiveScene().path;
         }
 
         /// <summary>


### PR DESCRIPTION
The SDK Manager made sure to not trigger the managing of the scripting
define symbols and population of the object reference when a scene is
reloaded. This behavior is wrong when the following is done:
- Change which SDKs are used or which objects are referenced in the SDK
Manager.
- Wait for it to change the scripting define symbols (if needed).
- Reload the scene **without** saving the changes done to the SDK
Manager.
This results in a scene reload that neither reverts the scripting define
symbols, nor the object references according to the previous
configuration of the SDK Manager.

This fix makes sure to always manage the scripting define symbols and
populate the object references on a scene reload.