### PR TITLE
fix(SDK): ensure Oculus Avatar define symbol is added correctly

### DIFF
--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs
@@ -23,10 +23,11 @@ namespace VRTK
             return typeof(SDK_OculusVRDefines).Assembly.GetType("OVRInput") != null;
         }
 
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(AvatarScriptingDefineSymbol, BuildTargetGroupName)]
         private static bool IsOculusVRAvatarAvailable()
         {
-            return IsOculusVRAvailable() && typeof(SDK_OculusVRDefines).Assembly.GetType("OVRAvatar") != null;
+            return typeof(SDK_OculusVRDefines).Assembly.GetType("OvrAvatar") != null;
         }
     }
 }


### PR DESCRIPTION
The Oculus Avatar scripting define symbol was not being added when
switching to the Oculus SDK. This fix now resolves that issue.