### PR TITLE
fix(RoomExtender_PlayAreaGizmo): null play area

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
@@ -41,8 +41,12 @@
 
         private void DrawWireframe()
         {
-            Vector3[] vertices = (playArea != null ? VRTK_SDK_Bridge.GetPlayAreaVertices(playArea.gameObject) : new Vector3[0]);
+            if (playArea == null || roomExtender == null)
+            {
+                return;
+            }
 
+            var vertices = VRTK_SDK_Bridge.GetPlayAreaVertices(playArea.gameObject);
             if (vertices == null || vertices.Length == 0)
             {
                 return;

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -3,7 +3,6 @@ namespace VRTK
 {
     using UnityEngine;
 #if UNITY_EDITOR
-    using UnityEngine.SceneManagement;
     using UnityEditor;
     using UnityEditor.Callbacks;
 #endif
@@ -60,7 +59,23 @@ namespace VRTK
         /// <summary>
         /// The singleton instance to access the SDK Manager variables from.
         /// </summary>
-        public static VRTK_SDKManager instance;
+        public static VRTK_SDKManager instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    var sdkManager = FindObjectOfType<VRTK_SDKManager>();
+                    if (sdkManager)
+                    {
+                        sdkManager.CreateInstance();
+                    }
+                }
+
+                return _instance;
+            }
+        }
+        private static VRTK_SDKManager _instance;
 
         [Tooltip("If this is true then the instance of the SDK Manager won't be destroyed on every scene load.")]
         public bool persistOnLoad;
@@ -594,12 +609,6 @@ namespace VRTK
 
             RemoveLegacyScriptingDefineSymbols();
 
-            var sdkManager = FindObjectOfType<VRTK_SDKManager>();
-            if (sdkManager)
-            {
-                sdkManager.CreateInstance();
-            }
-
             if (instance != null && !instance.ManageScriptingDefineSymbols(false, false))
             {
                 instance.PopulateObjectReferences(false);
@@ -664,9 +673,9 @@ namespace VRTK
 
         private void CreateInstance()
         {
-            if (instance == null)
+            if (_instance == null)
             {
-                instance = this;
+                _instance = this;
 
                 string sdkErrorDescriptions = string.Join("\n- ", GetSimplifiedSDKErrorDescriptions());
                 if (!string.IsNullOrEmpty(sdkErrorDescriptions))
@@ -680,7 +689,7 @@ namespace VRTK
                     DontDestroyOnLoad(gameObject);
                 }
             }
-            else if (instance != this)
+            else if (_instance != this)
             {
                 Destroy(gameObject);
             }


### PR DESCRIPTION
The play area gizmo of the RoomExtender looks up the play area in
`Awake` and later uses it when drawing the gizmo. The issue is that the
SDK Manager is not set up correctly at that point in time so the
returned play area is null, resulting in errors when trying to draw the
gizmo.

This fix makes sure `VRTK_SDKManager.instance` is always set up, no
matter when the getter is called. Additionally the play area gizmo
drawing method is changed to not throw any errors if the needed objects
weren't found in the `Awake` method. That method logs a warning already,
so the user is notified about the reason the gizmo isn't drawing.

This fix resolves #985.