### PR TITLE
feat(Utilities): add custom raycast script for customising rays - resolves #1034

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System;
 
     /// <summary>
     /// The height adjust teleporter extends the basic teleporter and allows for the y position of the user's position to be altered based on whether the teleport location is on top of another object.
@@ -17,7 +18,10 @@ namespace VRTK
     {
         [Header("Height Adjust Options")]
 
-        [Tooltip("The layers to ignore when raycasting to find floors.")]
+        [Tooltip("A custom raycaster to use when raycasting to find floors.")]
+        public VRTK_CustomRaycast customRaycast;
+        [Tooltip("**OBSOLETE** The layers to ignore when raycasting to find floors.")]
+        [Obsolete("`VRTK_HeightAdjustTeleport.layersToIgnore` is no longer used in the `VRTK_HeightAdjustTeleport` class. This parameter will be removed in a future version of VRTK.")]
         public LayerMask layersToIgnore = Physics.IgnoreRaycastLayer;
 
         protected override void OnEnable()
@@ -43,13 +47,13 @@ namespace VRTK
 
         protected virtual float GetTeleportY(Transform target, Vector3 tipPosition)
         {
-            var newY = playArea.position.y;
-            var heightOffset = 0.1f;
+            float newY = playArea.position.y;
+            float heightOffset = 0.1f;
             //Check to see if the tip is on top of an object
-            var rayStartPositionOffset = Vector3.up * heightOffset;
-            var ray = new Ray(tipPosition + rayStartPositionOffset, -playArea.up);
+            Vector3 rayStartPositionOffset = Vector3.up * heightOffset;
+            Ray ray = new Ray(tipPosition + rayStartPositionOffset, -playArea.up);
             RaycastHit rayCollidedWith;
-            if (target && Physics.Raycast(ray, out rayCollidedWith, Mathf.Infinity, ~layersToIgnore))
+            if (target && VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity))
             {
                 newY = (tipPosition.y - rayCollidedWith.distance) + heightOffset;
             }

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -50,7 +50,11 @@ namespace VRTK
 
         [Tooltip("An optional Play Area Cursor generator to add to the destination position of the pointer tip.")]
         public VRTK_PlayAreaCursor playareaCursor;
-        [Tooltip("The layers for the pointer's raycasts to ignore.")]
+
+        [Tooltip("A custom raycaster to use for the pointer's raycasts to ignore.")]
+        public VRTK_CustomRaycast customRaycast;
+        [Tooltip("**OBSOLETE** The layers for the pointer's raycasts to ignore.")]
+        [Obsolete("`VRTK_BasePointerRenderer.layersToIgnore` is no longer used in the `VRTK_BasePointerRenderer` class. This parameter will be removed in a future version of VRTK.")]
         public LayerMask layersToIgnore = Physics.IgnoreRaycastLayer;
         [Tooltip("Specifies the smoothing to be applied to the pointer origin when positioning the pointer tip.")]
         public PointerOriginSmoothingSettings pointerOriginSmoothingSettings = new PointerOriginSmoothingSettings();
@@ -395,7 +399,7 @@ namespace VRTK
         {
             if (givenObject)
             {
-                var pointerRenderer = givenObject.GetComponent<MeshRenderer>();
+                MeshRenderer pointerRenderer = givenObject.GetComponent<MeshRenderer>();
                 pointerRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
                 pointerRenderer.receiveShadows = false;
                 pointerRenderer.material = defaultMaterial;
@@ -458,11 +462,11 @@ namespace VRTK
             objectInteractor.layer = LayerMask.NameToLayer("Ignore Raycast");
             VRTK_PlayerObject.SetPlayerObject(objectInteractor, VRTK_PlayerObject.ObjectTypes.Pointer);
 
-            var objectInteractorCollider = new GameObject(string.Format("[{0}]BasePointerRenderer_ObjectInteractor_Collider", gameObject.name));
+            GameObject objectInteractorCollider = new GameObject(string.Format("[{0}]BasePointerRenderer_ObjectInteractor_Collider", gameObject.name));
             objectInteractorCollider.transform.SetParent(objectInteractor.transform);
             objectInteractorCollider.transform.localPosition = Vector3.zero;
             objectInteractorCollider.layer = LayerMask.NameToLayer("Ignore Raycast");
-            var tmpCollider = objectInteractorCollider.AddComponent<SphereCollider>();
+            SphereCollider tmpCollider = objectInteractorCollider.AddComponent<SphereCollider>();
             tmpCollider.isTrigger = true;
             VRTK_PlayerObject.SetPlayerObject(objectInteractorCollider, VRTK_PlayerObject.ObjectTypes.Pointer);
 
@@ -472,7 +476,7 @@ namespace VRTK
                 objectInteractorAttachPoint.transform.SetParent(objectInteractor.transform);
                 objectInteractorAttachPoint.transform.localPosition = Vector3.zero;
                 objectInteractorAttachPoint.layer = LayerMask.NameToLayer("Ignore Raycast");
-                var objectInteratorRigidBody = objectInteractorAttachPoint.AddComponent<Rigidbody>();
+                Rigidbody objectInteratorRigidBody = objectInteractorAttachPoint.AddComponent<Rigidbody>();
                 objectInteratorRigidBody.isKinematic = true;
                 objectInteratorRigidBody.freezeRotation = true;
                 objectInteratorRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
@@ -194,7 +194,7 @@ namespace VRTK
             if ((attachedRotation * 100f) > heightLimitAngle)
             {
                 useForward = new Vector3(useForward.x, fixedForwardBeamForward.y, useForward.z);
-                var controllerRotationOffset = 1f - (attachedRotation - (heightLimitAngle / 100f));
+                float controllerRotationOffset = 1f - (attachedRotation - (heightLimitAngle / 100f));
                 calculatedLength = (maximumLength * controllerRotationOffset) * controllerRotationOffset;
             }
             else
@@ -202,11 +202,11 @@ namespace VRTK
                 fixedForwardBeamForward = origin.forward;
             }
 
-            var actualLength = calculatedLength;
+            float actualLength = calculatedLength;
             Ray pointerRaycast = new Ray(origin.position, useForward);
 
             RaycastHit collidedWith;
-            var hasRayHit = Physics.Raycast(pointerRaycast, out collidedWith, calculatedLength, ~layersToIgnore);
+            bool hasRayHit = VRTK_CustomRaycast.Raycast(customRaycast, pointerRaycast, out collidedWith, layersToIgnore, calculatedLength);
 
             float contactDistance = 0f;
             //reset if beam not hitting or hitting new target
@@ -237,7 +237,7 @@ namespace VRTK
             Ray projectedBeamDownRaycast = new Ray(jointPosition, Vector3.down);
             RaycastHit collidedWith;
 
-            var downRayHit = Physics.Raycast(projectedBeamDownRaycast, out collidedWith, float.PositiveInfinity, ~layersToIgnore);
+            bool downRayHit = VRTK_CustomRaycast.Raycast(customRaycast, projectedBeamDownRaycast, out collidedWith, layersToIgnore, float.PositiveInfinity);
 
             if (!downRayHit || (destinationHit.collider && destinationHit.collider != collidedWith.collider))
             {
@@ -279,21 +279,21 @@ namespace VRTK
 
                 for (int i = 0; i < tracerDensity - checkFrequency; i += checkFrequency)
                 {
-                    var currentPoint = checkPoints[i];
-                    var nextPoint = (i + checkFrequency < checkPoints.Length ? checkPoints[i + checkFrequency] : checkPoints[checkPoints.Length - 1]);
-                    var nextPointDirection = (nextPoint - currentPoint).normalized;
-                    var nextPointDistance = Vector3.Distance(currentPoint, nextPoint);
+                    Vector3 currentPoint = checkPoints[i];
+                    Vector3 nextPoint = (i + checkFrequency < checkPoints.Length ? checkPoints[i + checkFrequency] : checkPoints[checkPoints.Length - 1]);
+                    Vector3 nextPointDirection = (nextPoint - currentPoint).normalized;
+                    float nextPointDistance = Vector3.Distance(currentPoint, nextPoint);
 
                     Ray checkCollisionRay = new Ray(currentPoint, nextPointDirection);
                     RaycastHit checkCollisionHit;
 
-                    if (Physics.Raycast(checkCollisionRay, out checkCollisionHit, nextPointDistance, ~layersToIgnore))
+                    if (VRTK_CustomRaycast.Raycast(customRaycast, checkCollisionRay, out checkCollisionHit, layersToIgnore, nextPointDistance))
                     {
-                        var collisionPoint = checkCollisionRay.GetPoint(checkCollisionHit.distance);
+                        Vector3 collisionPoint = checkCollisionRay.GetPoint(checkCollisionHit.distance);
                         Ray downwardCheckRay = new Ray(collisionPoint + (Vector3.up * 0.01f), Vector3.down);
                         RaycastHit downwardCheckHit;
 
-                        if (Physics.Raycast(downwardCheckRay, out downwardCheckHit, float.PositiveInfinity, ~layersToIgnore))
+                        if (VRTK_CustomRaycast.Raycast(customRaycast, downwardCheckRay, out downwardCheckHit, layersToIgnore, float.PositiveInfinity))
                         {
                             destinationHit = downwardCheckHit;
                             newDownPosition = downwardCheckRay.GetPoint(downwardCheckHit.distance); ;
@@ -319,7 +319,7 @@ namespace VRTK
                 downPosition,
                 downPosition,
                 };
-                var tracerMaterial = (customTracer ? null : defaultMaterial);
+                Material tracerMaterial = (customTracer ? null : defaultMaterial);
                 actualTracer.SetPoints(beamPoints, tracerMaterial, currentColor);
                 if (tracerVisibility == VisibilityStates.AlwaysOff)
                 {

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -178,7 +178,7 @@ namespace VRTK
             Transform origin = GetOrigin();
             Ray pointerRaycast = new Ray(origin.position, origin.forward);
             RaycastHit pointerCollidedWith;
-            var rayHit = Physics.Raycast(pointerRaycast, out pointerCollidedWith, maximumLength, ~layersToIgnore);
+            bool rayHit = VRTK_CustomRaycast.Raycast(customRaycast, pointerRaycast, out pointerCollidedWith, layersToIgnore, maximumLength);
 
             CheckRayMiss(rayHit, pointerCollidedWith);
             CheckRayHit(rayHit, pointerCollidedWith);
@@ -197,7 +197,7 @@ namespace VRTK
             if (actualContainer)
             {
                 //if the additional decimal isn't added then the beam position glitches
-                var beamPosition = tracerLength / (2f + BEAM_ADJUST_OFFSET);
+                float beamPosition = tracerLength / (2f + BEAM_ADJUST_OFFSET);
 
                 actualTracer.transform.localScale = new Vector3(scaleFactor, scaleFactor, tracerLength);
                 actualTracer.transform.localPosition = Vector3.forward * beamPosition;

--- a/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
@@ -1,0 +1,54 @@
+﻿// Custom Raycast|Utilities|90045
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// A Custom Raycast allows to specify custom options for a Physics.Raycast.
+    /// </summary>
+    /// <remarks>
+    /// A number of other scripts can utilise a Custom Raycast to further customise the raycasts that the scripts use internally.
+    ///
+    /// For example, the VRTK_BodyPhysics script can be set to ignore trigger colliders when casting to see if it should teleport up or down to the nearest floor.
+    /// </remarks>
+    public class VRTK_CustomRaycast : MonoBehaviour
+    {
+        [Tooltip("The layers to ignore when raycasting.")]
+        public LayerMask layersToIgnore = Physics.IgnoreRaycastLayer;
+        [Tooltip("Determines whether the ray will interact with trigger colliders.")]
+        public QueryTriggerInteraction triggerInteraction = QueryTriggerInteraction.UseGlobal;
+
+        /// <summary>
+        /// The Raycast method is used to generate a raycast either from the given CustomRaycast object or a default Physics.Raycast.
+        /// </summary>
+        /// <param name="customCast">The optional raycast object with customised raycast parameters.</param>
+        /// <param name="ray">The Ray to cast with.</param>
+        /// <param name="hitData">The raycast hit data.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the raycast.</param>
+        /// <param name="length">The maximum length of the raycast.</param>
+        /// <returns>Returns true if the raycast successfully collides with a valid object.</returns>
+        public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomCast(ray, out hitData, length);
+            }
+            else
+            {
+                return Physics.Raycast(ray, out hitData, Mathf.Infinity, ~ignoreLayers);
+            }
+        }
+
+        /// <summary>
+        /// The CustomCast method is used to generate a raycast based on the options defined in the CustomRaycast object.
+        /// </summary>
+        /// <param name="ray">The Ray to cast with.</param>
+        /// <param name="hitData">The raycast hit data.</param>
+        /// <param name="length">The maximum length of the raycast.</param>
+        /// <returns>Returns true if the raycast successfully collides with a valid object.</returns>
+        public virtual bool CustomCast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)
+        {
+            return Physics.Raycast(ray, out hitData, Mathf.Infinity, ~layersToIgnore, triggerInteraction);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4f3942f053b21854fbc5d1227c94120b
+timeCreated: 1489944747
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1180,7 +1180,7 @@ Specifies the smoothing to be applied to the pointer.
  * **Smooths Rotation:** Whether or not to smooth the rotation of the pointer origin when positioning the pointer tip.
  * **Max Allowed Per Frame Angle Difference:** The maximum allowed angle between the unsmoothed pointer origin and the smoothed pointer origin per frame to use for smoothing.
  * **Playarea Cursor:** An optional Play Area Cursor generator to add to the destination position of the pointer tip.
- * **Layers To Ignore:** The layers for the pointer's raycasts to ignore.
+ * **Custom Raycast:** A custom raycaster to use for the pointer's raycasts to ignore.
  * **Valid Collision Color:** The colour to change the pointer materials when the pointer collides with a valid object. Set to `Color.clear` to bypass changing material colour on valid collision.
  * **Invalid Collision Color:** The colour to change the pointer materials when the pointer is not colliding with anything or with an invalid object. Set to `Color.clear` to bypass changing material colour on invalid collision.
  * **Tracer Visibility:** Determines when the main tracer of the pointer renderer will be visible.
@@ -1516,7 +1516,7 @@ The height adjust teleporter extends the basic teleporter and allows for the y p
 
 ### Inspector Parameters
 
- * **Layers To Ignore:** The layers to ignore when raycasting to find floors.
+ * **Custom Raycast:** A custom raycaster to use when raycasting to find floors.
 
 ### Example
 
@@ -4697,7 +4697,7 @@ To allow for peeking over a ledge and not falling, a fall restiction can happen 
  * **Movement Threshold:** The amount of movement of the headset between the headset's current position and the current standing position to determine if the user is walking in play space and to ignore the body physics collisions if the movement delta is above this threshold.
  * **Standing History Samples:** The maximum number of samples to collect of headset position before determining if the current standing position within the play space has changed.
  * **Lean Y Threshold:** The `y` distance between the headset and the object being leaned over, if object being leaned over is taller than this threshold then the current standing position won't be updated.
- * **Layers To Ignore:** The layers to ignore when raycasting to find floors.
+ * **Custom Raycast:** A custom raycaster to use when raycasting to find floors.
  * **Fall Restriction:** A check to see if the drop to nearest floor should take place. If the selected restrictor is still over the current floor then the drop to nearest floor will not occur. Works well for being able to lean over ledges and look down. Only works for falling down not teleporting up.
  * **Gravity Fall Y Threshold:** When the `y` distance between the floor and the headset exceeds this distance and `Enable Body Collisions` is true then the rigidbody gravity will be used instead of teleport to drop to nearest floor.
  * **Blink Y Threshold:** The `y` distance between the floor and the headset that must change before a fade transition is initiated. If the new user location is at a higher distance than the threshold then the headset blink transition will activate on teleport. If the new user location is within the threshold then no blink transition will happen, which is useful for walking up slopes, meshes and terrains to prevent constant blinking.
@@ -5461,6 +5461,7 @@ A collection of scripts that provide useful functionality to aid the creation pr
  * [Device Finder](#device-finder-vrtk_devicefinder)
  * [Shared Methods](#shared-methods-vrtk_sharedmethods)
  * [Policy List](#policy-list-vrtk_policylist)
+ * [Custom Raycast](#custom-raycast-vrtk_customraycast)
  * [Adaptive Quality](#adaptive-quality-vrtk_adaptivequality)
  * [Object Follow](#object-follow-vrtk_objectfollow)
  * [Rigidbody Follow](#rigidbody-follow-vrtk_rigidbodyfollow)
@@ -6128,6 +6129,53 @@ The Find method performs the set operation to determine if the given game object
    * `bool` - Returns true of the given game object matches the policy list or given string logic.
 
 The Check method is used to check if a game object should be ignored based on a given string or policy list.
+
+---
+
+## Custom Raycast (VRTK_CustomRaycast)
+
+### Overview
+
+A Custom Raycast allows to specify custom options for a Physics.Raycast.
+
+A number of other scripts can utilise a Custom Raycast to further customise the raycasts that the scripts use internally.
+
+For example, the VRTK_BodyPhysics script can be set to ignore trigger colliders when casting to see if it should teleport up or down to the nearest floor.
+
+### Inspector Parameters
+
+ * **Layers To Ignore:** The layers to ignore when raycasting.
+ * **Trigger Interaction:** Determines whether the ray will interact with trigger colliders.
+
+### Class Methods
+
+#### Raycast/5
+
+  > `public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity)`
+
+  * Parameters
+   * `VRTK_CustomRaycast customCast` - The optional raycast object with customised raycast parameters.
+   * `Ray ray` - The Ray to cast with.
+   * `out RaycastHit hitData` - The raycast hit data.
+   * `LayerMask ignoreLayers` - A layermask of layers to ignore from the raycast.
+   * `float length` - The maximum length of the raycast.
+  * Returns
+   * `bool` - Returns true if the raycast successfully collides with a valid object.
+
+The Raycast method is used to generate a raycast either from the given CustomRaycast object or a default Physics.Raycast.
+
+#### CustomCast/3
+
+  > `public virtual bool CustomCast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)`
+
+  * Parameters
+   * `Ray ray` - The Ray to cast with.
+   * `out RaycastHit hitData` - The raycast hit data.
+   * `float length` - The maximum length of the raycast.
+  * Returns
+   * `bool` - Returns true if the raycast successfully collides with a valid object.
+
+The CustomCast method is used to generate a raycast based on the options defined in the CustomRaycast object.
 
 ---
 


### PR DESCRIPTION
Many of the VRTK scripts utilise raycasts but have the raycast options
hard coded in the script. This new Custom Raycast script allows any
VRTK script that uses a raycast to have the raycast customised by
injecting a Custom Raycast into it.

Previously, the VRTK scripts that utilised a raycast would have a
`Layers To Ignore` parameter which would be passed through to the
raycast. However, this has now been deprecated as all of these scripts
can achieve the same customisation by using a Custom Raycast instead.