### PR TITLE
fix(OculusAvatar): only set up once

### DIFF
--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
@@ -108,7 +108,7 @@ namespace VRTK
             if (avatarContainer == null)
             {
                 avatarContainer = FindObjectOfType<OvrAvatar>();
-                if (avatarContainer)
+                if (avatarContainer != null && avatarContainer.GetComponent<VRTK_TransformFollow>() == null)
                 {
                     var objectFollow = avatarContainer.gameObject.AddComponent<VRTK_TransformFollow>();
                     objectFollow.gameObjectToFollow = GetPlayArea().gameObject;


### PR DESCRIPTION
The Oculus Avatar SDK is supported by making sure the `OvrAvatar`
follows the movement of the play area game object. The script that
handles the following was added multiple times in some cases. This fix
makes sure to only add the script if needed.