### PR TITLE
fix(ObjectFollow): runtime usage

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
@@ -67,16 +67,16 @@ namespace VRTK
             }
         }
 
-        protected virtual void OnEnable()
-        {
-            gameObjectToChange = (gameObjectToChange != null ? gameObjectToChange : gameObject);
-        }
-
         protected virtual void OnValidate()
         {
             maxAllowedPerFrameDistanceDifference = Mathf.Max(0.0001f, maxAllowedPerFrameDistanceDifference);
             maxAllowedPerFrameAngleDifference = Mathf.Max(0.0001f, maxAllowedPerFrameAngleDifference);
             maxAllowedPerFrameSizeDifference = Mathf.Max(0.0001f, maxAllowedPerFrameSizeDifference);
+        }
+
+        protected virtual void Update()
+        {
+            gameObjectToChange = gameObjectToChange != null ? gameObjectToChange : gameObject;
         }
 
         protected abstract Vector3 GetPositionToFollow();

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
@@ -27,23 +27,25 @@ namespace VRTK
         protected Rigidbody rigidbodyToFollow;
         protected Rigidbody rigidbodyToChange;
 
-        protected override void OnEnable()
+        protected virtual void OnEnable()
         {
-            base.OnEnable();
-
-            if (gameObjectToFollow == null)
-            {
-                return;
-            }
-
-            rigidbodyToFollow = gameObjectToFollow.GetComponent<Rigidbody>();
-            rigidbodyToChange = gameObjectToChange.GetComponent<Rigidbody>();
+            CacheRigidbodies();
         }
 
         protected virtual void OnDisable()
         {
             rigidbodyToFollow = null;
             rigidbodyToChange = null;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (rigidbodyToFollow == null || rigidbodyToChange == null)
+            {
+                CacheRigidbodies();
+            }
         }
 
         protected virtual void FixedUpdate()
@@ -98,6 +100,17 @@ namespace VRTK
         protected override Vector3 GetScaleToFollow()
         {
             return rigidbodyToFollow.transform.localScale;
+        }
+
+        protected virtual void CacheRigidbodies()
+        {
+            if (gameObjectToFollow == null)
+            {
+                return;
+            }
+
+            rigidbodyToFollow = gameObjectToFollow.GetComponent<Rigidbody>();
+            rigidbodyToChange = gameObjectToChange.GetComponent<Rigidbody>();
         }
     }
 }


### PR DESCRIPTION
The Object Follow scripts cache some needed components in their
`OnEnable` methods. This meant that using these scripts at runtime
needed a toggle of their enabled state. The fix is to cache the
components even if the needed setup isn't done as soon as `OnEnable` is
called.