### PR TITLE
fix(SDKManager): populate object references

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -315,6 +315,13 @@ namespace VRTK
                 return;
             }
 
+            actualBoundaries = null;
+            actualHeadset = null;
+            actualLeftController = null;
+            actualRightController = null;
+            modelAliasLeftController = null;
+            modelAliasRightController = null;
+
             SDK_BaseBoundaries boundariesSDK = GetBoundariesSDK();
             SDK_BaseHeadset headsetSDK = GetHeadsetSDK();
             SDK_BaseController controllerSDK = GetControllerSDK();


### PR DESCRIPTION
Populating the object references of the SDK Manager was broken: You had
to switch to the Fallback SDK first and then switch to your desired SDK
to actually allow populating the object references based on the desired
SDK. The fix is to make sure the various object references are set to
`null` before asking the selected SDKs for their objects.