### PR TITLE
fix(Interaction): force secondary controller release on primary drop

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
+++ b/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
@@ -47,6 +47,7 @@ namespace VRTK.SecondaryControllerGrabActions
         /// </summary>
         public override void ProcessUpdate()
         {
+            base.ProcessUpdate();
             CheckForceStopDistance(ungrabDistance);
         }
 
@@ -55,6 +56,7 @@ namespace VRTK.SecondaryControllerGrabActions
         /// </summary>
         public override void ProcessFixedUpdate()
         {
+            base.ProcessFixedUpdate();
             if (initialised)
             {
                 if (uniformScaling)
@@ -70,7 +72,7 @@ namespace VRTK.SecondaryControllerGrabActions
 
         protected virtual void ApplyScale(Vector3 newScale)
         {
-            var existingScale = grabbedObject.transform.localScale;
+            Vector3 existingScale = grabbedObject.transform.localScale;
 
             float finalScaleX = (lockXAxis ? existingScale.x : newScale.x);
             float finalScaleY = (lockYAxis ? existingScale.y : newScale.y);

--- a/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_ControlDirectionGrabAction.cs
+++ b/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_ControlDirectionGrabAction.cs
@@ -70,6 +70,7 @@ namespace VRTK.SecondaryControllerGrabActions
         /// </summary>
         public override void OnDropAction()
         {
+            base.OnDropAction();
             StopRealignOnRelease();
         }
 
@@ -78,6 +79,7 @@ namespace VRTK.SecondaryControllerGrabActions
         /// </summary>
         public override void ProcessUpdate()
         {
+            base.ProcessUpdate();
             CheckForceStopDistance(ungrabDistance);
         }
 
@@ -86,6 +88,7 @@ namespace VRTK.SecondaryControllerGrabActions
         /// </summary>
         public override void ProcessFixedUpdate()
         {
+            base.ProcessFixedUpdate();
             if (initialised)
             {
                 AimObject();

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -371,8 +371,8 @@ namespace VRTK
                 }
                 grabbedObjectScript.Ungrabbed(grabbingObject);
                 grabbedObjectScript.ToggleHighlight(false);
-
                 ToggleControllerVisibility(true);
+
                 OnControllerUngrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
             }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -330,11 +330,11 @@ namespace VRTK
         /// <param name="previousGrabbingObject">The game object that was previously grabbing this object.</param>
         public virtual void Ungrabbed(GameObject previousGrabbingObject)
         {
-            var secondaryGrabbingObject = GetSecondaryGrabbingObject();
+            GameObject secondaryGrabbingObject = GetSecondaryGrabbingObject();
             if (!secondaryGrabbingObject || secondaryGrabbingObject != previousGrabbingObject)
             {
                 SecondaryControllerUngrab(secondaryGrabbingObject);
-                PrimaryControllerUngrab(previousGrabbingObject);
+                PrimaryControllerUngrab(previousGrabbingObject, secondaryGrabbingObject);
             }
             else
             {
@@ -850,15 +850,16 @@ namespace VRTK
             }
         }
 
-        protected virtual void PrimaryControllerUngrab(GameObject previousGrabbingObject)
+        protected virtual void PrimaryControllerUngrab(GameObject previousGrabbingObject, GameObject previousSecondaryGrabbingObject)
         {
             UnpauseCollisions();
             RemoveTrackPoint();
             ResetUseState(previousGrabbingObject);
             grabbingObjects.Clear();
-            if (secondaryGrabActionScript)
+            if (secondaryGrabActionScript != null && previousSecondaryGrabbingObject != null)
             {
                 secondaryGrabActionScript.OnDropAction();
+                previousSecondaryGrabbingObject.GetComponent<VRTK_InteractGrab>().ForceRelease();
             }
             LoadPreviousState();
         }


### PR DESCRIPTION
There was an issue where the secondary controller was not notified of
the object release if the secondary controller was grabbing whilst the
primary controller was released.

The action is that the object is dropped and the secondary controller
has no influence over the object any more, but the secondary
controller Interact Grab script was not notified of the drop so it
would not emit the event and would keep the state of a grabbed object
until the grab button on the secondary controller was released.

This has been fixed by calling `ForceRelease` on the secondary
controller if the primary controller is ungrabbed. As the secondary
controller grab actions are cleaned up before the primary controller
then a `ForceRelease` should simply clean up the state of the
secondary controller Interact Grab script and not actually force
drop the object if it's still being held by the primary controller.