### PR TITLE
Terrain height checking should account for multiple terrains and terrain position

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -204,7 +204,7 @@ namespace VRTK
             if (adjustYForTerrain && target.GetComponent<Terrain>())
             {
                 var checkPosition = (useHeadsetForPosition ? new Vector3(headset.position.x, position.y, headset.position.z) : position);
-                var terrainHeight = Terrain.activeTerrain.SampleHeight(checkPosition);
+                var terrainHeight = target.GetComponent<Terrain>().SampleHeight(checkPosition) + target.position.y;
                 position.y = (terrainHeight > position.y ? position.y : Terrain.activeTerrain.GetPosition().y + terrainHeight);
             }
             return position;


### PR DESCRIPTION
While using the dash teleporter in a fairly complex project with multiple terrains, I had a problem with the player sometimes getting dropped below the terrain. After some debugging it turned out to be the CheckTerrainCollision() method in VRTK_BasicTeleport adjusting the position in relation to Terrain.activeTerrain, which assumes just one terrain. It also doesn't take the terrain position into account.
This one-line change fixes that..