### PR TITLE
fix(UpdatePrompt): prevent null path to version file

### DIFF
--- a/Assets/VRTK/Editor/VRTK_UpdatePrompt.cs
+++ b/Assets/VRTK/Editor/VRTK_UpdatePrompt.cs
@@ -136,7 +136,7 @@ public class VRTK_UpdatePrompt : EditorWindow
 
     private static bool UpdateRequired()
     {
-        string assetGuid = AssetDatabase.FindAssets(typeof(VRTK_UpdatePrompt).FullName).FirstOrDefault();
+        string assetGuid = AssetDatabase.FindAssets(typeof(VRTK_UpdatePrompt).FullName).First();
         string path = AssetDatabase.GUIDToAssetPath(assetGuid);
         path = Path.GetDirectoryName(Path.GetDirectoryName(path));
 


### PR DESCRIPTION
When checking for an VRTK update the Update Prompt tries to find the
version file by looking at the directory the script is in. This fix
makes sure to throw an exception on not finding the script instead of
using a `null` path, therefore making the issue more obvious in case
there is an issue finding the version file at all.