### PR TITLE
fix(Simulator): null headset in Editor

### DIFF
--- a/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
@@ -138,8 +138,11 @@ namespace VRTK
             rotList = new List<Vector3>();
 
             var headset = GetHeadset();
-            lastPos = headset.position;
-            lastRot = headset.rotation.eulerAngles;
+            if (headset != null)
+            {
+                lastPos = headset.position;
+                lastRot = headset.rotation.eulerAngles;
+            }
         }
     }
 }


### PR DESCRIPTION
The simulator's headset script sometimes threw a
`NullReferenceException` in the editor after changing the selected SDK
in the SDK Manager. The fix is to handle a `null` headset in the script.