### PR TITLE
fix(SDK): caching SDK Manager objects methods

### DIFF
--- a/Assets/VRTK/SDK/Base/SDK_BaseBoundaries.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseBoundaries.cs
@@ -44,16 +44,5 @@ namespace VRTK
         /// <param name="playArea">The GameObject containing the play area representation.</param>
         /// <returns>Returns true if the play area size has been auto calibrated and set by external sensors.</returns>
         public abstract bool IsPlayAreaSizeCalibrated(GameObject playArea);
-
-        protected Transform GetSDKManagerPlayArea()
-        {
-            var sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null && sdkManager.actualBoundaries != null)
-            {
-                cachedPlayArea = (sdkManager.actualBoundaries ? sdkManager.actualBoundaries.transform : null);
-                return cachedPlayArea;
-            }
-            return null;
-        }
     }
 }

--- a/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
@@ -71,16 +71,5 @@ namespace VRTK
         /// </summary>
         /// <param name="camera">The Transform to with the camera on to add the fade functionality to.</param>
         public abstract void AddHeadsetFade(Transform camera);
-
-        protected Transform GetSDKManagerHeadset()
-        {
-            var sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null && sdkManager.actualHeadset != null)
-            {
-                cachedHeadset = (sdkManager.actualHeadset ? sdkManager.actualHeadset.transform : null);
-                return cachedHeadset;
-            }
-            return null;
-        }
     }
 }

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamHeadset.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamHeadset.cs
@@ -46,7 +46,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the headset in the scene.</returns>
         public override Transform GetHeadset()
         {
-            cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
                 var foundCamera = Camera.main; //assume native support

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
@@ -33,7 +33,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the play area in the scene.</returns>
         public override Transform GetPlayArea()
         {
-            cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
                 var ovrManager = FindObjectOfType<OVRManager>();

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
@@ -49,7 +49,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the headset in the scene.</returns>
         public override Transform GetHeadset()
         {
-            cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
                 cachedHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("/TrackingSpace/CenterEyeAnchor").transform;
@@ -63,7 +62,6 @@ namespace VRTK
         /// <returns>A transform of the object holding the headset camera in the scene.</returns>
         public override Transform GetHeadsetCamera()
         {
-            cachedHeadsetCamera = GetSDKManagerHeadset();
             if (cachedHeadsetCamera == null)
             {
                 cachedHeadsetCamera = GetHeadset();

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -30,7 +30,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the play area in the scene.</returns>
         public override Transform GetPlayArea()
         {
-            cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
                 var steamVRPlayArea = FindObjectOfType<SteamVR_PlayArea>();

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -40,7 +40,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the headset in the scene.</returns>
         public override Transform GetHeadset()
         {
-            cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
 #if (UNITY_5_4_OR_NEWER)
@@ -62,7 +61,6 @@ namespace VRTK
         /// <returns>A transform of the object holding the headset camera in the scene.</returns>
         public override Transform GetHeadsetCamera()
         {
-            cachedHeadsetCamera = GetSDKManagerHeadset();
             if (cachedHeadsetCamera == null)
             {
                 var foundCamera = FindObjectOfType<SteamVR_Camera>();

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRBoundaries.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRBoundaries.cs
@@ -30,7 +30,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the play area in the scene.</returns>
         public override Transform GetPlayArea()
         {
-            cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
                 cachedPlayArea = Ximmerse.VR.VRContext.main.transform;

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRHeadset.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRHeadset.cs
@@ -75,7 +75,6 @@ namespace VRTK
         /// <returns>A transform of the object representing the headset in the scene.</returns>
         public override Transform GetHeadset()
         {
-            cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
                 var foundCamera = FindObjectOfType<TrackedHead>();
@@ -93,7 +92,6 @@ namespace VRTK
         /// <returns>A transform of the object holding the headset camera in the scene.</returns>
         public override Transform GetHeadsetCamera()
         {
-            cachedHeadsetCamera = GetSDKManagerHeadset();
             if (cachedHeadsetCamera == null)
             {
                 var foundCamera = VRContext.GetAnchor(VRNode.CenterEye);


### PR DESCRIPTION
The SDK bases Boundaries and Headset provided methods to their
subclasses that made it easier to get the SDK Manager's play area and
headset, respectively. The methods themselves and their usage didn't
result in the intended caching of the returned objects. Since the
subclasses do the caching properly already the methods and their usage
is removed in this fix.