### PR TITLE
chore(SDK): move private variable

### DIFF
--- a/Assets/VRTK/SDK/Base/SDK_ScriptingDefineSymbolPredicateAttribute.cs
+++ b/Assets/VRTK/SDK/Base/SDK_ScriptingDefineSymbolPredicateAttribute.cs
@@ -24,8 +24,6 @@ namespace VRTK
         /// </summary>
         public string symbol;
 
-        [SerializeField]
-        private string buildTargetGroupName;
 #if UNITY_EDITOR
         /// <summary>
         /// The build target group to use when conditionally adding or removing <see cref="symbol"/>.
@@ -33,6 +31,8 @@ namespace VRTK
         [NonSerialized]
         public BuildTargetGroup buildTargetGroup;
 #endif
+        [SerializeField]
+        private string buildTargetGroupName;
 
         private SDK_ScriptingDefineSymbolPredicateAttribute()
         {
@@ -104,7 +104,7 @@ namespace VRTK
 
             if (buildTargetGroup == BuildTargetGroup.Unknown)
             {
-                throw new ArgumentOutOfRangeException("groupName", groupName, string.Format("The buildTargetGroupName '{0}' isn't allowed.", groupName));
+                throw new ArgumentOutOfRangeException("groupName", groupName, string.Format("'{0}' isn't allowed.", groupName));
             }
 #endif
         }


### PR DESCRIPTION
A private variable in the Scripting Define Symbol Predicate Attribute
has been moved down to adhere to the coding conventions. Additionally an
exception message has been updated to keep the same style that is used
for the other error cases.