### PR TITLE
fix(UICanvas): RectTransform in 5.5.2p2 and 5.6

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/UI_Interactions.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/UI_Interactions.cs
@@ -3,6 +3,7 @@
     using UnityEngine;
     using UnityEngine.EventSystems;
     using UnityEngine.UI;
+    using System.Collections;
 
     public class UI_Interactions : MonoBehaviour
     {
@@ -41,6 +42,13 @@
 
         public void CreateCanvas()
         {
+            StartCoroutine(CreateCanvasOnNextFrame());
+        }
+
+        private IEnumerator CreateCanvasOnNextFrame()
+        {
+            yield return null;
+
             var canvasCount = FindObjectsOfType<Canvas>().Length - EXISTING_CANVAS_COUNT;
             var newCanvasGO = new GameObject("TempCanvas");
             newCanvasGO.layer = 5;
@@ -51,11 +59,9 @@
             canvasRT.localScale = new Vector3(0.005f, 0.005f, 0.005f);
             canvasRT.eulerAngles = new Vector3(0f, 270f, 0f);
 
-            var newButtonGO = new GameObject("TempButton");
+            var newButtonGO = new GameObject("TempButton", typeof(RectTransform));
             newButtonGO.transform.parent = newCanvasGO.transform;
             newButtonGO.layer = 5;
-
-            newButtonGO.AddComponent<RectTransform>();
 
             var buttonRT = newButtonGO.GetComponent<RectTransform>();
             buttonRT.position = new Vector3(0f, 0f, 0f);
@@ -71,11 +77,11 @@
             buttonColourBlock.highlightedColor = Color.red;
             canvasButton.colors = buttonColourBlock;
 
-            var newTextGO = new GameObject("BtnText");
+            var newTextGO = new GameObject("BtnText", typeof(RectTransform));
             newTextGO.transform.parent = newButtonGO.transform;
             newTextGO.layer = 5;
 
-            var textRT = newTextGO.AddComponent<RectTransform>();
+            var textRT = newTextGO.GetComponent<RectTransform>();
             textRT.position = new Vector3(0f, 0f, 0f);
             textRT.anchoredPosition = new Vector3(0f, 0f, 0f);
             textRT.localPosition = new Vector3(0f, 0f, 0f);

--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -4,6 +4,7 @@ namespace VRTK
     using UnityEngine;
     using UnityEngine.UI;
     using UnityEngine.EventSystems;
+    using System.Collections;
 
     /// <summary>
     /// The UI Canvas is used to denote which World Canvases are interactable by a UI Pointer.
@@ -23,6 +24,7 @@ namespace VRTK
 
         protected BoxCollider canvasBoxCollider;
         protected Rigidbody canvasRigidBody;
+        protected Coroutine draggablePanelCreation;
         protected const string CANVAS_DRAGGABLE_PANEL = "VRTK_UICANVAS_DRAGGABLE_PANEL";
         protected const string ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT = "VRTK_UICANVAS_ACTIVATOR_FRONT_TRIGGER";
 
@@ -108,16 +110,17 @@ namespace VRTK
                 canvasRigidBody.isKinematic = true;
             }
 
-            CreateDraggablePanel(canvas, canvasSize);
+            draggablePanelCreation = StartCoroutine(CreateDraggablePanel(canvas, canvasSize));
             CreateActivator(canvas, canvasSize);
         }
 
-        protected virtual void CreateDraggablePanel(Canvas canvas, Vector2 canvasSize)
+        protected virtual IEnumerator CreateDraggablePanel(Canvas canvas, Vector2 canvasSize)
         {
             if (canvas && !canvas.transform.FindChild(CANVAS_DRAGGABLE_PANEL))
             {
-                var draggablePanel = new GameObject(CANVAS_DRAGGABLE_PANEL);
-                draggablePanel.AddComponent<RectTransform>();
+                yield return null;
+
+                var draggablePanel = new GameObject(CANVAS_DRAGGABLE_PANEL, typeof(RectTransform));
                 draggablePanel.AddComponent<LayoutElement>().ignoreLayout = true;
                 draggablePanel.AddComponent<Image>().color = Color.clear;
                 draggablePanel.AddComponent<EventTrigger>();
@@ -192,6 +195,7 @@ namespace VRTK
                 Destroy(canvasRigidBody);
             }
 
+            StopCoroutine(draggablePanelCreation);
             var draggablePanel = canvas.transform.FindChild(CANVAS_DRAGGABLE_PANEL);
             if (draggablePanel)
             {


### PR DESCRIPTION
Unity changed the way additions of components derived from `Transform`
are handled:
- From the 5.5.2p2 changelog:
>Kernel: Prevent scripts from adding Transform-derived components during
their Awake methods.

- From the 5.6.0b11 changelog:
>UI: Adding UI elements via script will cause OnDisable and OnEnable to
be called on all scripts in the hierarchy if a RectTransform needs to be
added.

To fix the first problem the creation of any game object that uses
`RectTransform` is deferred to the next frame. The second problem is
fixed by specifying the `RectTransform` to add in the game object
constructor.