### PR TITLE
feat(InteractableObject): add snap zone events

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -553,7 +553,7 @@ namespace VRTK
             {
                 //Turn on the highlighter
                 highlightObject.SetActive(state);
-                ioCheck.SetSnapDropZoneHover(state);
+                ioCheck.SetSnapDropZoneHover(this, state);
 
                 willSnap = state;
                 isHighlighted = state;

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -35,6 +35,22 @@
         /// Emits the InteractableObjectUnused class event.
         /// </summary>
         public UnityObjectEvent OnUnuse = new UnityObjectEvent();
+        /// <summary>
+        /// Emits the InteractableObjectEnteredSnapDropZone class event.
+        /// </summary>
+        public UnityObjectEvent OnEnterSnapDropZone = new UnityObjectEvent();
+        /// <summary>
+        /// Emits the InteractableObjectExitedSnapDropZone class event.
+        /// </summary>
+        public UnityObjectEvent OnExitSnapDropZone = new UnityObjectEvent();
+        /// <summary>
+        /// Emits the InteractableObjectSnappedToDropZone class event.
+        /// </summary>
+        public UnityObjectEvent OnSnapToDropZone = new UnityObjectEvent();
+        /// <summary>
+        /// Emits the InteractableObjectUnsnappedFromDropZone class event.
+        /// </summary>
+        public UnityObjectEvent OnUnsnapFromDropZone = new UnityObjectEvent();
 
         private void SetInteractableObject()
         {
@@ -59,6 +75,10 @@
             io.InteractableObjectUngrabbed += UnGrab;
             io.InteractableObjectUsed += Use;
             io.InteractableObjectUnused += Unuse;
+            io.InteractableObjectEnteredSnapDropZone += EnterSnapDropZone;
+            io.InteractableObjectExitedSnapDropZone += ExitSnapDropZone;
+            io.InteractableObjectSnappedToDropZone += SnapToDropZone;
+            io.InteractableObjectUnsnappedFromDropZone += UnsnapFromDropZone;
         }
 
         private void Touch(object o, InteractableObjectEventArgs e)
@@ -91,6 +111,26 @@
             OnUnuse.Invoke(o, e);
         }
 
+        private void EnterSnapDropZone(object o, InteractableObjectEventArgs e)
+        {
+            OnEnterSnapDropZone.Invoke(o, e);
+        }
+
+        private void ExitSnapDropZone(object o, InteractableObjectEventArgs e)
+        {
+            OnExitSnapDropZone.Invoke(o, e);
+        }
+
+        private void SnapToDropZone(object o, InteractableObjectEventArgs e)
+        {
+            OnSnapToDropZone.Invoke(o, e);
+        }
+
+        private void UnsnapFromDropZone(object o, InteractableObjectEventArgs e)
+        {
+            OnUnsnapFromDropZone.Invoke(o, e);
+        }
+
         private void OnDisable()
         {
             if (io == null)
@@ -104,6 +144,10 @@
             io.InteractableObjectUngrabbed -= UnGrab;
             io.InteractableObjectUsed -= Use;
             io.InteractableObjectUnused -= Unuse;
+            io.InteractableObjectEnteredSnapDropZone -= EnterSnapDropZone;
+            io.InteractableObjectExitedSnapDropZone -= ExitSnapDropZone;
+            io.InteractableObjectSnappedToDropZone -= SnapToDropZone;
+            io.InteractableObjectUnsnappedFromDropZone -= UnsnapFromDropZone;
         }
     }
 }


### PR DESCRIPTION
Mirror the events from `SnapDropZone` to the `InteractableObject`
because at times its more useful to observe these actions from the point
of view of the object being manipulated.
An example might be an object that changes shape depending if it's
hovering over or snapped to a drop zone.

This is the implementation for #1055