### PR TITLE
fix(UICanvas): ghost in layout group

### DIFF
--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -118,6 +118,7 @@ namespace VRTK
             {
                 var draggablePanel = new GameObject(CANVAS_DRAGGABLE_PANEL);
                 draggablePanel.AddComponent<RectTransform>();
+                draggablePanel.AddComponent<LayoutElement>().ignoreLayout = true;
                 draggablePanel.AddComponent<Image>().color = Color.clear;
                 draggablePanel.AddComponent<EventTrigger>();
                 draggablePanel.transform.SetParent(canvas.transform);


### PR DESCRIPTION
The draggable helper game object the UI Canvas uses interferes with the
layout system and shows up as an empty "ghost" object when used in
conjunction with a layout group. The fix is to add a `LayoutElement` and
setting `ignoreLayout` to true so the layout system ignores that element
completely.

This fix resolves #925.