### PR TITLE
fix(Simulator): render model null

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_ControllerTracker.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_ControllerTracker.cs
@@ -13,6 +13,8 @@
             {
                 trackedController = actualController.GetComponent<VRTK_TrackedController>();
             }
+
+            Update();
         }
 
         protected virtual void Update()


### PR DESCRIPTION
The simulator would throw a `NullReferenceException` in
`SDK_SimController.GetControllerRenderModel` because the alias
controller wasn't parented to the actual one yet. This fix makes sure to
parent the script alias controller to the actual object immediately.