### PR TITLE
fix(ObjectFollow): runtime usage (again)

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
@@ -49,8 +49,13 @@ namespace VRTK
         /// <summary>
         /// Follow `gameObjectToFollow` using the current settings.
         /// </summary>
-        public void Follow()
+        public virtual void Follow()
         {
+            if (gameObjectToFollow == null)
+            {
+                return;
+            }
+
             if (followsPosition)
             {
                 FollowPosition();
@@ -67,16 +72,16 @@ namespace VRTK
             }
         }
 
+        protected virtual void OnEnable()
+        {
+            gameObjectToChange = gameObjectToChange != null ? gameObjectToChange : gameObject;
+        }
+
         protected virtual void OnValidate()
         {
             maxAllowedPerFrameDistanceDifference = Mathf.Max(0.0001f, maxAllowedPerFrameDistanceDifference);
             maxAllowedPerFrameAngleDifference = Mathf.Max(0.0001f, maxAllowedPerFrameAngleDifference);
             maxAllowedPerFrameSizeDifference = Mathf.Max(0.0001f, maxAllowedPerFrameSizeDifference);
-        }
-
-        protected virtual void Update()
-        {
-            gameObjectToChange = gameObjectToChange != null ? gameObjectToChange : gameObject;
         }
 
         protected abstract Vector3 GetPositionToFollow();

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_RigidbodyFollow.cs
@@ -27,25 +27,16 @@ namespace VRTK
         protected Rigidbody rigidbodyToFollow;
         protected Rigidbody rigidbodyToChange;
 
-        protected virtual void OnEnable()
+        public override void Follow()
         {
             CacheRigidbodies();
+            base.Follow();
         }
 
         protected virtual void OnDisable()
         {
             rigidbodyToFollow = null;
             rigidbodyToChange = null;
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (rigidbodyToFollow == null || rigidbodyToChange == null)
-            {
-                CacheRigidbodies();
-            }
         }
 
         protected virtual void FixedUpdate()
@@ -104,7 +95,8 @@ namespace VRTK
 
         protected virtual void CacheRigidbodies()
         {
-            if (gameObjectToFollow == null)
+            if (gameObjectToFollow == null || gameObjectToChange == null
+                || (rigidbodyToFollow != null && rigidbodyToChange != null))
             {
                 return;
             }

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
@@ -56,9 +56,15 @@ namespace VRTK
         protected Transform transformToFollow;
         protected Transform transformToChange;
 
-        protected virtual void OnEnable()
+        public override void Follow()
         {
             CacheTransforms();
+            base.Follow();
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
 
             if (moment == FollowMoment.OnPreRender)
             {
@@ -73,15 +79,8 @@ namespace VRTK
             Camera.onPreRender -= OnCamPreRender;
         }
 
-        protected override void Update()
+        protected void Update()
         {
-            base.Update();
-
-            if (transformToFollow == null || transformToChange == null)
-            {
-                CacheTransforms();
-            }
-
             if (moment == FollowMoment.OnUpdate)
             {
                 Follow();
@@ -127,7 +126,8 @@ namespace VRTK
 
         protected virtual void CacheTransforms()
         {
-            if (gameObjectToFollow == null)
+            if (gameObjectToFollow == null || gameObjectToChange == null
+                || (transformToFollow != null && transformToChange != null))
             {
                 return;
             }


### PR DESCRIPTION
The Object Follow scripts were updated to allow easier usage at runtime
in #1014. But they still threw errors when not disabling the runtime
created script early. The fix is to cache more often in the subclasses
and bail out early in the `VRTK_ObjectFollow.Follow` method.