### PR TITLE
feat(sdk): implement support for gear vr

### DIFF
--- a/Assets/VRTK/SDK/GearVR.meta
+++ b/Assets/VRTK/SDK/GearVR.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 583107901f1e1f744bd614a9283a59c1
+folderAsset: yes
+timeCreated: 1487646248
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/GearVR/GearVR_README.md
+++ b/Assets/VRTK/SDK/GearVR/GearVR_README.md
@@ -1,5 +1,5 @@
 ## VRTK Samsung Gear VR Support
-_Ryan Dawson (@coderdawson)_
+_Ryan Dawson (@coderdawson), Giovanni Paolo Viganò (@gpvigano)_
 
 Samsung Gear VR is a mobile, Android-based VR platform that is extremely limited when compared to other desktop-based VR platforms such as the HTC Vive and Oculus Rift. The Gear VR headset supports orientation tracking only; it does not support position tracking. For input, the Gear VR headset has a very simple touchpad on its right side; it does not support motion or pointer based controllers. The touchpad supports the detection of a tap/click and can also be used for some simple directional swiping. The headset also includes a back button. Most implementations on the Gear VR rely on gaze-based pointers and touchpad tapping for application input.
 
@@ -18,31 +18,74 @@ Developing for Samsung Gear VR requires that your environment have both Unity an
 ### Setup
 
 For simple VR support, all that is required is to turn on Unity's `Virtual Reality Supported` project setting and place a GameObject with the Camera component on it in your scene and tag the GameObject with the `MainCamera` tag. However, in order to support features like teleporting you must place your camera under a parent GameObject so the camera can be moved. Follow the steps below to configure your scene for Gear VR deployment with VRTK feature support.
- * Basic Setup
-   * Create a GameObject, named `CameraRig`, positioned where the player should be located in your virtual world. This GameObject will be the parent for our camera. 
-     * Standard naming for a GameObject such as this is `CameraRig`, but you can name it whatever you like.
-     * **NOTE**: You will want to ensure that the `CameraRig` Transform's Y value is 0.
-   * Create a Camera GameObject (GameObject with a `Camera` component) as a child of the `CameraRig` GameObject previously created.
-     * **NOTE**: This Camera GameObject must be named `Camera`, `Main Camera`, or `Headset`.
-     * Since Gear VR is a non-position tracked platform it is important that the position of the child Camera GameObject be at the height at which you would like the player to be in your world with zero for both the X and Z value on the Transform. Some experimentation will be needed here.
-   * Create a GameObject in your scene called `VRTK` and add the `VRTK_SDKManager` to it.
-   * Select `Gear VR` from the `Quick select SDK` drop-down on the `VRTK_SDKManager` component inspector and wait for your scripts to be recompiled.
-   * Click the `Auto Populate Linked Objects` button on the `VRTK_SDKManager` inspector to find the relevant Linked Objects.
- * Gaze Pointer Setup
-   * Add a `VRTK_ControllerEvents` component to your camera GameObject.
-   * Add a `VRTK_Pointer` component to your camera GameObject.
-   * Add a `VRTK_StraightPointerRenderer` component to your camera GameObject.
-   * Drag your camera GameObject to the `Pointer Renderer` object field of the `VRTK_Pointer` component.
- * Gaze Pointer Highlighting/Grabbing
-   * Add a `VRTK_InteractTouch` component to your camera GameObject.
-   * Add a `VRTK_InteractGrab` component to your camera GameObject.
-   * Check the `Interact With Objects` and `Grab To Pointer Tip` checkboxes on the `VRTK_Pointer` component.
+* Basic Setup
+  * Create a GameObject, named `[CameraRig]`, positioned where the **feet** of the player should be located in your virtual world. This GameObject will be the parent for our camera.
+    * **NOTE**: Ensure that the `CameraRig` Transform's Y value is set to the floor level (actually the "feet level").
+    * **NOTE**: Since Gear VR is a non-position tracked platform it is important that the position of the `[CameraRig]` be at the position at which you would like the player to be in your world. A navigation technique can be used to move around, like teleporting or walking (beware of motion sickness).
+  * Create a Camera GameObject (GameObject with a `Camera` component) as a child of the `CameraRig` GameObject previously created.
+    * **NOTE**: This Camera GameObject must be named `Camera`, `Main Camera`, or `Headset`.
+    * **NOTE**: Ensure that the Camera Transform's Y value is set to the user height (actually the "eyes level") with zero for both the X and Z value on the Transform. The Camera (local) position is actually the offset of eyes from avatar's feet.
+  * Create a GameObject in your scene called `[VRTK]` and add the `VRTK_SDKManager` to it.
+  * Select `Gear VR` from the `Quick select SDK` drop-down on the `VRTK_SDKManager` component inspector and wait for your scripts to be recompiled.
+  * Click the `Auto Populate Linked Objects` button on the `VRTK_SDKManager` inspector to find the relevant Linked Objects.
+    * You should have `Actual Boundaries` set to `[CameraRig]` and `Actual Headset` set to `Camera` (assuming that this is the name of your camera game object)
+  * Create a game object named `Headset` as child of `[VRTK]`
+    * Add to it a VRTK_Transform Follow component
+      * Set `Game Object To Follow` to `Camera` (drag your camera game object to this field)
+      * Set `Game Object To Change` to `Headset` or leave it empty (it will be automatically set)
+    * Add a `VRTK_ControllerEvents` component
+      * **NOTE**: Only some aliases are used by GearVR. `Touchpad Touch`, `Touchpad Press`, `Button One Touch`, `Button One Press` are routed to D-Pad touch, `Button Two Press` and `Button Two Touch` are routed to back button press (holding down the back button activates the system menu).
+* Gaze Pointer Setup
+  * Add a `VRTK_Pointer` component to the `Headset` game object.
+    * Set `Controller` to the `VRTK_ControllerEvents` component of your camera GameObject (drag your camera game object to the `Controller` slot).
+component.
+    * Check `Activate On Enable` and uncheck `Hold Button To Activate` if you want the pointer always visible.
+  * Add a `VRTK_StraightPointerRenderer` component to your `Headset` game object.
+    * Set `Tracer Visibility` to `Always Off`
+    * Set the `Pointer Renderer` object field of the `VRTK_Pointer` to this component (drag your camera game object to the `Pointer Renderer` slot)
+* Gaze Pointer Highlighting/Grabbing
+  * Add a `VRTK_InteractTouch` component to your `Headset` game object.
+  * Add a `VRTK_InteractGrab` component to your `Headset` game object.
+  * Check the `Interact With Objects` and `Grab To Pointer Tip` checkboxes on the `VRTK_Pointer` component.
+  * If you are using also the teleport you can use this configuration:
+     * in the `VRTK_Pointer` component
+       * set `Selection Button` to `Button Two Press`
+     * set `Pointer Set Button` to `Button Two Press`
+     * `VRTK_ControllerEvents` component
+  * Check each interactive object:
+    * Set `Allowed Grab Controllers` to `Both` on the `VRTK_Interactable Object` component of each object.
+    * **NOTE**: Probably setting `Precision Grab` on the `VRTK_Fixed Joint Grap Attach` component of each interactive object makes the interaction easier.
+* UI Pointer setup
+  * Set up the Gaze Pointer
+  * Add a `VRTK_UI_Pointer` component to the `Headset` game object
+    * Set `Activation Button` to `Undefined`
+    * Set `Activation Mode` to `Always On`
+    * Set `Selection Button` to `Touchpad touch`
+  * In the `VRTK_ControllerEvents` component set `UI Click Button` to `Touchpad touch`
+Deploying and running your project on your development device for Gear VR:
+* switch your Unity project platform to Android
+* copy special OSIG file additions (e.g. `oculussig_*`) to your project under `Assets/Plugins/Android/Assets/`
+* make some changes to Unity Player Settings (Other Settings)
+  * Rendering
+    * uncheck *Auto Graphics API*
+    * remove *OpenGLES2* from the *Graphics APIs* list
+  * Identification
+    * set *Bundle Identifier*
+    * set *Minimum API Level* to **API level 18** or higher
 
-Deploying and running your project on your development device for Gear VR requires that your Unity project platform be switched to Android, some changes to Unity Player Settings, and special OSIG file additions to your project under Assets/Plugins/Android/Assets/. Follow the detailed instructions on the Oculus website [here](https://developer3.oculus.com/documentation/game-engines/latest/concepts/unity-build-android/) to get your application running on device.
+Follow the [detailed instructions on the Oculus website](https://developer3.oculus.com/documentation/game-engines/latest/concepts/unity-build-android/) to get your application running on device.
+
+You can also test a GearVR setup directly in the Editor, switching to Android platform and pressing Play:
+* Move your camera in the Editor (or attach a proper script to move it with the keyboard/mouse)
+* Left mouse button is routed to the D-Pad touch
+* ESC key is routed to the D-Pad back button
 
 ### VRTK Gear VR Controller Support
 
-The Oculus Mobile SDK maps the tap of the Gear VR touchpad to Button.One and the back button to Button.Two in the [OVRInput class](https://developer3.oculus.com/documentation/game-engines/latest/concepts/unity-ovrinput/). Unity maps the inputs via the Input class with button names "Fire1" and "Cancel". To make working with VRTK on the Gear VR a bit simpler the inputs are mapped to allow compatibility with other VRTK platform button mappings so the tap of the touchpad works for several VRTK button aliases as follows:
+The Oculus Mobile SDK maps the tap of the Gear VR D-Pad to Button.One and the back button to Button.Two in the [OVRInput class](https://developer3.oculus.com/documentation/game-engines/latest/concepts/unity-ovrinput/). Unity maps the inputs via the Input class with button names "Fire1" and "Cancel".
+
+The closer analogy with the original htc Vive controller is D-Pad==Touchpad, Back==Menu (Back held down==System menu).
+This is the suggested mapping, but, to make working with VRTK on the Gear VR a bit simpler, the inputs are mapped to allow compatibility with other VRTK platform button mappings so the tap of the touchpad works for several VRTK button aliases as follows:
 
 **Touchpad Tap (Button One Mappings)**
 * Touchpad_Touch

--- a/Assets/VRTK/SDK/GearVR/GearVR_README.md
+++ b/Assets/VRTK/SDK/GearVR/GearVR_README.md
@@ -1,0 +1,55 @@
+## VRTK Samsung Gear VR Support
+_Ryan Dawson (@coderdawson)_
+
+Samsung Gear VR is a mobile, Android-based VR platform that is extremely limited when compared to other desktop-based VR platforms such as the HTC Vive and Oculus Rift. The Gear VR headset supports orientation tracking only; it does not support position tracking. For input, the Gear VR headset has a very simple touchpad on its right side; it does not support motion or pointer based controllers. The touchpad supports the detection of a tap/click and can also be used for some simple directional swiping. The headset also includes a back button. Most implementations on the Gear VR rely on gaze-based pointers and touchpad tapping for application input.
+
+Currently, Samsung Gear VR requires a Samsung Galaxy S6, S6 Edge, S6 Edge+, S7, S7 Edge, or Note 5 handset. With a mobile device used as the Gear VR's main processing unit, the performance capabilities are also extremely limited when compared with other desktop-base VR platforms. Special care must be taken to ensure your application can run at 60 fps. It is recommended that your application target between 50 and 100 draw calls per frame and stay below 100,000 vertices. 
+
+**BE WARNED**: Mobile VR development is not for the faint of heart. Performance issues can arise with the simplist of visuals if they are not properly optimized. On top of this, VRTK was developed primarily for desktop-based VR platforms and mobile VR specific optimizations may be required in order to fully utilize it such a platform. 
+
+### Pre-requisites
+
+Developing for Samsung Gear VR requires that your environment have both Unity and your development phone set up first. Follow the steps/links below to configure your development environment and phone.
+
+ 1. [Setup Unity for Android development](https://docs.unity3d.com/Manual/android-sdksetup.html)
+ 2. [Install the USB drivers for your phone.](https://developer.android.com/studio/run/oem-usb.html)
+ 3. Enable developer settings on your phone by following [this guide](https://developer.android.com/studio/run/device.html#device-developer-options), then enable USB debugging on the developer menu.
+
+### Setup
+
+For simple VR support, all that is required is to turn on Unity's `Virtual Reality Supported` project setting and place a GameObject with the Camera component on it in your scene and tag the GameObject with the `MainCamera` tag. However, in order to support features like teleporting you must place your camera under a parent GameObject so the camera can be moved. Follow the steps below to configure your scene for Gear VR deployment with VRTK feature support.
+ * Basic Setup
+   * Create a GameObject, named `CameraRig`, positioned where the player should be located in your virtual world. This GameObject will be the parent for our camera. 
+     * Standard naming for a GameObject such as this is `CameraRig`, but you can name it whatever you like.
+     * **NOTE**: You will want to ensure that the `CameraRig` Transform's Y value is 0.
+   * Create a Camera GameObject (GameObject with a `Camera` component) as a child of the `CameraRig` GameObject previously created.
+     * **NOTE**: This Camera GameObject must be named `Camera`, `Main Camera`, or `Headset`.
+     * Since Gear VR is a non-position tracked platform it is important that the position of the child Camera GameObject be at the height at which you would like the player to be in your world with zero for both the X and Z value on the Transform. Some experimentation will be needed here.
+   * Create a GameObject in your scene called `VRTK` and add the `VRTK_SDKManager` to it.
+   * Select `Gear VR` from the `Quick select SDK` drop-down on the `VRTK_SDKManager` component inspector and wait for your scripts to be recompiled.
+   * Click the `Auto Populate Linked Objects` button on the `VRTK_SDKManager` inspector to find the relevant Linked Objects.
+ * Gaze Pointer Setup
+   * Add a `VRTK_ControllerEvents` component to your camera GameObject.
+   * Add a `VRTK_Pointer` component to your camera GameObject.
+   * Add a `VRTK_StraightPointerRenderer` component to your camera GameObject.
+   * Drag your camera GameObject to the `Pointer Renderer` object field of the `VRTK_Pointer` component.
+ * Gaze Pointer Highlighting/Grabbing
+   * Add a `VRTK_InteractTouch` component to your camera GameObject.
+   * Add a `VRTK_InteractGrab` component to your camera GameObject.
+   * Check the `Interact With Objects` and `Grab To Pointer Tip` checkboxes on the `VRTK_Pointer` component.
+
+Deploying and running your project on your development device for Gear VR requires that your Unity project platform be switched to Android, some changes to Unity Player Settings, and special OSIG file additions to your project under Assets/Plugins/Android/Assets/. Follow the detailed instructions on the Oculus website [here](https://developer3.oculus.com/documentation/game-engines/latest/concepts/unity-build-android/) to get your application running on device.
+
+### VRTK Gear VR Controller Support
+
+The Oculus Mobile SDK maps the tap of the Gear VR touchpad to Button.One and the back button to Button.Two in the [OVRInput class](https://developer3.oculus.com/documentation/game-engines/latest/concepts/unity-ovrinput/). Unity maps the inputs via the Input class with button names "Fire1" and "Cancel". To make working with VRTK on the Gear VR a bit simpler the inputs are mapped to allow compatibility with other VRTK platform button mappings so the tap of the touchpad works for several VRTK button aliases as follows:
+
+**Touchpad Tap (Button One Mappings)**
+* Touchpad_Touch
+* Touchpad_Press
+* Button_One_Touch
+* Button_One_Press
+
+**Back Button (Button Two Mappings)**
+* Button_Two_Touch
+* Button_Two_Press

--- a/Assets/VRTK/SDK/GearVR/GearVR_README.md.meta
+++ b/Assets/VRTK/SDK/GearVR/GearVR_README.md.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f16e552a0fffce45bc95b617b408997
+timeCreated: 1487635366
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRBoundaries.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRBoundaries.cs
@@ -1,8 +1,9 @@
 ﻿// GearVR Boundaries|SDK_GearVR|004
 namespace VRTK
 {
-#if VRTK_SDK_GEARVR
+#if VRTK_DEFINE_SDK_GEARVR
     using UnityEngine;
+#endif
 
     /// <summary>
     /// The Base Boundaries SDK script provides a bridge to SDK methods that deal with the play area of SDKs that support room scale play spaces.
@@ -10,8 +11,15 @@ namespace VRTK
     /// <remarks>
     /// This is the fallback class that will just return default values.
     /// </remarks>
-    public class SDK_GearVRBoundaries : SDK_BaseBoundaries
+    [SDK_Description(typeof(SDK_GearVRSystem))]
+    public class SDK_GearVRBoundaries
+#if VRTK_DEFINE_SDK_GEARVR
+        : SDK_BaseBoundaries
+#else
+        : SDK_FallbackBoundaries
+#endif
     {
+#if VRTK_DEFINE_SDK_GEARVR
         private Vector3[] cachedBoundaryVertices;
 
         /// <summary>
@@ -28,17 +36,17 @@ namespace VRTK
         public override Transform GetPlayArea()
         {
             cachedPlayArea = GetSDKManagerPlayArea();
-            if (cachedPlayArea == null) 
+            if (cachedPlayArea == null)
             {
                 var mainCamera = Camera.main;
-                if (mainCamera != null) 
+                if (mainCamera != null)
                 {
                     var mainCameraTransform = mainCamera.transform;
-                    if (mainCameraTransform.parent != null) 
+                    if (mainCameraTransform.parent != null)
                     {
                         cachedPlayArea = mainCameraTransform.parent;
                     }
-                    else 
+                    else
                     {
 #if UNITY_EDITOR
                         Debug.LogWarning("In order to allow teleporting to work, the main camera must be under a parent GameObject that can be moved!");
@@ -58,7 +66,7 @@ namespace VRTK
         /// <returns>A Vector3 array of the points in the scene that represent the play area boundaries.</returns>
         public override Vector3[] GetPlayAreaVertices(GameObject playArea)
         {
-            if (cachedBoundaryVertices == null) 
+            if (cachedBoundaryVertices == null)
             {
                 float thickness = 0.1f;
                 Vector3 outerBoundary = new Vector3(1f, 0f, 1f);
@@ -99,10 +107,6 @@ namespace VRTK
         {
             return true;
         }
-    }
-#else
-    public class SDK_GearVRBoundaries : SDK_FallbackBoundaries
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRBoundaries.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRBoundaries.cs
@@ -1,0 +1,108 @@
+﻿// GearVR Boundaries|SDK_GearVR|004
+namespace VRTK
+{
+#if VRTK_SDK_GEARVR
+    using UnityEngine;
+
+    /// <summary>
+    /// The Base Boundaries SDK script provides a bridge to SDK methods that deal with the play area of SDKs that support room scale play spaces.
+    /// </summary>
+    /// <remarks>
+    /// This is the fallback class that will just return default values.
+    /// </remarks>
+    public class SDK_GearVRBoundaries : SDK_BaseBoundaries
+    {
+        private Vector3[] cachedBoundaryVertices;
+
+        /// <summary>
+        /// The InitBoundaries method is run on start of scene and can be used to initialse anything on game start.
+        /// </summary>
+        public override void InitBoundaries()
+        {
+        }
+
+        /// <summary>
+        /// The GetPlayArea method returns the Transform of the object that is used to represent the play area in the scene.
+        /// </summary>
+        /// <returns>A transform of the object representing the play area in the scene.</returns>
+        public override Transform GetPlayArea()
+        {
+            cachedPlayArea = GetSDKManagerPlayArea();
+            if (cachedPlayArea == null) 
+            {
+                var mainCamera = Camera.main;
+                if (mainCamera != null) 
+                {
+                    var mainCameraTransform = mainCamera.transform;
+                    if (mainCameraTransform.parent != null) 
+                    {
+                        cachedPlayArea = mainCameraTransform.parent;
+                    }
+                    else 
+                    {
+#if UNITY_EDITOR
+                        Debug.LogWarning("In order to allow teleporting to work, the main camera must be under a parent GameObject that can be moved!");
+#endif
+                        cachedPlayArea = mainCameraTransform;
+                    }
+                }
+            }
+
+            return cachedPlayArea;
+        }
+
+        /// <summary>
+        /// The GetPlayAreaVertices method returns the points of the play area boundaries.
+        /// </summary>
+        /// <param name="playArea">The GameObject containing the play area representation.</param>
+        /// <returns>A Vector3 array of the points in the scene that represent the play area boundaries.</returns>
+        public override Vector3[] GetPlayAreaVertices(GameObject playArea)
+        {
+            if (cachedBoundaryVertices == null) 
+            {
+                float thickness = 0.1f;
+                Vector3 outerBoundary = new Vector3(1f, 0f, 1f);
+
+                cachedBoundaryVertices = new Vector3[8]
+                {
+                    new Vector3(outerBoundary.x - thickness, 0f, outerBoundary.z - thickness),
+                    new Vector3(0f + thickness, 0f, outerBoundary.z - thickness),
+                    new Vector3(0f + thickness, 0f, 0f + thickness),
+                    new Vector3(outerBoundary.x - thickness, 0f, 0f + thickness),
+
+                    new Vector3(outerBoundary.x, 0f, outerBoundary.z),
+                    new Vector3(0f, 0f, outerBoundary.z),
+                    new Vector3(0f, 0f, 0f),
+                    new Vector3(outerBoundary.x, 0f, 0f)
+                };
+            }
+
+            return cachedBoundaryVertices;
+        }
+
+        /// <summary>
+        /// The GetPlayAreaBorderThickness returns the thickness of the drawn border for the given play area.
+        /// </summary>
+        /// <param name="playArea">The GameObject containing the play area representation.</param>
+        /// <returns>The thickness of the drawn border.</returns>
+        public override float GetPlayAreaBorderThickness(GameObject playArea)
+        {
+            return 0.1f;
+        }
+
+        /// <summary>
+        /// The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
+        /// </summary>
+        /// <param name="playArea">The GameObject containing the play area representation.</param>
+        /// <returns>Returns true if the play area size has been auto calibrated and set by external sensors.</returns>
+        public override bool IsPlayAreaSizeCalibrated(GameObject playArea)
+        {
+            return true;
+        }
+    }
+#else
+    public class SDK_GearVRBoundaries : SDK_FallbackBoundaries
+    {
+    }
+#endif
+}

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRBoundaries.cs.meta
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRBoundaries.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 35b5c1d4a208d2443821bf02cca7edf6
+timeCreated: 1487445452
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRController.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRController.cs
@@ -1,0 +1,720 @@
+﻿// GearVR Controller|SDK_GearVR|003
+namespace VRTK
+{
+#if VRTK_SDK_GEARVR
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The OculusVR Controller SDK script provides a bridge to SDK methods that deal with the input devices.
+    /// </summary>
+    public class SDK_GearVRController : SDK_BaseController
+    {
+        private static readonly string ButtonOneAlias = "Fire1";
+        private static readonly string ButtonTwoAlias = "Cancel";
+
+        private bool touchpadPressed;
+        private bool backButtonPressed;
+
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="index">The index of the controller.</param>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public override void ProcessUpdate(uint index, Dictionary<string, object> options)
+        {
+            if (Input.GetButtonDown(ButtonOneAlias))
+                touchpadPressed = true;
+            else if (Input.GetButtonUp(ButtonOneAlias))
+                touchpadPressed = false;
+
+            if (Input.GetButtonDown(ButtonTwoAlias))
+                backButtonPressed = true;
+            else if (Input.GetButtonUp(ButtonTwoAlias))
+                backButtonPressed = false;
+        }
+
+        /// <summary>
+        /// The GetControllerDefaultColliderPath returns the path to the prefab that contains the collider objects for the default controller of this SDK.
+        /// </summary>
+        /// <param name="hand">The controller hand to check for</param>
+        /// <returns>A path to the resource that contains the collider GameObject.</returns>
+        public override string GetControllerDefaultColliderPath(ControllerHand hand)
+        {
+            return "ControllerColliders/Fallback";
+        }
+
+        /// <summary>
+        /// The GetControllerElementPath returns the path to the game object that the given controller element for the given hand resides in.
+        /// </summary>
+        /// <param name="element">The controller element to look up.</param>
+        /// <param name="hand">The controller hand to look up.</param>
+        /// <param name="fullPath">Whether to get the initial path or the full path to the element.</param>
+        /// <returns>A string containing the path to the game object that the controller element resides in.</returns>
+        public override string GetControllerElementPath(ControllerElements element, ControllerHand hand, bool fullPath = false)
+        {
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// The GetControllerIndex method returns the index of the given controller.
+        /// </summary>
+        /// <param name="controller">The GameObject containing the controller.</param>
+        /// <returns>The index of the given controller.</returns>
+        public override uint GetControllerIndex(GameObject controller)
+        {
+            uint index = uint.MaxValue;
+
+            switch (controller.name) 
+            {
+                case "Camera":
+                case "Main Camera":
+                case "Headset":
+                    index = 0;
+                    break;
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// The GetControllerByIndex method returns the GameObject of a controller with a specific index.
+        /// </summary>
+        /// <param name="index">The index of the controller to find.</param>
+        /// <param name="actual">If true it will return the actual controller, if false it will return the script alias controller GameObject.</param>
+        /// <returns></returns>
+        public override GameObject GetControllerByIndex(uint index, bool actual = false)
+        {
+            GameObject controller = null;
+
+            if (index == 0)
+            {
+                controller = VRTK_SDKManager.instance.GetHeadsetSDK().GetHeadset().gameObject;
+            }
+
+            return controller;
+        }
+
+        /// <summary>
+        /// The GetControllerOrigin method returns the origin of the given controller.
+        /// </summary>
+        /// <param name="controller">The controller to retrieve the origin from.</param>
+        /// <returns>A Transform containing the origin of the controller.</returns>
+        public override Transform GetControllerOrigin(GameObject controller)
+        {
+            return VRTK_SDKManager.instance.GetHeadsetSDK().GetHeadset();
+        }
+
+        /// <summary>
+        /// The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
+        /// </summary>
+        /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
+        /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        public override Transform GenerateControllerPointerOrigin(GameObject parent)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// The GetControllerLeftHand method returns the GameObject containing the representation of the left hand controller.
+        /// </summary>
+        /// <param name="actual">If true it will return the actual controller, if false it will return the script alias controller GameObject.</param>
+        /// <returns>The GameObject containing the left hand controller.</returns>
+        public override GameObject GetControllerLeftHand(bool actual = false)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// The GetControllerRightHand method returns the GameObject containing the representation of the right hand controller.
+        /// </summary>
+        /// <param name="actual">If true it will return the actual controller, if false it will return the script alias controller GameObject.</param>
+        /// <returns>The GameObject containing the right hand controller.</returns>
+        public override GameObject GetControllerRightHand(bool actual = false)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// The IsControllerLeftHand/1 method is used to check if the given controller is the the left hand controller.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <returns>Returns true if the given controller is the left hand controller.</returns>
+        public override bool IsControllerLeftHand(GameObject controller)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsControllerRightHand/1 method is used to check if the given controller is the the right hand controller.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <returns>Returns true if the given controller is the right hand controller.</returns>
+        public override bool IsControllerRightHand(GameObject controller)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsControllerLeftHand/2 method is used to check if the given controller is the the left hand controller.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <param name="actual">If true it will check the actual controller, if false it will check the script alias controller.</param>
+        /// <returns>Returns true if the given controller is the left hand controller.</returns>
+        public override bool IsControllerLeftHand(GameObject controller, bool actual)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <param name="actual">If true it will check the actual controller, if false it will check the script alias controller.</param>
+        /// <returns>Returns true if the given controller is the right hand controller.</returns>
+        public override bool IsControllerRightHand(GameObject controller, bool actual)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The GetControllerModel method returns the model alias for the given GameObject.
+        /// </summary>
+        /// <param name="controller">The GameObject to get the model alias for.</param>
+        /// <returns>The GameObject that has the model alias within it.</returns>
+        public override GameObject GetControllerModel(GameObject controller)
+        {
+            return GetControllerModelFromController(controller);
+        }
+
+        /// <summary>
+        /// The GetControllerModel method returns the model alias for the given controller hand.
+        /// </summary>
+        /// <param name="hand">The hand enum of which controller model to retrieve.</param>
+        /// <returns>The GameObject that has the model alias within it.</returns>
+        public override GameObject GetControllerModel(ControllerHand hand)
+        {
+            var sdkManager = VRTK_SDKManager.instance;
+            if (Application.isPlaying && sdkManager != null) 
+            {
+                return sdkManager.GetHeadsetSDK().GetHeadset().gameObject;
+            }
+            else 
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The GetControllerRenderModel method gets the game object that contains the given controller's render model.
+        /// </summary>
+        /// <param name="controller">The GameObject to check.</param>
+        /// <returns>A GameObject containing the object that has a render model for the controller.</returns>
+        public override GameObject GetControllerRenderModel(GameObject controller)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// The SetControllerRenderModelWheel method sets the state of the scroll wheel on the controller render model.
+        /// </summary>
+        /// <param name="renderModel">The GameObject containing the controller render model.</param>
+        /// <param name="state">If true and the render model has a scroll wheen then it will be displayed, if false then the scroll wheel will be hidden.</param>
+        public override void SetControllerRenderModelWheel(GameObject renderModel, bool state)
+        {
+        }
+
+        /// <summary>
+        /// The HapticPulseOnIndex method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
+        public override void HapticPulseOnIndex(uint index, float strength = 0.5f)
+        {
+        }
+
+        /// <summary>
+        /// The GetHapticModifiers method is used to return modifiers for the duration and interval if the SDK handles it slightly differently.
+        /// </summary>
+        /// <returns>An SDK_ControllerHapticModifiers object with a given `durationModifier` and an `intervalModifier`.</returns>
+        public override SDK_ControllerHapticModifiers GetHapticModifiers()
+        {
+            return new SDK_ControllerHapticModifiers();
+        }
+
+        /// <summary>
+        /// The GetVelocityOnIndex method is used to determine the current velocity of the tracked object on the given index.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector3 containing the current velocity of the tracked object.</returns>
+        public override Vector3 GetVelocityOnIndex(uint index)
+        {
+            return Vector3.zero;
+        }
+
+        /// <summary>
+        /// The GetAngularVelocityOnIndex method is used to determine the current angular velocity of the tracked object on the given index.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector3 containing the current angular velocity of the tracked object.</returns>
+        public override Vector3 GetAngularVelocityOnIndex(uint index)
+        {
+            return Vector3.zero;
+        }
+
+        /// <summary>
+        /// The GetTouchpadAxisOnIndex method is used to get the current touch position on the controller touchpad.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector2 containing the current x,y position of where the touchpad is being touched.</returns>
+        public override Vector2 GetTouchpadAxisOnIndex(uint index)
+        {
+            return Input.mousePosition;
+        }
+
+        /// <summary>
+        /// The GetTriggerAxisOnIndex method is used to get the current trigger position on the controller.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector2 containing the current position of the trigger.</returns>
+        public override Vector2 GetTriggerAxisOnIndex(uint index)
+        {
+            return Vector2.zero;
+        }
+
+        /// <summary>
+        /// The GetGripAxisOnIndex method is used to get the current grip position on the controller.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>A Vector2 containing the current position of the grip.</returns>
+        public override Vector2 GetGripAxisOnIndex(uint index)
+        {
+            return Vector2.zero;
+        }
+
+        /// <summary>
+        /// The GetTriggerHairlineDeltaOnIndex method is used to get the difference between the current trigger press and the previous frame trigger press.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>The delta between the trigger presses.</returns>
+        public override float GetTriggerHairlineDeltaOnIndex(uint index)
+        {
+            return 0f;
+        }
+
+        /// <summary>
+        /// The GetGripHairlineDeltaOnIndex method is used to get the difference between the current grip press and the previous frame grip press.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>The delta between the grip presses.</returns>
+        public override float GetGripHairlineDeltaOnIndex(uint index)
+        {
+            return 0f;
+        }
+
+        /// <summary>
+        /// The IsTriggerPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsTriggerPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsTriggerPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsTriggerPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsTriggerTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsTriggerTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTriggerTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsTriggerTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairTriggerDownOnIndex method is used to determine if the controller button has passed it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has passed it's press threshold.</returns>
+        public override bool IsHairTriggerDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairTriggerUpOnIndex method is used to determine if the controller button has been released from it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released from it's press threshold.</returns>
+        public override bool IsHairTriggerUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsGripPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsGripPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsGripPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsGripTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsGripTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsGripTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsGripTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairGripDownOnIndex method is used to determine if the controller button has passed it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has passed it's press threshold.</returns>
+        public override bool IsHairGripDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsHairGripUpOnIndex method is used to determine if the controller button has been released from it's press threshold.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released from it's press threshold.</returns>
+        public override bool IsHairGripUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsTouchpadPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsTouchpadPressedOnIndex(uint index)
+        {
+            return touchpadPressed;
+        }
+
+        /// <summary>
+        /// The IsTouchpadPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsTouchpadPressedDownOnIndex(uint index)
+        {
+            return Input.GetButtonDown(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsTouchpadPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsTouchpadPressedUpOnIndex(uint index)
+        {
+            return Input.GetButtonUp(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsTouchpadTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsTouchpadTouchedOnIndex(uint index)
+        {
+            return touchpadPressed;
+        }
+
+        /// <summary>
+        /// The IsTouchpadTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsTouchpadTouchedDownOnIndex(uint index)
+        {
+            return Input.GetButtonDown(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsTouchpadTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsTouchpadTouchedUpOnIndex(uint index)
+        {
+            return Input.GetButtonUp(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonOnePressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsButtonOnePressedOnIndex(uint index)
+        {
+            return touchpadPressed;
+        }
+
+        /// <summary>
+        /// The IsButtonOnePressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsButtonOnePressedDownOnIndex(uint index)
+        {
+            return Input.GetButtonDown(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonOnePressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonOnePressedUpOnIndex(uint index)
+        {
+            return Input.GetButtonUp(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonOneTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsButtonOneTouchedOnIndex(uint index)
+        {
+            return touchpadPressed;
+        }
+
+        /// <summary>
+        /// The IsButtonOneTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsButtonOneTouchedDownOnIndex(uint index)
+        {
+            return Input.GetButtonDown(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonOneTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonOneTouchedUpOnIndex(uint index)
+        {
+            return Input.GetButtonUp(ButtonOneAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonTwoPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsButtonTwoPressedOnIndex(uint index)
+        {
+            return backButtonPressed;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsButtonTwoPressedDownOnIndex(uint index)
+        {
+            return Input.GetButtonDown(ButtonTwoAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonTwoPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonTwoPressedUpOnIndex(uint index)
+        {
+            return Input.GetButtonUp(ButtonTwoAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonTwoTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsButtonTwoTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsButtonTwoTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsButtonTwoTouchedDownOnIndex(uint index)
+        {
+            return Input.GetButtonDown(ButtonTwoAlias);
+        }
+
+        /// <summary>
+        /// The IsButtonTwoTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsButtonTwoTouchedUpOnIndex(uint index)
+        {
+            return Input.GetButtonUp(ButtonTwoAlias);
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedOnIndex method is used to determine if the controller button is being pressed down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being pressed.</returns>
+        public override bool IsStartMenuPressedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedDownOnIndex method is used to determine if the controller button has just been pressed down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been pressed down.</returns>
+        public override bool IsStartMenuPressedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuPressedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuPressedUpOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedOnIndex method is used to determine if the controller button is being touched down continually.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button is continually being touched.</returns>
+        public override bool IsStartMenuTouchedOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedDownOnIndex method is used to determine if the controller button has just been touched down.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been touched down.</returns>
+        public override bool IsStartMenuTouchedDownOnIndex(uint index)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The IsStartMenuTouchedUpOnIndex method is used to determine if the controller button has just been released.
+        /// </summary>
+        /// <param name="index">The index of the tracked object to check for.</param>
+        /// <returns>Returns true if the button has just been released.</returns>
+        public override bool IsStartMenuTouchedUpOnIndex(uint index)
+        {
+            return false;
+        }
+    }
+#else
+    public class SDK_GearVRController : SDK_FallbackController
+    {
+    }
+#endif
+}

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRController.cs.meta
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: dd616f3944b60c24d946c7c72b85b02c
+timeCreated: 1487445454
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRDefines.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRDefines.cs
@@ -1,0 +1,25 @@
+﻿// GearVR Defines|SDK_GearVR|001
+namespace VRTK
+{
+    /// <summary>
+    /// Handles all the scripting define symbols for the GearVR SDK.
+    /// </summary>
+    public static class SDK_GearVRDefines
+    {
+        /// <summary>
+        /// The scripting define symbol for the GearVR SDK.
+        /// </summary>
+        public const string ScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_GEARVR";
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Android")]
+        private static bool IsGearVRAvailable()
+        {
+            // Native support for Oculus by Unity
+#if UNITY_ANDROID
+            return true;
+#else
+            return false;
+#endif
+        }
+    }
+}

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRDefines.cs.meta
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRDefines.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3cf1b4a262878ed4088ccaf479f6f514
+timeCreated: 1489490923
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRHeadset.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRHeadset.cs
@@ -1,15 +1,23 @@
 ﻿// GearVR Headset|SDK_GearVR|002
 namespace VRTK
 {
-#if VRTK_SDK_GEARVR
+#if VRTK_DEFINE_SDK_GEARVR
     using UnityEngine;
     using System.Collections.Generic;
+#endif
 
     /// <summary>
     /// The GearVR Headset SDK script provides a bridge to the GearVR SDK.
     /// </summary>
-    public class SDK_GearVRHeadset : SDK_BaseHeadset
+    [SDK_Description(typeof(SDK_GearVRSystem))]
+    public class SDK_GearVRHeadset
+#if VRTK_DEFINE_SDK_GEARVR
+        : SDK_BaseHeadset
+#else
+        : SDK_FallbackHeadset
+#endif
     {
+#if VRTK_DEFINE_SDK_GEARVR
         private Quaternion previousHeadsetRotation;
         private Quaternion currentHeadsetRotation;
 
@@ -33,7 +41,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                var mainCamera = Camera.main;
+                Camera mainCamera = Camera.main;
                 if (mainCamera != null)
                 {
                     cachedHeadset = mainCamera.transform;
@@ -111,10 +119,6 @@ namespace VRTK
                 camera.gameObject.AddComponent<VRTK_ScreenFade>();
             }
         }
-    }
-#else
-    public class SDK_GearVRHeadset : SDK_FallbackHeadset
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRHeadset.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRHeadset.cs
@@ -1,0 +1,120 @@
+﻿// GearVR Headset|SDK_GearVR|002
+namespace VRTK
+{
+#if VRTK_SDK_GEARVR
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The GearVR Headset SDK script provides a bridge to the GearVR SDK.
+    /// </summary>
+    public class SDK_GearVRHeadset : SDK_BaseHeadset
+    {
+        private Quaternion previousHeadsetRotation;
+        private Quaternion currentHeadsetRotation;
+
+        /// <summary>
+        /// The ProcessUpdate method enables an SDK to run logic for every Unity Update
+        /// </summary>
+        /// <param name="options">A dictionary of generic options that can be used to within the update.</param>
+        public override void ProcessUpdate(Dictionary<string, object> options)
+        {
+            var device = GetHeadset();
+            previousHeadsetRotation = currentHeadsetRotation;
+            currentHeadsetRotation = device.transform.rotation;
+        }
+
+        /// <summary>
+        /// The GetHeadset method returns the Transform of the object that is used to represent the headset in the scene.
+        /// </summary>
+        /// <returns>A transform of the object representing the headset in the scene.</returns>
+        public override Transform GetHeadset()
+        {
+            cachedHeadset = GetSDKManagerHeadset();
+            if (cachedHeadset == null)
+            {
+                var mainCamera = Camera.main;
+                if (mainCamera != null)
+                {
+                    cachedHeadset = mainCamera.transform;
+                }
+            }
+            return cachedHeadset;
+        }
+
+        /// <summary>
+        /// The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
+        /// </summary>
+        /// <returns>A transform of the object holding the headset camera in the scene.</returns>
+        public override Transform GetHeadsetCamera()
+        {
+            cachedHeadsetCamera = GetSDKManagerHeadset();
+            if (cachedHeadsetCamera == null)
+            {
+                cachedHeadsetCamera = GetHeadset();
+            }
+            return cachedHeadsetCamera;
+        }
+
+        /// <summary>
+        /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current velocity of the headset.</returns>
+        public override Vector3 GetHeadsetVelocity()
+        {
+            return Vector3.zero;
+        }
+
+        /// <summary>
+        /// The GetHeadsetAngularVelocity method is used to determine the current angular velocity of the headset.
+        /// </summary>
+        /// <returns>A Vector3 containing the current angular velocity of the headset.</returns>
+        public override Vector3 GetHeadsetAngularVelocity()
+        {
+            var deltaRotation = currentHeadsetRotation * Quaternion.Inverse(previousHeadsetRotation);
+            return new Vector3(Mathf.DeltaAngle(0, deltaRotation.eulerAngles.x), Mathf.DeltaAngle(0, deltaRotation.eulerAngles.y), Mathf.DeltaAngle(0, deltaRotation.eulerAngles.z));
+        }
+
+        /// <summary>
+        /// The HeadsetFade method is used to apply a fade to the headset camera to progressively change the colour.
+        /// </summary>
+        /// <param name="color">The colour to fade to.</param>
+        /// <param name="duration">The amount of time the fade should take to reach the given colour.</param>
+        /// <param name="fadeOverlay">Determines whether to use an overlay on the fade.</param>
+        public override void HeadsetFade(Color color, float duration, bool fadeOverlay = false)
+        {
+            VRTK_ScreenFade.Start(color, duration);
+        }
+
+        /// <summary>
+        /// The HasHeadsetFade method checks to see if the given game object (usually the camera) has the ability to fade the viewpoint.
+        /// </summary>
+        /// <param name="obj">The Transform to check to see if a camera fade is available on.</param>
+        /// <returns>Returns true if the headset has fade functionality on it.</returns>
+        public override bool HasHeadsetFade(Transform obj)
+        {
+            if (obj.GetComponentInChildren<VRTK_ScreenFade>())
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The AddHeadsetFade method attempts to add the fade functionality to the game object with the camera on it.
+        /// </summary>
+        /// <param name="camera">The Transform to with the camera on to add the fade functionality to.</param>
+        public override void AddHeadsetFade(Transform camera)
+        {
+            if (camera && !camera.GetComponent<VRTK_ScreenFade>())
+            {
+                camera.gameObject.AddComponent<VRTK_ScreenFade>();
+            }
+        }
+    }
+#else
+    public class SDK_GearVRHeadset : SDK_FallbackHeadset
+    {
+    }
+#endif
+}

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRHeadset.cs.meta
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRHeadset.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c9965594c3f8329458581aaf29a2de85
+timeCreated: 1487445453
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRSystem.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRSystem.cs
@@ -1,12 +1,18 @@
 ﻿// GearVR System|SDK_GearVR|001
 namespace VRTK
 {
-#if VRTK_SDK_GEARVR
     /// <summary>
     /// The GearVR System SDK script provides a bridge to the GearVR SDK.
     /// </summary>
-    public class SDK_GearVRSystem : SDK_BaseSystem
+    [SDK_Description("GearVR", SDK_GearVRDefines.ScriptingDefineSymbol)]
+    public class SDK_GearVRSystem
+#if VRTK_DEFINE_SDK_GEARVR
+        : SDK_BaseSystem
+#else
+        : SDK_FallbackSystem
+#endif
     {
+#if VRTK_DEFINE_SDK_GEARVR
         /// <summary>
         /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.
         /// </summary>
@@ -32,10 +38,6 @@ namespace VRTK
         public override void ForceInterleavedReprojectionOn(bool force)
         {
         }
-    }
-#else
-    public class SDK_GearVRSystem : SDK_FallbackSystem
-    {
-    }
 #endif
+    }
 }

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRSystem.cs
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRSystem.cs
@@ -1,0 +1,41 @@
+﻿// GearVR System|SDK_GearVR|001
+namespace VRTK
+{
+#if VRTK_SDK_GEARVR
+    /// <summary>
+    /// The GearVR System SDK script provides a bridge to the GearVR SDK.
+    /// </summary>
+    public class SDK_GearVRSystem : SDK_BaseSystem
+    {
+        /// <summary>
+        /// The IsDisplayOnDesktop method returns true if the display is extending the desktop.
+        /// </summary>
+        /// <returns>Returns true if the display is extending the desktop</returns>
+        public override bool IsDisplayOnDesktop()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The ShouldAppRenderWithLowResources method is used to determine if the Unity app should use low resource mode. Typically true when the dashboard is showing.
+        /// </summary>
+        /// <returns>Returns true if the Unity app should render with low resources.</returns>
+        public override bool ShouldAppRenderWithLowResources()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The ForceInterleavedReprojectionOn method determines whether Interleaved Reprojection should be forced on or off.
+        /// </summary>
+        /// <param name="force">If true then Interleaved Reprojection will be forced on, if false it will not be forced on.</param>
+        public override void ForceInterleavedReprojectionOn(bool force)
+        {
+        }
+    }
+#else
+    public class SDK_GearVRSystem : SDK_FallbackSystem
+    {
+    }
+#endif
+}

--- a/Assets/VRTK/SDK/GearVR/SDK_GearVRSystem.cs.meta
+++ b/Assets/VRTK/SDK/GearVR/SDK_GearVRSystem.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 71e5ef23138524c46bc43b463e21e8b2
+timeCreated: 1487445452
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is the PR #944 by @CoderDawson updated to the latest VRTK version,
modified to be compliant with the new SDK management and with updated
documentation.

Add SDK_GearVRDefines to handle the scripting symbols for the GearVR.

Refactor and update other GearVR/SDK files.

Update documentation (`GearVR_README.md`).

Tested with GearVR:
* object touching and grabbing (005_Controller_BasicObjectGrabbing)
* interaction with Unity UI (034_Controls_InteractingWithUnityUI)
* teleport (044_CameraRig_RestrictedTeleportZones)

The examples were tested after changing `[CameraRig]` and `[VRTK]` in
order to support GearVR.