### PR TITLE
fix(OculusSDK): support Utilities SDK version 1.12.0

### DIFF
--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
@@ -48,15 +48,9 @@ namespace VRTK
         /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
         public override void ProcessUpdate(uint index, Dictionary<string, object> options)
         {
-            if (index < uint.MaxValue)
-            {
-                var device = GetTrackedObject(GetControllerByIndex(index));
-                previousControllerRotations[index] = currentControllerRotations[index];
-                currentControllerRotations[index] = device.transform.rotation;
-
-                UpdateHairValues(index, GetTriggerAxisOnIndex(index).x, GetTriggerHairlineDeltaOnIndex(index), ref previousHairTriggerState[index], ref currentHairTriggerState[index], ref hairTriggerLimit[index]);
-                UpdateHairValues(index, GetGripAxisOnIndex(index).x, GetGripHairlineDeltaOnIndex(index), ref previousHairGripState[index], ref currentHairGripState[index], ref hairGripLimit[index]);
-            }
+#if VRTK_DEFINE_OCULUSVR_UTILITIES_1_11_0_OR_OLDER
+            CalculateAngularVelocity(index);
+#endif
         }
 
         /// <summary>
@@ -66,6 +60,9 @@ namespace VRTK
         /// <param name="options">A dictionary of generic options that can be used to within the fixed update.</param>
         public override void ProcessFixedUpdate(uint index, Dictionary<string, object> options)
         {
+#if VRTK_DEFINE_OCULUSVR_UTILITIES_1_12_0_OR_NEWER
+            CalculateAngularVelocity(index);
+#endif
         }
 
         /// <summary>
@@ -894,6 +891,19 @@ namespace VRTK
         public override bool IsStartMenuTouchedUpOnIndex(uint index)
         {
             return false;
+        }
+
+        private void CalculateAngularVelocity(uint index)
+        {
+            if (index < uint.MaxValue)
+            {
+                var device = GetTrackedObject(GetControllerByIndex(index));
+                previousControllerRotations[index] = currentControllerRotations[index];
+                currentControllerRotations[index] = device.transform.rotation;
+
+                UpdateHairValues(index, GetTriggerAxisOnIndex(index).x, GetTriggerHairlineDeltaOnIndex(index), ref previousHairTriggerState[index], ref currentHairTriggerState[index], ref hairTriggerLimit[index]);
+                UpdateHairValues(index, GetGripAxisOnIndex(index).x, GetGripHairlineDeltaOnIndex(index), ref previousHairGripState[index], ref currentHairGripState[index], ref hairGripLimit[index]);
+            }
         }
 
         private void SetTrackedControllerCaches(bool forceRefresh = false)

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRDefines.cs
@@ -1,6 +1,9 @@
 ﻿// OculusVR Defines|SDK_OculusVR|001
 namespace VRTK
 {
+    using System;
+    using System.Reflection;
+
     /// <summary>
     /// Handles all the scripting define symbols for the OculusVR and Avatar SDKs.
     /// </summary>
@@ -18,15 +21,62 @@ namespace VRTK
         private const string BuildTargetGroupName = "Standalone";
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
-        private static bool IsOculusVRAvailable()
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUSVR_UTILITIES_1_12_0_OR_NEWER", BuildTargetGroupName)]
+        private static bool IsUtilitiesVersion1120OrNewer()
         {
-            return typeof(SDK_OculusVRDefines).Assembly.GetType("OVRInput") != null;
+            Version wrapperVersion = GetOculusWrapperVersion();
+            return wrapperVersion != null && wrapperVersion >= new Version(1, 12, 0);
+        }
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUSVR_UTILITIES_1_11_0_OR_OLDER", BuildTargetGroupName)]
+        private static bool IsUtilitiesVersion1110OrOlder()
+        {
+            Version wrapperVersion = GetOculusWrapperVersion();
+            return wrapperVersion != null && wrapperVersion < new Version(1, 12, 0);
         }
 
         [SDK_ScriptingDefineSymbolPredicate(AvatarScriptingDefineSymbol, BuildTargetGroupName)]
-        private static bool IsOculusVRAvatarAvailable()
+        private static bool IsAvatarAvailable()
         {
-            return IsOculusVRAvailable() && typeof(SDK_OculusVRDefines).Assembly.GetType("OvrAvatar") != null;
+            return (IsUtilitiesVersion1120OrNewer() || IsUtilitiesVersion1110OrOlder())
+                   && typeof(SDK_OculusVRDefines).Assembly.GetType("OvrAvatar") != null;
+        }
+
+        private static Version GetOculusWrapperVersion()
+        {
+            Type pluginClass = typeof(SDK_OculusVRDefines).Assembly.GetType("OVRPlugin");
+            if (pluginClass == null)
+            {
+                return null;
+            }
+
+            FieldInfo versionField = pluginClass.GetField("wrapperVersion", BindingFlags.Public | BindingFlags.Static);
+            if (versionField == null)
+            {
+                return null;
+            }
+
+            var version = (Version)versionField.GetValue(null);
+            return version;
+        }
+
+        private static Version GetOculusRuntimeVersion()
+        {
+            Type pluginClass = typeof(SDK_OculusVRDefines).Assembly.GetType("OVRPlugin");
+            if (pluginClass == null)
+            {
+                return null;
+            }
+
+            PropertyInfo versionProperty = pluginClass.GetProperty("version", BindingFlags.Public | BindingFlags.Static);
+            if (versionProperty == null)
+            {
+                return null;
+            }
+
+            var version = (Version)versionProperty.GetGetMethod().Invoke(null, null);
+            return version;
         }
     }
 }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
@@ -27,9 +27,9 @@ namespace VRTK
         /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
         public override void ProcessUpdate(Dictionary<string, object> options)
         {
-            var device = GetHeadset();
-            previousHeadsetRotation = currentHeadsetRotation;
-            currentHeadsetRotation = device.transform.rotation;
+#if VRTK_DEFINE_OCULUSVR_UTILITIES_1_11_0_OR_OLDER
+            CalculateAngularVelocity();
+#endif
         }
 
         /// <summary>
@@ -38,6 +38,9 @@ namespace VRTK
         /// <param name="options">A dictionary of generic options that can be used to within the fixed update.</param>
         public override void ProcessFixedUpdate(Dictionary<string, object> options)
         {
+#if VRTK_DEFINE_OCULUSVR_UTILITIES_1_12_0_OR_NEWER
+            CalculateAngularVelocity();
+#endif
         }
 
         /// <summary>
@@ -74,7 +77,13 @@ namespace VRTK
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>
         public override Vector3 GetHeadsetVelocity()
         {
+#if VRTK_DEFINE_OCULUSVR_UTILITIES_1_11_0_OR_OLDER
             return OVRManager.isHmdPresent ? OVRPlugin.GetEyeVelocity(OVRPlugin.Eye.Left).ToOVRPose().position : Vector3.zero;
+#elif VRTK_DEFINE_OCULUSVR_UTILITIES_1_12_0_OR_NEWER
+            return OVRManager.isHmdPresent ? OVRPlugin.GetNodeVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero;
+#else
+            return Vector3.zero;
+#endif
         }
 
         /// <summary>
@@ -122,6 +131,12 @@ namespace VRTK
             {
                 camera.gameObject.AddComponent<VRTK_ScreenFade>();
             }
+        }
+
+        private void CalculateAngularVelocity()
+        {
+            previousHeadsetRotation = currentHeadsetRotation;
+            currentHeadsetRotation = GetHeadset().transform.rotation;
         }
 #endif
     }


### PR DESCRIPTION
Oculus updated their Utilities SDK to version 1.12.0 and introduced some
breaking changes. This fix adds support for the new version while
maintaining support for the previous version.