### PR TITLE
fix(SDKManager): undo and redo

### DIFF
--- a/Assets/VRTK/Editor/VRTK_SDKManagerEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_SDKManagerEditor.cs
@@ -105,12 +105,13 @@
             if (EditorGUI.EndChangeCheck())
             {
                 string quicklySelectedSDKName = availableSDKGUIContents[quicklySelectedSDKIndex].text.Replace(SDKNotInstalledDescription, "");
+                Func<VRTK_SDKInfo, bool> predicate = info => info.description.prettyName == quicklySelectedSDKName;
 
                 Undo.RecordObject(sdkManager, "SDK Change (Quick Select)");
-                sdkManager.systemSDKInfo = VRTK_SDKManager.AvailableSystemSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
-                sdkManager.boundariesSDKInfo = VRTK_SDKManager.AvailableBoundariesSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
-                sdkManager.headsetSDKInfo = VRTK_SDKManager.AvailableHeadsetSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
-                sdkManager.controllerSDKInfo = VRTK_SDKManager.AvailableControllerSDKInfos.First(info => info.description.prettyName == quicklySelectedSDKName);
+                sdkManager.systemSDKInfo = VRTK_SDKManager.AvailableSystemSDKInfos.First(predicate);
+                sdkManager.boundariesSDKInfo = VRTK_SDKManager.AvailableBoundariesSDKInfos.First(predicate);
+                sdkManager.headsetSDKInfo = VRTK_SDKManager.AvailableHeadsetSDKInfos.First(predicate);
+                sdkManager.controllerSDKInfo = VRTK_SDKManager.AvailableControllerSDKInfos.First(predicate);
             }
 
             GUIContent[] availableSystemSDKGUIContents = availableSystemSDKNames.Select(guiContentCreator).ToArray();
@@ -158,8 +159,22 @@
 
         private void UndoRedoPerformed()
         {
-            //make sure to manage scripting define symbols in case an SDK change was undone
-            ((VRTK_SDKManager)target).ManageScriptingDefineSymbols(false, false);
+            //make sure to trigger populating the object references in case an SDK change was undone
+            var sdkManager = (VRTK_SDKManager)target;
+            VRTK_SDKInfo systemSDKInfo = sdkManager.systemSDKInfo;
+            VRTK_SDKInfo boundariesSDKInfo = sdkManager.boundariesSDKInfo;
+            VRTK_SDKInfo headsetSDKInfo = sdkManager.headsetSDKInfo;
+            VRTK_SDKInfo controllerSDKInfo = sdkManager.controllerSDKInfo;
+
+            sdkManager.systemSDKInfo = null;
+            sdkManager.boundariesSDKInfo = null;
+            sdkManager.headsetSDKInfo = null;
+            sdkManager.controllerSDKInfo = null;
+
+            sdkManager.systemSDKInfo = systemSDKInfo;
+            sdkManager.boundariesSDKInfo = boundariesSDKInfo;
+            sdkManager.headsetSDKInfo = headsetSDKInfo;
+            sdkManager.controllerSDKInfo = controllerSDKInfo;
         }
 
         #endregion

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs
@@ -65,6 +65,15 @@ namespace VRTK
         {
         }
 
+        /// <summary>
+        /// Creates a new SDK info by copying an existing one.
+        /// </summary>
+        /// <param name="infoToCopy">The SDK info to copy.</param>
+        public VRTK_SDKInfo(VRTK_SDKInfo infoToCopy)
+        {
+            SetUp(Type.GetType(infoToCopy.baseTypeName), Type.GetType(infoToCopy.fallbackTypeName), infoToCopy.typeName);
+        }
+
         private void SetUp(Type baseType, Type fallbackType, string actualTypeName)
         {
             if (!baseType.IsSubclassOf(typeof(SDK_Base)))

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -110,8 +110,8 @@ namespace VRTK
 #endif
                 cachedSystemSDK = null;
 
-                cachedSystemSDKInfo = value;
-                HandleSDKInfoSetter();
+                cachedSystemSDKInfo = new VRTK_SDKInfo(value);
+                PopulateObjectReferences(false);
             }
         }
         /// <summary>
@@ -138,8 +138,8 @@ namespace VRTK
 #endif
                 cachedBoundariesSDK = null;
 
-                cachedBoundariesSDKInfo = value;
-                HandleSDKInfoSetter();
+                cachedBoundariesSDKInfo = new VRTK_SDKInfo(value);
+                PopulateObjectReferences(false);
             }
         }
         /// <summary>
@@ -166,8 +166,8 @@ namespace VRTK
 #endif
                 cachedHeadsetSDK = null;
 
-                cachedHeadsetSDKInfo = value;
-                HandleSDKInfoSetter();
+                cachedHeadsetSDKInfo = new VRTK_SDKInfo(value);
+                PopulateObjectReferences(false);
             }
         }
         /// <summary>
@@ -194,8 +194,8 @@ namespace VRTK
 #endif
                 cachedControllerSDK = null;
 
-                cachedControllerSDKInfo = value;
-                HandleSDKInfoSetter();
+                cachedControllerSDKInfo = new VRTK_SDKInfo(value);
+                PopulateObjectReferences(false);
             }
         }
 
@@ -710,21 +710,6 @@ namespace VRTK
             {
                 Debug.LogError(sdkErrorDescription);
             }
-        }
-
-        /// <summary>
-        /// Handles the various SDK info setters by making sure to automatically manage the scripting define symbols or populate the object references if the SDK Manager is set to do so.
-        /// </summary>
-        private void HandleSDKInfoSetter()
-        {
-#if UNITY_EDITOR
-            if (!ManageScriptingDefineSymbols(false, false))
-            {
-                PopulateObjectReferences(false);
-            }
-#else
-            PopulateObjectReferences(false);
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Undoing or redoing changes to the selected SDKs of the SDK Manager lead
to a broken state of populated object references. The fix is to copy the
selected SDK Info whenever it's changed. That will prevent undos and
redos from changing the SDK Infos the SDK Manager uses as the list of
available SDK Infos. Additionally both the SDK Manager and its Editor
were simplified where possible.