### PR TITLE
feat(Presence): add custom raycast option to headset controller aware - resolves #1054

### DIFF
--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
@@ -39,6 +39,8 @@ namespace VRTK
         public Transform customRightControllerOrigin;
         [Tooltip("A custom transform to provide the world space position of the left controller.")]
         public Transform customLeftControllerOrigin;
+        [Tooltip("A custom raycaster to use when raycasting to find controllers.")]
+        public VRTK_CustomRaycast customRaycast;
 
         /// <summary>
         /// Emitted when the controller is obscured by another object.
@@ -185,7 +187,7 @@ namespace VRTK
             {
                 var destination = (customDestination ? customDestination.position : controller.transform.position);
                 RaycastHit hitInfo;
-                if (Physics.Linecast(headset.position, destination, out hitInfo))
+                if (VRTK_CustomRaycast.Linecast(customRaycast, headset.position, destination, out hitInfo, new LayerMask()))
                 {
                     obscured = true;
                 }

--- a/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
@@ -21,7 +21,7 @@ namespace VRTK
         /// <summary>
         /// The Raycast method is used to generate a raycast either from the given CustomRaycast object or a default Physics.Raycast.
         /// </summary>
-        /// <param name="customCast">The optional raycast object with customised raycast parameters.</param>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
         /// <param name="ray">The Ray to cast with.</param>
         /// <param name="hitData">The raycast hit data.</param>
         /// <param name="ignoreLayers">A layermask of layers to ignore from the raycast.</param>
@@ -31,7 +31,7 @@ namespace VRTK
         {
             if (customCast != null)
             {
-                return customCast.CustomCast(ray, out hitData, length);
+                return customCast.CustomRaycast(ray, out hitData, length);
             }
             else
             {
@@ -40,15 +40,48 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The CustomCast method is used to generate a raycast based on the options defined in the CustomRaycast object.
+        /// The Linecast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="startPosition">The world position to start the linecast from.</param>
+        /// <param name="endPosition">The world position to end the linecast at.</param>
+        /// <param name="hitData">The linecast hit data.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the linecast.</param>
+        /// <returns>Returns true if the linecast successfully collides with a valid object.</returns>
+        public static bool Linecast(VRTK_CustomRaycast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomLinecast(startPosition, endPosition, out hitData);
+            }
+            else
+            {
+                return Physics.Linecast(startPosition, endPosition, out hitData);
+            }
+        }
+
+        /// <summary>
+        /// The CustomRaycast method is used to generate a raycast based on the options defined in the CustomRaycast object.
         /// </summary>
         /// <param name="ray">The Ray to cast with.</param>
         /// <param name="hitData">The raycast hit data.</param>
         /// <param name="length">The maximum length of the raycast.</param>
         /// <returns>Returns true if the raycast successfully collides with a valid object.</returns>
-        public virtual bool CustomCast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)
+        public virtual bool CustomRaycast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)
         {
             return Physics.Raycast(ray, out hitData, Mathf.Infinity, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomLinecast method is used to generate a linecast based on the options defined in the CustomRaycast object.
+        /// </summary>
+        /// <param name="startPosition">The world position to start the linecast from.</param>
+        /// <param name="endPosition">The world position to end the linecast at.</param>
+        /// <param name="hitData">The linecast hit data.</param>
+        /// <returns>Returns true if the line successfully collides with a valid object.</returns>
+        public virtual bool CustomLinecast(Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData)
+        {
+            return Physics.Linecast(startPosition, endPosition, out hitData, ~layersToIgnore);
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4687,6 +4687,7 @@ The purpose of Headset Controller Aware is to allow the headset to know if somet
  * **Controller Glance Radius:** The radius of the accepted distance from the controller origin point to determine if the controller is being looked at.
  * **Custom Right Controller Origin:** A custom transform to provide the world space position of the right controller.
  * **Custom Left Controller Origin:** A custom transform to provide the world space position of the left controller.
+ * **Custom Raycast:** A custom raycaster to use when raycasting to find controllers.
 
 ### Class Events
 
@@ -6257,7 +6258,7 @@ For example, the VRTK_BodyPhysics script can be set to ignore trigger colliders 
   > `public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity)`
 
   * Parameters
-   * `VRTK_CustomRaycast customCast` - The optional raycast object with customised raycast parameters.
+   * `VRTK_CustomRaycast customCast` - The optional object with customised cast parameters.
    * `Ray ray` - The Ray to cast with.
    * `out RaycastHit hitData` - The raycast hit data.
    * `LayerMask ignoreLayers` - A layermask of layers to ignore from the raycast.
@@ -6267,9 +6268,24 @@ For example, the VRTK_BodyPhysics script can be set to ignore trigger colliders 
 
 The Raycast method is used to generate a raycast either from the given CustomRaycast object or a default Physics.Raycast.
 
-#### CustomCast/3
+#### Linecast/5
 
-  > `public virtual bool CustomCast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)`
+  > `public static bool Linecast(VRTK_CustomRaycast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers)`
+
+  * Parameters
+   * `VRTK_CustomRaycast customCast` - The optional object with customised cast parameters.
+   * `Vector3 startPosition` - The world position to start the linecast from.
+   * `Vector3 endPosition` - The world position to end the linecast at.
+   * `out RaycastHit hitData` - The linecast hit data.
+   * `LayerMask ignoreLayers` - A layermask of layers to ignore from the linecast.
+  * Returns
+   * `bool` - Returns true if the linecast successfully collides with a valid object.
+
+The Linecast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
+
+#### CustomRaycast/3
+
+  > `public virtual bool CustomRaycast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)`
 
   * Parameters
    * `Ray ray` - The Ray to cast with.
@@ -6278,7 +6294,20 @@ The Raycast method is used to generate a raycast either from the given CustomRay
   * Returns
    * `bool` - Returns true if the raycast successfully collides with a valid object.
 
-The CustomCast method is used to generate a raycast based on the options defined in the CustomRaycast object.
+The CustomRaycast method is used to generate a raycast based on the options defined in the CustomRaycast object.
+
+#### CustomLinecast/3
+
+  > `public virtual bool CustomLinecast(Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData)`
+
+  * Parameters
+   * `Vector3 startPosition` - The world position to start the linecast from.
+   * `Vector3 endPosition` - The world position to end the linecast at.
+   * `out RaycastHit hitData` - The linecast hit data.
+  * Returns
+   * `bool` - Returns true if the line successfully collides with a valid object.
+
+The CustomLinecast method is used to generate a linecast based on the options defined in the CustomRaycast object.
 
 ---
 


### PR DESCRIPTION
The Headset Controller Aware script can now accept a CustomRaycast
object to determine how the Linecast from the Headset to the controller
interacts with other world objects.