### PR TITLE
feat(SDK): allow additional tracked controller usage

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_ControllerTracker.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_ControllerTracker.cs
@@ -8,12 +8,8 @@
 
         protected virtual void OnEnable()
         {
-            var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
-            if (actualController)
-            {
-                trackedController = actualController.GetComponent<VRTK_TrackedController>();
-            }
-
+            GameObject actualController = VRTK_DeviceFinder.GetActualController(gameObject);
+            trackedController = (actualController != null ? actualController.GetComponent<VRTK_TrackedController>() : GetComponent<VRTK_TrackedController>());
             Update();
         }
 

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
@@ -57,6 +57,10 @@
         protected virtual void OnEnable()
         {
             aliasController = VRTK_DeviceFinder.GetScriptAliasController(gameObject);
+            if (aliasController == null)
+            {
+                aliasController = gameObject;
+            }
 
             if (enableControllerCoroutine != null)
             {
@@ -97,7 +101,7 @@
 
             VRTK_SDK_Bridge.ControllerProcessUpdate(index);
 
-            if (aliasController && gameObject.activeInHierarchy && !aliasController.activeSelf)
+            if (aliasController != null && gameObject.activeInHierarchy && !aliasController.activeSelf)
             {
                 aliasController.SetActive(true);
             }


### PR DESCRIPTION
The HTC Trackers are now supported in a basic way by allowing for
additional tracked controllers to be supported by the SteamVR SDK
Bridge. The tracker support still requires manual configuration of
the tracker objects and only works with SteamVR. But until more
tracking solutions come out, this will be ok as the HTC trackers
can only be used with SteamVR at the moment anyway.

To set a tracker up:

 * Follow HTC Tracker instructions to set object up with SteamVR
 * Add `VRTK_TrackedController` to tracker object
 * Add `VRTK_ControllerTracker` to tracker object
 * The tracker object is now usable by VRTK
 * Attach any controller scripts directly to the tracker object