### PR TITLE
chore(Structure): add update prompt editor window

### DIFF
--- a/Assets/VRTK/Editor/VRTK_UpdatePrompt.cs
+++ b/Assets/VRTK/Editor/VRTK_UpdatePrompt.cs
@@ -1,0 +1,153 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+[InitializeOnLoad]
+public class VRTK_UpdatePrompt : EditorWindow
+{
+    private const string remoteURL = "https://raw.githubusercontent.com/thestonefox/VRTK/";
+    private const string remoteVersionFile = "master/Assets/VRTK/Version.txt";
+    private const string remoteChangelogFile = "master/CHANGELOG.md";
+    private const string localVersionFile = "Assets/VRTK/Version.txt";
+    private const string pluginURL = "https://www.assetstore.unity3d.com/en/#!/content/64131";
+    private const string hideVersionPrompt = "VRTK.HideVersionPrompt.v{0}";
+
+    private static bool versionChecked = false;
+    private static WWW versionResource;
+    private static WWW changelogResource;
+    private static string versionReceived;
+    private static string changelogReceived;
+    private static string versionLocal;
+    private static VRTK_UpdatePrompt promptWindow;
+
+    private Vector2 scrollPosition;
+    private bool hideToggle;
+
+    static VRTK_UpdatePrompt()
+    {
+        EditorApplication.update += Update;
+    }
+
+    public void OnGUI()
+    {
+        EditorGUILayout.HelpBox("A new version of VRTK is available.", MessageType.Warning);
+
+        scrollPosition = GUILayout.BeginScrollView(scrollPosition);
+
+        GUILayout.Label("Current version: " + versionLocal);
+        GUILayout.Label("New version: " + versionReceived);
+
+        if (changelogReceived != null && changelogReceived.Trim() != "")
+        {
+            GUILayout.Label("Changelog :");
+            EditorGUILayout.HelpBox(changelogReceived.Trim().Replace("\n## ", "\n\n## ").Replace("\n * **", "\n\n * **"), MessageType.None);
+        }
+
+        GUILayout.EndScrollView();
+
+        GUILayout.FlexibleSpace();
+
+        if (GUILayout.Button("Get Latest Version"))
+        {
+            Application.OpenURL(pluginURL);
+        }
+
+        EditorGUI.BeginChangeCheck();
+        bool hidePromptInFuture = GUILayout.Toggle(hideToggle, "Do not prompt for this version again.");
+        if (EditorGUI.EndChangeCheck())
+        {
+            hideToggle = hidePromptInFuture;
+            string key = string.Format(hideVersionPrompt, versionReceived);
+            if (hidePromptInFuture)
+            {
+                EditorPrefs.SetBool(key, true);
+            }
+            else
+            {
+                EditorPrefs.DeleteKey(key);
+            }
+        }
+    }
+
+    private static void Update()
+    {
+        if (!versionChecked)
+        {
+            versionResource = (versionResource ?? new WWW(remoteURL + remoteVersionFile));
+            if (!versionResource.isDone)
+            {
+                return;
+            }
+
+            versionReceived = (ValidURL(versionResource) ? versionResource.text : "");
+            versionResource = null;
+            versionChecked = true;
+
+            if (UpdateRequired())
+            {
+                changelogResource = new WWW(remoteURL + remoteChangelogFile);
+                promptWindow = GetWindow<VRTK_UpdatePrompt>(true);
+                promptWindow.minSize = new Vector2(640, 480);
+                promptWindow.titleContent = new GUIContent("VRTK Update");
+            }
+        }
+
+        if (changelogResource != null)
+        {
+            if (!changelogResource.isDone)
+            {
+                return;
+            }
+
+            changelogReceived = (ValidURL(changelogResource) ? ParseChangelog(changelogResource.text) : "");
+
+            changelogResource = null;
+
+            if (changelogReceived != "")
+            {
+                promptWindow.Repaint();
+            }
+        }
+        EditorApplication.update -= Update;
+    }
+
+    private static bool ValidURL(WWW resource)
+    {
+        return (string.IsNullOrEmpty(resource.error) && !Regex.IsMatch(resource.text, "404 not found", RegexOptions.IgnoreCase));
+    }
+
+    private static bool UpdateRequired()
+    {
+        versionLocal = File.ReadAllText(localVersionFile);
+        if (string.IsNullOrEmpty(versionLocal) || string.IsNullOrEmpty(versionReceived) || versionReceived == versionLocal || EditorPrefs.HasKey(string.Format(hideVersionPrompt, versionReceived)))
+        {
+            return false;
+        }
+
+        return (ParseVersion(versionReceived) > ParseVersion(versionLocal));
+    }
+
+    private static int ParseVersion(string versionText)
+    {
+        string[] versionBits = versionText.Trim().Split('.');
+        string formattedVersion = "";
+        foreach (string versionBit in versionBits)
+        {
+            formattedVersion += versionBit.PadLeft(3, '0');
+        }
+        return int.Parse(formattedVersion);
+    }
+
+    protected static string ParseChangelog(string fullChangelog)
+    {
+        string[] changelogBits = fullChangelog.Trim().Split(new string[] { "\n# " }, StringSplitOptions.RemoveEmptyEntries);
+        if (changelogBits.Length < 1)
+        {
+            return "";
+        }
+
+        return changelogBits[1];
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_UpdatePrompt.cs.meta
+++ b/Assets/VRTK/Editor/VRTK_UpdatePrompt.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 78a543c4827c41743b26750c4bb75178
+timeCreated: 1489228808
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A new prompt window has been added that checks to see if the local
version of VRTK matches the latest release on github. If it does
not match then a prompt window appears informing the user that an
update is available and shows the latest chunk of the changelog.

It also provides a button to open the asset store page for VRTK and
provides an option to hide the popup window if the update isn't wanted.