### PR TITLE
feat(Logger): add custom logger to better handle log events

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Archery/Follow.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Archery/Follow.cs
@@ -24,7 +24,7 @@
             }
             else
             {
-                Debug.LogError("No follow target defined!");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.NOT_DEFINED, new string[] { "target" }));
             }
         }
     }

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/ButtonReactor.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/ButtonReactor.cs
@@ -22,7 +22,7 @@
 
         private void handlePush(object sender, Control3DEventArgs e)
         {
-            Debug.Log("Pushed");
+            VRTK_Logger.Info("Pushed");
 
             GameObject newGo = (GameObject)Instantiate(go, dispenseLocation.position, Quaternion.identity);
             Destroy(newGo, 10f);

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/PanelMenu/PanelMenuUIGrid.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/PanelMenu/PanelMenuUIGrid.cs
@@ -38,7 +38,7 @@ namespace VRTK.Examples.PanelMenu
             gridLayoutGroup = GetComponent<GridLayoutGroup>();
             if (gridLayoutGroup == null)
             {
-                Debug.LogWarning("The PanelMenuUIGrid could not automatically find the UI GridLayoutGroup component.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "PanelMenuUIGrid", "GridLayoutGroup", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/PanelMenu/PanelMenuUISlider.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/PanelMenu/PanelMenuUISlider.cs
@@ -27,7 +27,7 @@ namespace VRTK.Examples.PanelMenu
             slider = GetComponent<Slider>();
             if (slider == null)
             {
-                Debug.LogWarning("The PanelMenuUISlider could not automatically find the UI Slider component.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "PanelMenuUISlider", "Slider", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Sphere_Spawner.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Sphere_Spawner.cs
@@ -11,7 +11,7 @@
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
-                Debug.LogError("VRTK_ControllerEvents_ListenerExample is required to be attached to a Controller that has the VRTK_ControllerEvents script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "Sphere_Spawner", "VRTK_ControllerEvents", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/UI_Interactions.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/UI_Interactions.cs
@@ -11,22 +11,22 @@
 
         public void Button_Red()
         {
-            Debug.Log("Red Button Clicked");
+            VRTK_Logger.Info("Red Button Clicked");
         }
 
         public void Button_Pink()
         {
-            Debug.Log("Pink Button Clicked");
+            VRTK_Logger.Info("Pink Button Clicked");
         }
 
         public void Toggle(bool state)
         {
-            Debug.Log("The toggle state is " + (state ? "on" : "off"));
+            VRTK_Logger.Info("The toggle state is " + (state ? "on" : "off"));
         }
 
         public void Dropdown(int value)
         {
-            Debug.Log("Dropdown option selected was ID " + value);
+            VRTK_Logger.Info("Dropdown option selected was ID " + value);
         }
 
         public void SetDropText(BaseEventData data)

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/UI_Keyboard.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/UI_Keyboard.cs
@@ -22,7 +22,7 @@
 
         public void Enter()
         {
-            Debug.Log("You've typed [" + input.text + "]");
+            VRTK_Logger.Info("You've typed [" + input.text + "]");
             input.text = "";
         }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerAppearance_Example.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerAppearance_Example.cs
@@ -23,7 +23,7 @@
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
-                Debug.LogError("VRTK_ControllerEvents_ListenerExample is required to be attached to a Controller that has the VRTK_ControllerEvents script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerAppearance_Example", "VRTK_ControllerEvents", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
@@ -8,7 +8,7 @@
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
-                Debug.LogError("VRTK_ControllerEvents_ListenerExample is required to be attached to a Controller that has the VRTK_ControllerEvents script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerEvents_ListenerExample", "VRTK_ControllerEvents", "the same"}));
                 return;
             }
 
@@ -72,7 +72,7 @@
 
         private void DebugLogger(uint index, string button, string action, ControllerInteractionEventArgs e)
         {
-            Debug.Log("Controller on index '" + index + "' " + button + " has been " + action
+            VRTK_Logger.Info("Controller on index '" + index + "' " + button + " has been " + action
                     + " with a pressure of " + e.buttonPressure + " / trackpad axis at: " + e.touchpadAxis + " (" + e.touchpadAngle + " degrees)");
         }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerInteract_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerInteract_ListenerExample.cs
@@ -8,7 +8,7 @@
         {
             if (GetComponent<VRTK_InteractTouch>() == null || GetComponent<VRTK_InteractGrab>() == null)
             {
-                Debug.LogError("VRTK_ControllerInteracts_ListenerExample is required to be attached to a Controller that has the VRTK_InteractTouch and VRTK_InteractGrab script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerInteract_ListenerExample", "VRTK_InteractTouch and VRTK_InteractGrab", "the Controller Alias" }));
                 return;
             }
 
@@ -21,7 +21,7 @@
 
         private void DebugLogger(uint index, string action, GameObject target)
         {
-            Debug.Log("Controller on index '" + index + "' is " + action + " an object named " + target.name);
+            VRTK_Logger.Info("Controller on index '" + index + "' is " + action + " an object named " + target.name);
         }
 
         private void DoInteractTouch(object sender, ObjectInteractEventArgs e)

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerPointerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerPointerEvents_ListenerExample.cs
@@ -8,7 +8,7 @@
         {
             if (GetComponent<VRTK_DestinationMarker>() == null)
             {
-                Debug.LogError("VRTK_ControllerPointerEvents_ListenerExample is required to be attached to a Controller that has the `VRTK_DestinationMarker` script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerPointerEvents_ListenerExample", "VRTK_DestinationMarker", "the Controller Alias" }));
                 return;
             }
 
@@ -22,7 +22,7 @@
         {
             string targetName = (target ? target.name : "<NO VALID TARGET>");
             string colliderName = (raycastHit.collider ? raycastHit.collider.name : "<NO VALID COLLIDER>");
-            Debug.Log("Controller on index '" + index + "' is " + action + " at a distance of " + distance + " on object named [" + targetName + "] on the collider named [" + colliderName + "] - the pointer tip position is/was: " + tipPosition);
+            VRTK_Logger.Info("Controller on index '" + index + "' is " + action + " at a distance of " + distance + " on object named [" + targetName + "] on the collider named [" + colliderName + "] - the pointer tip position is/was: " + tipPosition);
         }
 
         private void DoPointerIn(object sender, DestinationMarkerEventArgs e)

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerUIPointerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerUIPointerEvents_ListenerExample.cs
@@ -10,7 +10,7 @@
         {
             if (GetComponent<VRTK_UIPointer>() == null)
             {
-                Debug.LogError("VRTK_ControllerUIPointerEvents_ListenerExample is required to be attached to a Controller that has the VRTK_UIPointer script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerUIPointerEvents_ListenerExample", "VRTK_UIPointer", "the Controller Alias" }));
                 return;
             }
 
@@ -29,7 +29,7 @@
 
         private void VRTK_ControllerUIPointerEvents_ListenerExample_UIPointerElementEnter(object sender, UIPointerEventArgs e)
         {
-            Debug.Log("UI Pointer entered " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
+            VRTK_Logger.Info("UI Pointer entered " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
             if (togglePointerOnHit && GetComponent<VRTK_Pointer>())
             {
                 GetComponent<VRTK_Pointer>().Toggle(true);
@@ -38,7 +38,7 @@
 
         private void VRTK_ControllerUIPointerEvents_ListenerExample_UIPointerElementExit(object sender, UIPointerEventArgs e)
         {
-            Debug.Log("UI Pointer exited " + e.previousTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive);
+            VRTK_Logger.Info("UI Pointer exited " + e.previousTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive);
             if (togglePointerOnHit && GetComponent<VRTK_Pointer>())
             {
                 GetComponent<VRTK_Pointer>().Toggle(false);
@@ -47,17 +47,17 @@
 
         private void VRTK_ControllerUIPointerEvents_ListenerExample_UIPointerElementClick(object sender, UIPointerEventArgs e)
         {
-            Debug.Log("UI Pointer clicked " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
+            VRTK_Logger.Info("UI Pointer clicked " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
         }
 
         private void VRTK_ControllerUIPointerEvents_ListenerExample_UIPointerElementDragStart(object sender, UIPointerEventArgs e)
         {
-            Debug.Log("UI Pointer started dragging " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
+            VRTK_Logger.Info("UI Pointer started dragging " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
         }
 
         private void VRTK_ControllerUIPointerEvents_ListenerExample_UIPointerElementDragEnd(object sender, UIPointerEventArgs e)
         {
-            Debug.Log("UI Pointer stopped dragging " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
+            VRTK_Logger.Info("UI Pointer stopped dragging " + e.currentTarget.name + " on Controller index [" + e.controllerIndex + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
         }
     }
 }

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_RoomExtender_ControllerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_RoomExtender_ControllerExample.cs
@@ -11,12 +11,12 @@
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
-                Debug.LogError("VRTK_RoomExtender_ControllerExample is required to be attached to a Controller that has the VRTK_ControllerEvents script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_RoomExtender_ControllerExample", "VRTK_ControllerEvents", "the Controller Alias" }));
                 return;
             }
             if (FindObjectOfType<VRTK_RoomExtender>() == null)
             {
-                Debug.LogError("VRTK_RoomExtender script is required.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, new string[] { "VRTK_RoomExtender_ControllerExample", "VRTK_RoomExtender" }));
                 return;
             }
             roomExtender = FindObjectOfType<VRTK_RoomExtender>();

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -309,7 +309,7 @@ namespace VRTK
                 //If a joint is being used but no joint is found then throw a warning in the console
                 if (snapType == SnapTypes.UseJoint && GetComponent<Joint>() == null)
                 {
-                    Debug.LogWarning("A Joint Component is required on the SnapDropZone GameObject called [" + name + "] because the Snap Type is set to `Use Joint`.");
+                    VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "SnapDropZone:" + name, "Joint", "the same", " because the `Snap Type` is set to `Use Joint`" }));
                 }
 
                 //Generate the editor highlighter object with the custom material
@@ -507,12 +507,12 @@ namespace VRTK
             var snapDropZoneJoint = GetComponent<Joint>();
             if (snapDropZoneJoint == null)
             {
-                Debug.LogError("No Joint Component was found on the SnapDropZone GameObject yet the Snap Type is set to `Use Joint`. Please manually add a joint to the SnapDropZone GameObject.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "SnapDropZone:" + name, "Joint", "the same", " because the `Snap Type` is set to `Use Joint`" }));
                 return;
             }
             if (snapTo == null)
             {
-                Debug.LogError("No Rigidbody was found on the Interactbale Object.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_SnapDropZone", "Rigidbody", "the `VRTK_InteractableObject`" }));
                 return;
             }
 

--- a/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
@@ -122,7 +122,7 @@ namespace VRTK
                 cachedCameraRig = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_InputSimulator>();
                 if (!cachedCameraRig)
                 {
-                    Debug.LogError("No GameObject with `SDK_InputSimulator` is found in the scene, have you added the `VRTK/Prefabs/VRSimulatorCameraRig` prefab to the scene?");
+                    VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, new string[] { "VRSimulatorCameraRig", "SDK_InputSimulator", ". check that the `VRTK/Prefabs/VRSimulatorCameraRig` prefab been added to the scene." }));
                 }
             }
             return cachedCameraRig;

--- a/Assets/VRTK/Scripts/Controls/2D/PanelMenu/PanelMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/PanelMenu/PanelMenuController.cs
@@ -137,7 +137,7 @@ namespace VRTK
             interactableObject = gameObject.transform.parent.gameObject;
             if (interactableObject == null || interactableObject.GetComponent<VRTK_InteractableObject>() == null)
             {
-                Debug.LogWarning("The PanelMenuController could not automatically find the parent VRTK_InteractableObject.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "PanelMenuController", "VRTK_InteractableObject", "a parent" }));
                 return;
             }
 
@@ -147,7 +147,7 @@ namespace VRTK
             canvasObject = gameObject.transform.GetChild(0).gameObject;
             if (canvasObject == null || canvasObject.GetComponent<Canvas>() == null)
             {
-                Debug.LogWarning("The PanelMenuController could not automatically find the required child canvas GameObject.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "PanelMenuController", "Canvas", "a child" }));
             }
         }
 
@@ -160,7 +160,7 @@ namespace VRTK
                     rotateTowards = VRTK_DeviceFinder.HeadsetCamera().gameObject;
                     if (rotateTowards == null)
                     {
-                        Debug.LogWarning("The PanelMenuController could not automatically find an object to rotate towards.");
+                        VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.COULD_NOT_FIND_OBJECT_FOR_ACTION, new string[] { "PanelMenuController", "an object", "rotate towards"}));
                     }
                 }
 

--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenu/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenu/VRTK_IndependentRadialMenuController.cs
@@ -53,7 +53,7 @@ namespace VRTK
             VRTK_InteractableObject newEventsManager = transform.GetComponentInParent<VRTK_InteractableObject>();
             if (newEventsManager == null)
             {
-                Debug.LogError("The radial menu must be a child of an interactable object or be set in the inspector!");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, new string[] { "VRTK_IndependentRadialMenuController", "VRTK_InteractableObject", "eventsManager", "the parent" }));
                 return;
             }
             else if (newEventsManager != eventsManager) // Changed managers
@@ -185,7 +185,7 @@ namespace VRTK
                 }
                 else
                 {
-                    Debug.LogWarning("The IndependentRadialMenu could not automatically find an object to rotate towards.");
+                    VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.COULD_NOT_FIND_OBJECT_FOR_ACTION, new string[] { "IndependentRadialMenu", "an object", "rotate towards" }));
                 }
             }
 

--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenuController.cs
@@ -31,7 +31,7 @@ namespace VRTK
         {
             if (events == null)
             {
-                Debug.LogError("The radial menu must be a child of the controller or be set in the inspector!");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, new string[] { "RadialMenuController", "VRTK_ControllerEvents", "events", "the parent" }));
                 return;
             }
             else

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
@@ -31,7 +31,7 @@ namespace VRTK.GrabAttachMechanics
         {
             if (!jointHolder)
             {
-                Debug.LogError("The VRTK_CustomJointGrabAttach script requires a Joint component to be provided to the `Custom Joint` parameter.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, new string[] { "VRTK_CustomJointGrabAttach", "Joint", "customJoint", "the same" }));
                 return;
             }
             var storedJoint = jointHolder.GetComponent<Joint>();

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -214,7 +214,7 @@ namespace VRTK.Highlighters
 
             if (copyModel == null)
             {
-                Debug.LogError("No Renderer has been found on the model to add highlighting to");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_OutlineObjectCopyHighlighter", "Renderer", "the same or child", " to add the highlighter to" }));
                 return null;
             }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerHighlighter.cs
@@ -216,7 +216,7 @@ namespace VRTK
 
             if (controllerAlias == null)
             {
-                Debug.LogError("No Controller Alias GameObject can be found, either specify one in the `Controller Alias` parameter or apply this script to a `Controller Alias` GameObject.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, new string[] { "VRTK_ControllerHighlighter", "Controller Alias GameObject", "controllerAlias", "the same" }));
                 return;
             }
 
@@ -428,7 +428,7 @@ namespace VRTK
             {
                 if (!modelContainer)
                 {
-                    Debug.LogError("No model container could be found. Have you selected a valid Controller SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Controller SDK from the dropdown.");
+                    VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "Controller Model", "Controller SDK" }));
                     return null;
                 }
                 cachedElements[path] = modelContainer.transform.Find(path);

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
@@ -96,7 +96,7 @@ namespace VRTK
         {
             if (!GetComponent<VRTK_InteractableObject>())
             {
-                Debug.LogError("The `VRTK_InteractControllerAppearance` script is required to be attached to a GameObject that has the `VRTK_InteractableObject` script also attached to it.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractControllerAppearance", "VRTK_InteractableObject", "the same" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -77,7 +77,7 @@ namespace VRTK
         {
             if (!GetComponent<VRTK_InteractableObject>())
             {
-                Debug.LogError("The `VRTK_InteractHaptics` script is required to be attached to a GameObject that has the `VRTK_InteractableObject` script also attached to it.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractHaptics", "VRTK_InteractableObject", "the same" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -426,7 +426,7 @@ namespace VRTK
             {
                 if (!defaultColliderPrefab)
                 {
-                    Debug.LogError("No default collider prefab could be found. Have you selected a valid Controller SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Controller SDK from the dropdown.");
+                    VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "default collider prefab", "Controller SDK" }));
                     return;
                 }
                 controllerCollisionDetector = Instantiate(defaultColliderPrefab, transform.position, transform.rotation) as GameObject;

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAutoGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAutoGrab.cs
@@ -52,7 +52,7 @@ namespace VRTK
 
             if (!objectToGrab)
             {
-                Debug.LogError("You have to assign an object that should be grabbed.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.NOT_DEFINED, new string[] { "objectToGrab" }));
                 yield break;
             }
 

--- a/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs
@@ -1,0 +1,146 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    public class VRTK_Logger : MonoBehaviour
+    {
+        public enum LogLevels
+        {
+            Trace,
+            Debug,
+            Info,
+            Warn,
+            Error,
+            Fatal,
+            None
+        }
+
+        public enum CommonMessageKeys
+        {
+            NOT_DEFINED,
+            REQUIRED_COMPONENT_MISSING_FROM_SCENE,
+            REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT,
+            REQUIRED_COMPONENT_MISSING_FROM_PARAMETER,
+            REQUIRED_COMPONENT_MISSING_NOT_INJECTED,
+            COULD_NOT_FIND_OBJECT_FOR_ACTION,
+            SDK_OBJECT_NOT_FOUND,
+            SDK_NOT_FOUND,
+            SDK_MANAGER_ERRORS
+        }
+
+        public static VRTK_Logger instance = null;
+
+        public static Dictionary<CommonMessageKeys, string> commonMessages = new Dictionary<CommonMessageKeys, string>()
+        {
+            {CommonMessageKeys.NOT_DEFINED, "`{0}` not defined{2}."},
+            {CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "`{0}` requires the `{1}` component to be available in the scene{2}."},
+            {CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "`{0}` requires the `{1}` component to be attached to {2} GameObject{3}."},
+            {CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_PARAMETER, "`{0}` requires a `{1}` component to be specified as the `{2}` parameter{3}."},
+            {CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, "`{0}` requires the `{1}` component. Either the `{2}` parameter is not set or no `{1}` component is attached to {3} GameObject{4}."},
+            {CommonMessageKeys.COULD_NOT_FIND_OBJECT_FOR_ACTION, "The `{0}` could not automatically find {1} to {2}."},
+            {CommonMessageKeys.SDK_OBJECT_NOT_FOUND, "No {0} could be found. Have you selected a valid {1} in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a {1} from the dropdown." },
+            {CommonMessageKeys.SDK_NOT_FOUND, "The SDK '{0}' doesn't exist anymore. The fallback SDK '{1}' will be used instead." },
+            {CommonMessageKeys.SDK_MANAGER_ERRORS, "The current SDK Manager setup is causing the following errors:\n\n{0}" }
+        };
+
+        public LogLevels minLevel = LogLevels.Info;
+        public bool throwExceptions = true;
+
+        public static void CreateIfNotExists()
+        {
+            if (instance == null)
+            {
+                GameObject loggerObject = new GameObject("[VRTK_Logger]");
+                instance = loggerObject.AddComponent<VRTK_Logger>();
+                instance.minLevel = LogLevels.Trace;
+                instance.throwExceptions = true;
+            }
+        }
+
+        public static string GetCommonMessage(CommonMessageKeys messageKey, string[] parameters = null)
+        {
+            parameters = (parameters == null ? new string[0] : parameters);
+            return (commonMessages.ContainsKey(messageKey) ? string.Format(commonMessages[messageKey], parameters) : "");
+        }
+
+        public static void Trace(string message)
+        {
+            Log(LogLevels.Trace, message);
+        }
+
+        public static void Debug(string message)
+        {
+            Log(LogLevels.Debug, message);
+        }
+
+        public static void Info(string message)
+        {
+            Log(LogLevels.Info, message);
+        }
+
+        public static void Warn(string message)
+        {
+            Log(LogLevels.Warn, message);
+        }
+
+        public static void Error(string message)
+        {
+            Log(LogLevels.Error, message);
+        }
+
+        public static void Fatal(string message)
+        {
+            Log(LogLevels.Fatal, message);
+        }
+
+        public static void Log(LogLevels level, string message)
+        {
+#if VRTK_NO_LOGGING
+            return;
+#endif
+            CreateIfNotExists();
+
+            if (instance.minLevel > level)
+            {
+                return;
+            }
+
+            switch (level)
+            {
+                case LogLevels.Trace:
+                case LogLevels.Debug:
+                case LogLevels.Info:
+                    UnityEngine.Debug.Log(message);
+                    break;
+                case LogLevels.Warn:
+                    UnityEngine.Debug.LogWarning(message);
+                    break;
+                case LogLevels.Error:
+                case LogLevels.Fatal:
+                    if (instance.throwExceptions)
+                    {
+                        throw new System.Exception(message);
+                    }
+                    else
+                    {
+                        UnityEngine.Debug.LogError(message);
+                    }
+                    break;
+            }
+        }
+
+        protected virtual void Awake()
+        {
+            if (instance == null)
+            {
+                instance = this;
+            }
+            else if (instance != this)
+            {
+                Destroy(gameObject);
+            }
+            DontDestroyOnLoad(gameObject);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs.meta
+++ b/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 77de5e9d808251247b08db8976014590
+timeCreated: 1490779817
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
@@ -18,7 +18,7 @@
             roomExtender = FindObjectOfType<VRTK_RoomExtender>();
             if (playArea == null || roomExtender == null)
             {
-                Debug.LogWarning("Could not find PlayArea or 'VRTK_RoomExtender'.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_RoomExtender_PlayAreaGizmo", "PlayArea or VRTK_RoomExtender", "an active" }));
                 return;
             }
         }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_MoveInPlace.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_MoveInPlace.cs
@@ -178,7 +178,7 @@ namespace VRTK
             }
             if (!playArea)
             {
-                Debug.LogError("No play area could be found. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "PlayArea", "Boundaries SDK" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_ObjectControl.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_ObjectControl.cs
@@ -119,7 +119,7 @@ namespace VRTK
             controllerEvents = (controller != null ? controller : GetComponent<VRTK_ControllerEvents>());
             if (!controllerEvents)
             {
-                Debug.LogError("A `VRTK_ControllerEvents` script is required for the `VRTK_ObjectControl` script to work. Either the `controller` parameter is not set or no `VRTK_ControllerEvents` is attached to this GameObject.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, new string[] { "VRTK_ObjectControl", "VRTK_ControllerEvents", "controller", "the same" }));
                 return;
             }
             SetControlledObject();

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_RoomExtender.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_RoomExtender.cs
@@ -59,7 +59,7 @@ namespace VRTK
                 }
                 else
                 {
-                    Debug.LogWarning("The VRTK_RoomExtender script needs a movementTransform to work.");
+                    VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, new string[] { "VRTK_RoomExtender", "Headset Transform" }));
                 }
             }
             playArea = VRTK_DeviceFinder.PlayAreaTransform();

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
@@ -215,13 +215,13 @@ namespace VRTK
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
             if (!playArea)
             {
-                Debug.LogError("No play area could be found. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "PlayArea", "Boundaries SDK" }));
             }
 
             headset = VRTK_DeviceFinder.HeadsetTransform();
             if (!headset)
             {
-                Debug.LogError("No headset could be found. Have you selected a valid Headset SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "HeadsetTransform", "Headset SDK" }));
             }
 
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
@@ -244,10 +244,10 @@ namespace VRTK
 
         protected virtual void Start()
         {
-            bodyCollider = playArea.GetComponent<CapsuleCollider>();
+            bodyCollider = playArea.GetComponentInChildren<CapsuleCollider>();
             if (!bodyCollider)
             {
-                Debug.LogError("No body collider could be found in the play area. VRTK_BodyPhysics script is required in one of the scene GameObjects.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_TouchpadMovement", "CapsuleCollider", "the PlayArea" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadWalking.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadWalking.cs
@@ -60,7 +60,7 @@ namespace VRTK
             controllerRightHand = VRTK_DeviceFinder.GetControllerRightHand();
             if (!playArea)
             {
-                Debug.LogError("No play area could be found. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "PlayArea", "Boundaries SDK" }));
             }
 
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);

--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -488,7 +488,7 @@ namespace VRTK
 
             if (controller == null)
             {
-                Debug.LogError("VRTK_BasePointer requires a Controller that has the VRTK_ControllerEvents script attached to it");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, new string[] { "VRTK_BasePointer", "VRTK_ControllerEvents", "controller", "the same" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -217,7 +217,7 @@ namespace VRTK
         {
             if (playArea == null)
             {
-                Debug.LogError("No play area could be found. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "PlayArea", "Boundaries SDK" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -185,7 +185,7 @@ namespace VRTK
             canClickOnHover = false;
             if (NoPointerRenderer())
             {
-                Debug.LogWarning("The VRTK_Pointer script requires a VRTK_BasePointerRenderer specified as the `Pointer Renderer` parameter.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_PARAMETER, new string[] { "VRTK_Pointer", "VRTK_BasePointerRenderer", "Pointer Renderer" }));
             }
             if (activateOnEnable)
             {
@@ -272,7 +272,7 @@ namespace VRTK
 
             if (controller == null && (activationButton != VRTK_ControllerEvents.ButtonAlias.Undefined || selectionButton != VRTK_ControllerEvents.ButtonAlias.Undefined))
             {
-                Debug.LogWarning("`VRTK_Pointer` requires a Controller that has the `VRTK_ControllerEvents` script attached to it. To omit this warning, set the `Activation Bubtton` and `Selection Button` to `Undefined`");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_Pointer", "VRTK_ControllerEvents", "the Controller Alias", ". To omit this warning, set the `Activation Button` and `Selection Button` to `Undefined`" }));
             }
 
             if (directionIndicator != null)
@@ -310,12 +310,12 @@ namespace VRTK
             {
                 if (selectOnPress && holdButtonToActivate)
                 {
-                    Debug.LogWarning("Hold Button To Activate and Select On Press cannot both be checked when using the same button for Activation and Selection. Fixing by setting Select On Press to false.");
+                    VRTK_Logger.Warn("`Hold Button To Activate` and `Select On Press` cannot both be checked when using the same button for Activation and Selection. Fixing by setting `Select On Press` to `false`.");
                 }
 
                 if (!selectOnPress && !holdButtonToActivate)
                 {
-                    Debug.LogWarning("Hold Button To Activate and Select On Press cannot both be unchecked when using the same button for Activation and Selection. Fixing by setting Select On Press to true.");
+                    VRTK_Logger.Warn("`Hold Button To Activate` and `Select On Press` cannot both be unchecked when using the same button for Activation and Selection. Fixing by setting `Select On Press` to `true`.");
                 }
                 selectOnPress = !holdButtonToActivate;
             }

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -716,7 +716,7 @@ namespace VRTK
 
             if (!playArea)
             {
-                Debug.LogError("No play area could be found. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "PlayArea", "Boundaries SDK" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetFade.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetFade.cs
@@ -141,7 +141,7 @@ namespace VRTK
             VRTK_SharedMethods.AddCameraFade();
             if (!VRTK_SDK_Bridge.HasHeadsetFade(headset))
             {
-                Debug.LogWarning("This 'VRTK_HeadsetFade' script needs a compatible fade script on the camera game object.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetFade", "compatible fade", "Camera" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
@@ -47,7 +47,7 @@ namespace VRTK
             ManageHeadsetListeners(true);
             if (!playArea)
             {
-                Debug.LogError("No play area could be found. Have you selected a valid Boundaries SDK in the SDK Manager? If you are unsure, then click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and select a Boundaries SDK from the dropdown.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, new string[] { "PlayArea", "Boundaries SDK" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -68,7 +68,7 @@ namespace VRTK
 
             if (!canvas || canvas.renderMode != RenderMode.WorldSpace)
             {
-                Debug.LogError("A VRTK_UICanvas requires to be placed on a Canvas that is set to `Render Mode = World Space`.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_UICanvas", "Canvas", "the same", " that is set to `Render Mode = World Space`" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/UI/VRTK_UIDraggableItem.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIDraggableItem.cs
@@ -120,7 +120,7 @@ namespace VRTK
             if (restrictToDropZone && !GetComponentInParent<VRTK_UIDropZone>())
             {
                 enabled = false;
-                Debug.LogError("A VRTK_UIDraggableItem with a `freeDrop = false` is required to be a child of a VRTK_UIDropZone GameObject.");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_UIDraggableItem", "VRTK_UIDropZone", "the parent", " if `freeDrop = false`" }));
             }
         }
 

--- a/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
@@ -228,7 +228,7 @@ namespace VRTK
         {
             if (!eventSystem)
             {
-                Debug.LogError("A VRTK_UIPointer requires an EventSystem");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, new string[] { "VRTK_UIPointer", "EventSystem" }));
                 return null;
             }
 
@@ -249,7 +249,7 @@ namespace VRTK
 
             if (!vrtkEventSystem)
             {
-                Debug.LogError("A VRTK_UIPointer requires an EventSystem");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, new string[] { "VRTK_UIPointer", "EventSystem" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetBasicTeleport();
             if (bt == null)
             {
-                Debug.LogError("The VRTK_BasicTeleport_UnityEvents script requires to be attached to a GameObject that contains a VRTK_BasicTeleport script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_BasicTeleport_UnityEvents", "VRTK_BasicTeleport", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
@@ -49,7 +49,7 @@
             SetBodyPhysics();
             if (bp == null)
             {
-                Debug.LogError("The VRTK_BodyPhysics_UnityEvents script requires to be attached to a GameObject that contains a VRTK_BodyPhysics script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_BodyPhysics_UnityEvents", "VRTK_BodyPhysics", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Button_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Button_UnityEvents.cs
@@ -29,7 +29,7 @@
             SetButton3D();
             if (b3d == null)
             {
-                Debug.LogError("The VRTK_Button_UnityEvents script requires to be attached to a GameObject that contains a VRTK_Button script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_Button_UnityEvents", "VRTK_Button", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Control_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Control_UnityEvents.cs
@@ -29,7 +29,7 @@
             SetControl3D();
             if (c3d == null)
             {
-                Debug.LogError("The VRTK_Control_UnityEvents script requires to be attached to a GameObject that contains a VRTK_Control script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_Control_UnityEvents", "VRTK_Control", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetControllerAction();
             if (ca == null)
             {
-                Debug.LogError("The VRTK_ControllerActions_UnityEvents script requires to be attached to a GameObject that contains a VRTK_ControllerActions script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerActions_UnityEvents", "VRTK_ControllerActions", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -227,7 +227,7 @@
             SetControllerEvents();
             if (ce == null)
             {
-                Debug.LogError("The VRTK_ControllerEvents_UnityEvents script requires to be attached to a GameObject that contains a VRTK_ControllerEvents script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerEvents_UnityEvents", "VRTK_ControllerEvents", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetDashTeleport();
             if (dt == null)
             {
-                Debug.LogError("The VRTK_DashTeleport_UnityEvents script requires to be attached to a GameObject that contains a VRTK_DashTeleport script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_DashTeleport_UnityEvents", "VRTK_DashTeleport", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
@@ -37,7 +37,7 @@
             SetDestinationMarker();
             if (dm == null)
             {
-                Debug.LogError("The VRTK_DestinationMarker_UnityEvents script requires to be attached to a GameObject that contains a VRTK_DestinationMarker script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_DestinationMarker_UnityEvents", "VRTK_DestinationMarker", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetHeadsetCollision();
             if (hc == null)
             {
-                Debug.LogError("The VRTK_HeadsetCollision_UnityEvents script requires to be attached to a GameObject that contains a VRTK_HeadsetCollision script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetCollision_UnityEvents", "VRTK_HeadsetCollision", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
@@ -42,7 +42,7 @@
             SetHeadsetControllerAware();
             if (hca == null)
             {
-                Debug.LogError("The VRTK_HeadsetControllerAware_UnityEvents script requires to be attached to a GameObject that contains a VRTK_HeadsetControllerAware script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetControllerAware_UnityEvents", "VRTK_HeadsetControllerAware", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
@@ -41,7 +41,7 @@
             SetHeadsetFade();
             if (hf == null)
             {
-                Debug.LogError("The VRTK_HeadsetFade_UnityEvents script requires to be attached to a GameObject that contains a VRTK_HeadsetFade script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetFade_UnityEvents", "VRTK_HeadsetFade", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetInteractGrab();
             if (ig == null)
             {
-                Debug.LogError("The VRTK_InteractGrab_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractGrab script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractGrab_UnityEvents", "VRTK_InteractGrab", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetInteractTouch();
             if (it == null)
             {
-                Debug.LogError("The VRTK_InteractTouch_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractTouch script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractTouch_UnityEvents", "VRTK_InteractTouch", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetInteractUse();
             if (iu == null)
             {
-                Debug.LogError("The VRTK_InteractUse_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractUse script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractUse_UnityEvents", "VRTK_InteractUse", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -65,7 +65,7 @@
             SetInteractableObject();
             if (io == null)
             {
-                Debug.LogError("The VRTK_InteractableObject_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractableObject script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractableObject_UnityEvents", "VRTK_InteractableObject", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectControl_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectControl_UnityEvents.cs
@@ -34,7 +34,7 @@
             SetObjectControl();
             if (oc == null)
             {
-                Debug.LogError("The VRTK_ObjectControl_UnityEvents script requires to be attached to a GameObject that contains a VRTK_ObjectControl script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ObjectControl_UnityEvents", "VRTK_ObjectControl", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
@@ -33,7 +33,7 @@
             SetPlayerClimb();
             if (pc == null)
             {
-                Debug.LogError("The VRTK_PlayerClimb_UnityEvents script requires to be attached to a GameObject that contains a VRTK_PlayerClimb script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_PlayerClimb_UnityEvents", "VRTK_PlayerClimb", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_SnapDropZone_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_SnapDropZone_UnityEvents.cs
@@ -41,7 +41,7 @@
             SetSnapDropZone();
             if (sdz == null)
             {
-                Debug.LogError("The VRTK_SnapDropZone_UnityEvents script requires to be attached to a GameObject that contains a VRTK_SnapDropZone script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_SnapDropZone_UnityEvents", "VRTK_SnapDropZone", "the same" }));
                 return;
             }
 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIPointer_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIPointer_UnityEvents.cs
@@ -45,7 +45,7 @@
             SetUIPointer();
             if (uip == null)
             {
-                Debug.LogError("The VRTK_UIPointer_UnityEvents script requires to be attached to a GameObject that contains a VRTK_UIPointer script");
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_UIPointer_UnityEvents", "VRTK_UIPointer", "the same" }));
                 return;
             }
             uip.UIPointerElementEnter += UIPointerElementEnter;

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKInfo.cs
@@ -102,7 +102,7 @@ namespace VRTK
             Type actualType = Type.GetType(actualTypeName);
             if (actualType == null)
             {
-                Debug.LogError(string.Format("The SDK '{0}' doesn't exist anymore. The fallback SDK '{1}' will be used instead.", actualTypeName, fallbackType.Name));
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_NOT_FOUND, new string[] { actualTypeName, fallbackType.Name }));
 
                 type = fallbackType;
                 originalTypeNameWhenFallbackIsUsed = actualTypeName;

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKManager.cs
@@ -443,13 +443,13 @@ namespace VRTK
                 string[] removedSymbols = currentSymbols.Except(newSymbols).ToArray();
                 if (removedSymbols.Length > 0)
                 {
-                    Debug.Log("Scripting Define Symbols removed from [Project Settings->Player]: " + string.Join(", ", removedSymbols));
+                    VRTK_Logger.Info("Scripting Define Symbols removed from [Project Settings->Player]: " + string.Join(", ", removedSymbols));
                 }
 
                 string[] addedSymbols = newSymbols.Except(currentSymbols).ToArray();
                 if (addedSymbols.Length > 0)
                 {
-                    Debug.Log("Scripting Define Symbols added To [Project Settings->Player]: " + string.Join(", ", addedSymbols));
+                    VRTK_Logger.Info("Scripting Define Symbols added To [Project Settings->Player]: " + string.Join(", ", addedSymbols));
                 }
 
                 if (!changedSymbols)
@@ -657,7 +657,7 @@ namespace VRTK
                 string[] removedSymbols = currentSymbols.Except(newSymbols).ToArray();
                 if (removedSymbols.Length > 0)
                 {
-                    Debug.Log("Legacy (i.e. used by previous VRTK versions only) Scripting Define Symbols removed from [Project Settings->Player]: " + string.Join(", ", removedSymbols));
+                    VRTK_Logger.Info("Legacy (i.e. used by previous VRTK versions only) Scripting Define Symbols removed from [Project Settings->Player]: " + string.Join(", ", removedSymbols));
                 }
             }
         }
@@ -705,7 +705,7 @@ namespace VRTK
                 if (!string.IsNullOrEmpty(sdkErrorDescriptions))
                 {
                     sdkErrorDescriptions = "- " + sdkErrorDescriptions;
-                    Debug.LogError("There are some errors because of the current SDK Manager setup:\n" + sdkErrorDescriptions);
+                    VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_MANAGER_ERRORS, new string[] { sdkErrorDescriptions }));
                 }
 
                 if (persistOnLoad && !VRTK_SharedMethods.IsEditTime())
@@ -736,7 +736,7 @@ namespace VRTK
             string sdkErrorDescription = GetSDKErrorDescription<BaseType>(prettyName, info, installedInfos);
             if (!string.IsNullOrEmpty(sdkErrorDescription))
             {
-                Debug.LogError(sdkErrorDescription);
+                VRTK_Logger.Error(sdkErrorDescription);
             }
         }
 

--- a/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs
@@ -54,7 +54,7 @@ namespace VRTK
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
             if (!headset)
             {
-                Debug.LogWarning("Could not find camera. Simulator deactivated.");
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, new string[] { "VRTK_Simulator", "Headset Camera", ". Simulator deactivated." }));
                 enabled = false;
                 return;
             }


### PR DESCRIPTION
a new VRTK_Logger script has been added that is now used in all VRTK
scripts for logging messages rather than directly calling `Debug.Log`
which gives greater control over how the logging messages are handled.

Because the Logger script instantiates itself at runtime in a non
destructable game object, it's possible to change the Logger settings
at runtime in the editor.

If the VRTK_Logger script is added to a GameObject in the editor then
the Logger parameters can be set at edit time and this logger will
be used at runtime.

All VRTK scripts have been updated to use the new logger and they all
use a standard message collection rather than hard coded messages that
leads to inconsistent display messages.