### PR TITLE
feat(Pointer): add variable downward length on bezier pointer

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
@@ -20,8 +20,8 @@ namespace VRTK
     {
         [Header("Bezier Pointer Appearance Settings")]
 
-        [Tooltip("The maximum length of the projected forward beam.")]
-        public float maximumLength = 10f;
+        [Tooltip("The maximum length of the projected beam. The x value is the length of the forward beam, the y value is the length of the downward beam.")]
+        public Vector2 maximumLength = new Vector2(10f, float.PositiveInfinity);
         [Tooltip("The number of items to render in the bezier curve tracer beam. A high number here will most likely have a negative impact of game performance due to large number of rendered objects.")]
         public int tracerDensity = 10;
         [Tooltip("The size of the ground cursor. This number also affects the size of the objects in the bezier curve tracer beam. The larger the radius, the larger the objects will be.")]
@@ -189,13 +189,13 @@ namespace VRTK
         {
             Transform origin = GetOrigin();
             float attachedRotation = Vector3.Dot(Vector3.up, origin.forward.normalized);
-            float calculatedLength = maximumLength;
+            float calculatedLength = maximumLength.x;
             Vector3 useForward = origin.forward;
             if ((attachedRotation * 100f) > heightLimitAngle)
             {
                 useForward = new Vector3(useForward.x, fixedForwardBeamForward.y, useForward.z);
                 float controllerRotationOffset = 1f - (attachedRotation - (heightLimitAngle / 100f));
-                calculatedLength = (maximumLength * controllerRotationOffset) * controllerRotationOffset;
+                calculatedLength = (maximumLength.x * controllerRotationOffset) * controllerRotationOffset;
             }
             else
             {
@@ -237,7 +237,7 @@ namespace VRTK
             Ray projectedBeamDownRaycast = new Ray(jointPosition, Vector3.down);
             RaycastHit collidedWith;
 
-            bool downRayHit = VRTK_CustomRaycast.Raycast(customRaycast, projectedBeamDownRaycast, out collidedWith, layersToIgnore, float.PositiveInfinity);
+            bool downRayHit = VRTK_CustomRaycast.Raycast(customRaycast, projectedBeamDownRaycast, out collidedWith, layersToIgnore, maximumLength.y);
 
             if (!downRayHit || (destinationHit.collider && destinationHit.collider != collidedWith.collider))
             {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1443,7 +1443,7 @@ It is more useful than the Simple Pointer Renderer for traversing objects of var
 
 ### Inspector Parameters
 
- * **Maximum Length:** The maximum length of the projected forward beam.
+ * **Maximum Length:** The maximum length of the projected beam. The x value is the length of the forward beam, the y value is the length of the downward beam.
  * **Tracer Density:** The number of items to render in the bezier curve tracer beam. A high number here will most likely have a negative impact of game performance due to large number of rendered objects.
  * **Cursor Radius:** The size of the ground cursor. This number also affects the size of the objects in the bezier curve tracer beam. The larger the radius, the larger the objects will be.
  * **Height Limit Angle:** The maximum angle in degrees of the origin before the beam curve height is restricted. A lower angle setting will prevent the beam being projected high into the sky and curving back down.


### PR DESCRIPTION
The Bezier Pointer Renderer now can have the downward length of the
beam set as well as setting the forward length of the beam.

This is now done by making the `maximumLength` parameter a Vector2
instead of a float where the `x` value represents the forward beam
length and the `y` value represents the downward beam length.