### PR TITLE
fix(UICanvas): unusable in Unity 5.6

### DIFF
--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -117,14 +117,14 @@ namespace VRTK
             if (canvas && !canvas.transform.FindChild(CANVAS_DRAGGABLE_PANEL))
             {
                 var draggablePanel = new GameObject(CANVAS_DRAGGABLE_PANEL);
+                draggablePanel.AddComponent<RectTransform>();
+                draggablePanel.AddComponent<Image>().color = Color.clear;
+                draggablePanel.AddComponent<EventTrigger>();
                 draggablePanel.transform.SetParent(canvas.transform);
                 draggablePanel.transform.localPosition = Vector3.zero;
                 draggablePanel.transform.localRotation = Quaternion.identity;
                 draggablePanel.transform.localScale = Vector3.one;
                 draggablePanel.transform.SetAsFirstSibling();
-                draggablePanel.AddComponent<RectTransform>();
-                draggablePanel.AddComponent<Image>().color = Color.clear;
-                draggablePanel.AddComponent<EventTrigger>();
 
                 draggablePanel.GetComponent<RectTransform>().sizeDelta = canvasSize;
             }


### PR DESCRIPTION
The UI Canvas creates a child game object to enable drag and drop of UI
elements on the canvas. That child object is a UI object so it gets
added a `RectTransform`. A `RectTransform` is inheriting from
`Transform` which means Unity does some stuff to the child object to
switch to that new transform. In Unity 5.6 this switching changed
somehow so the current implementation results in the parent of the
canvas' game object getting disabled.

The fix is to add the `RectTransform` as early as possible and only
adjust the parent and position of the transform afterwards.