### PR TITLE
fix(SDK): SteamVR defines

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
@@ -3,7 +3,6 @@ namespace VRTK
 {
     using System;
     using System.Reflection;
-    using Valve.VR;
 
     /// <summary>
     /// Handles all the scripting define symbols for the SteamVR SDK.
@@ -39,7 +38,7 @@ namespace VRTK
                 return false;
             }
 
-            return systemMethodParameters[0].ParameterType == typeof(EVREventType);
+            return systemMethodParameters[0].ParameterType == Type.GetType("Valve.VR.EVREventType");
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]


### PR DESCRIPTION
The SteamVR defines incorrectly used a SteamVR type directly which
resulted in compiler errors if the SteamVR plugin is not included in the
project. This fix makes sure to not use any SteamVR type directly and
resorts to use reflection instead.