### PR TITLE
refactor(UnityEvents): simplify by using new abstract superclass

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_BasicTeleport))]
-    public class VRTK_BasicTeleport_UnityEvents : MonoBehaviour
+    public sealed class VRTK_BasicTeleport_UnityEvents : VRTK_UnityEvents<VRTK_BasicTeleport>
     {
-        private VRTK_BasicTeleport bt;
+        [Serializable]
+        public sealed class TeleportEvent : UnityEvent<object, DestinationMarkerEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, DestinationMarkerEventArgs> { };
+        public TeleportEvent OnTeleporting = new TeleportEvent();
+        public TeleportEvent OnTeleported = new TeleportEvent();
 
-        /// <summary>
-        /// Emits the Teleporting class event.
-        /// </summary>
-        public UnityObjectEvent OnTeleporting = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the Teleported class event.
-        /// </summary>
-        public UnityObjectEvent OnTeleported = new UnityObjectEvent();
-
-        private void SetBasicTeleport()
+        protected override void AddListeners(VRTK_BasicTeleport component)
         {
-            if (bt == null)
-            {
-                bt = GetComponent<VRTK_BasicTeleport>();
-            }
+            component.Teleporting += Teleporting;
+            component.Teleported += Teleported;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_BasicTeleport component)
         {
-            SetBasicTeleport();
-            if (bt == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_BasicTeleport_UnityEvents", "VRTK_BasicTeleport", "the same" }));
-                return;
-            }
-
-            bt.Teleporting += Teleporting;
-            bt.Teleported += Teleported;
+            component.Teleporting -= Teleporting;
+            component.Teleported -= Teleported;
         }
 
         private void Teleporting(object o, DestinationMarkerEventArgs e)
@@ -49,17 +31,6 @@
         private void Teleported(object o, DestinationMarkerEventArgs e)
         {
             OnTeleported.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (bt == null)
-            {
-                return;
-            }
-
-            bt.Teleporting -= Teleporting;
-            bt.Teleported -= Teleported;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
@@ -1,64 +1,44 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_BodyPhysics))]
-    public class VRTK_BodyPhysics_UnityEvents : MonoBehaviour
+    public sealed class VRTK_BodyPhysics_UnityEvents : VRTK_UnityEvents<VRTK_BodyPhysics>
     {
-        private VRTK_BodyPhysics bp;
+        [Serializable]
+        public sealed class BodyPhysicsEvent : UnityEvent<object, BodyPhysicsEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, BodyPhysicsEventArgs> { };
+        public BodyPhysicsEvent OnStartFalling = new BodyPhysicsEvent();
+        public BodyPhysicsEvent OnStopFalling = new BodyPhysicsEvent();
 
-        /// <summary>
-        /// Emits the StartFalling class event.
-        /// </summary>
-        public UnityObjectEvent OnStartFalling = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the StopFalling class event.
-        /// </summary>
-        public UnityObjectEvent OnStopFalling = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the StartMoving class event.
-        /// </summary>
-        public UnityObjectEvent OnStartMoving = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the StopMoving class event.
-        /// </summary>
-        public UnityObjectEvent OnStopMoving = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the StartColliding class event.
-        /// </summary>
-        public UnityObjectEvent OnStartColliding = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the StopColliding class event.
-        /// </summary>
-        public UnityObjectEvent OnStopColliding = new UnityObjectEvent();
+        public BodyPhysicsEvent OnStartMoving = new BodyPhysicsEvent();
+        public BodyPhysicsEvent OnStopMoving = new BodyPhysicsEvent();
 
-        private void SetBodyPhysics()
+        public BodyPhysicsEvent OnStartColliding = new BodyPhysicsEvent();
+        public BodyPhysicsEvent OnStopColliding = new BodyPhysicsEvent();
+
+        protected override void AddListeners(VRTK_BodyPhysics component)
         {
-            if (bp == null)
-            {
-                bp = GetComponent<VRTK_BodyPhysics>();
-            }
+            component.StartFalling += StartFalling;
+            component.StopFalling += StopFalling;
+
+            component.StartMoving += StartMoving;
+            component.StopMoving += StopMoving;
+
+            component.StartColliding += StartColliding;
+            component.StopColliding += StopColliding;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_BodyPhysics component)
         {
-            SetBodyPhysics();
-            if (bp == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_BodyPhysics_UnityEvents", "VRTK_BodyPhysics", "the same" }));
-                return;
-            }
+            component.StartFalling -= StartFalling;
+            component.StopFalling -= StopFalling;
 
-            bp.StartFalling += StartFalling;
-            bp.StopFalling += StopFalling;
-            bp.StartMoving += StartMoving;
-            bp.StopMoving += StopMoving;
-            bp.StartColliding += StartColliding;
-            bp.StopColliding += StopColliding;
+            component.StartMoving -= StartMoving;
+            component.StopMoving -= StopMoving;
+
+            component.StartColliding -= StartColliding;
+            component.StopColliding -= StopColliding;
         }
 
         private void StartFalling(object o, BodyPhysicsEventArgs e)
@@ -89,21 +69,6 @@
         private void StopColliding(object o, BodyPhysicsEventArgs e)
         {
             OnStopColliding.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (bp == null)
-            {
-                return;
-            }
-
-            bp.StartFalling -= StartFalling;
-            bp.StopFalling -= StopFalling;
-            bp.StartMoving -= StartMoving;
-            bp.StopMoving -= StopMoving;
-            bp.StartColliding -= StartColliding;
-            bp.StopColliding -= StopColliding;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Button_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Button_UnityEvents.cs
@@ -1,54 +1,28 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_Button))]
-    public class VRTK_Button_UnityEvents : MonoBehaviour
+    public sealed class VRTK_Button_UnityEvents : VRTK_UnityEvents<VRTK_Button>
     {
-        private VRTK_Button b3d;
+        [Serializable]
+        public sealed class Button3DEvent : UnityEvent<object, Control3DEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, Control3DEventArgs> { };
+        public Button3DEvent OnPushed = new Button3DEvent();
 
-        /// <summary>
-        /// Emits the Pushed class event.
-        /// </summary>
-        public UnityObjectEvent OnPushed = new UnityObjectEvent();
-
-        private void SetButton3D()
+        protected override void AddListeners(VRTK_Button component)
         {
-            if (b3d == null)
-            {
-                b3d = GetComponent<VRTK_Button>();
-            }
+            component.Pushed += Pushed;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_Button component)
         {
-            SetButton3D();
-            if (b3d == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_Button_UnityEvents", "VRTK_Button", "the same" }));
-                return;
-            }
-
-            b3d.Pushed += Pushed;
+            component.Pushed -= Pushed;
         }
 
         private void Pushed(object o, Control3DEventArgs e)
         {
             OnPushed.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (b3d == null)
-            {
-                return;
-            }
-
-            b3d.Pushed -= Pushed;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Control_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_Control_UnityEvents.cs
@@ -1,54 +1,28 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_Control))]
-    public class VRTK_Control_UnityEvents : MonoBehaviour
+    public sealed class VRTK_Control_UnityEvents : VRTK_UnityEvents<VRTK_Control>
     {
-        private VRTK_Control c3d;
+        [Serializable]
+        public sealed class Control3DEvent : UnityEvent<object, Control3DEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, Control3DEventArgs> { };
+        public Control3DEvent OnValueChanged = new Control3DEvent();
 
-        /// <summary>
-        /// Emits the ValueChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnValueChanged = new UnityObjectEvent();
-
-        private void SetControl3D()
+        protected override void AddListeners(VRTK_Control component)
         {
-            if (c3d == null)
-            {
-                c3d = GetComponent<VRTK_Control>();
-            }
+            component.ValueChanged += ValueChanged;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_Control component)
         {
-            SetControl3D();
-            if (c3d == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_Control_UnityEvents", "VRTK_Control", "the same" }));
-                return;
-            }
-
-            c3d.ValueChanged += ValueChanged;
+            component.ValueChanged -= ValueChanged;
         }
 
         private void ValueChanged(object o, Control3DEventArgs e)
         {
             OnValueChanged.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (c3d == null)
-            {
-                return;
-            }
-
-            c3d.ValueChanged -= ValueChanged;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_ControllerActions))]
-    public class VRTK_ControllerActions_UnityEvents : MonoBehaviour
+    public sealed class VRTK_ControllerActions_UnityEvents : VRTK_UnityEvents<VRTK_ControllerActions>
     {
-        private VRTK_ControllerActions ca;
+        [Serializable]
+        public sealed class ControllerActionsEvent : UnityEvent<object, ControllerActionsEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, ControllerActionsEventArgs> { };
+        public ControllerActionsEvent OnControllerModelVisible = new ControllerActionsEvent();
+        public ControllerActionsEvent OnControllerModelInvisible = new ControllerActionsEvent();
 
-        /// <summary>
-        /// Emits the ControllerModelVisible class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerModelVisible = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerModelInvisible class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerModelInvisible = new UnityObjectEvent();
-
-        private void SetControllerAction()
+        protected override void AddListeners(VRTK_ControllerActions component)
         {
-            if (ca == null)
-            {
-                ca = GetComponent<VRTK_ControllerActions>();
-            }
+            component.ControllerModelVisible += ControllerModelVisible;
+            component.ControllerModelInvisible += ControllerModelInvisible;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_ControllerActions component)
         {
-            SetControllerAction();
-            if (ca == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerActions_UnityEvents", "VRTK_ControllerActions", "the same" }));
-                return;
-            }
-
-            ca.ControllerModelVisible += ControllerModelVisible;
-            ca.ControllerModelInvisible += ControllerModelInvisible;
+            component.ControllerModelVisible -= ControllerModelVisible;
+            component.ControllerModelInvisible -= ControllerModelInvisible;
         }
 
         private void ControllerModelVisible(object o, ControllerActionsEventArgs e)
@@ -49,17 +31,6 @@
         private void ControllerModelInvisible(object o, ControllerActionsEventArgs e)
         {
             OnControllerModelInvisible.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (ca == null)
-            {
-                return;
-            }
-
-            ca.ControllerModelVisible -= ControllerModelVisible;
-            ca.ControllerModelInvisible -= ControllerModelInvisible;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -1,293 +1,191 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_ControllerEvents))]
-    public class VRTK_ControllerEvents_UnityEvents : MonoBehaviour
+    public sealed class VRTK_ControllerEvents_UnityEvents : VRTK_UnityEvents<VRTK_ControllerEvents>
     {
-        private VRTK_ControllerEvents ce;
+        [Serializable]
+        public sealed class ControllerInteractionEvent : UnityEvent<object, ControllerInteractionEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, ControllerInteractionEventArgs> { };
+        public ControllerInteractionEvent OnTriggerPressed = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerReleased = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerTouchStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerTouchEnd = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerHairlineStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerHairlineEnd = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerClicked = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerUnclicked = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTriggerAxisChanged = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the TriggerPressed class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerPressed = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerReleased class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerReleased = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerTouchStart class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerTouchStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerTouchEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerTouchEnd = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerHairlineStart class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerHairlineStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerHairlineEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerHairlineEnd = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerClicked class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerClicked = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerUnclicked class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerUnclicked = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TriggerAxisChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnTriggerAxisChanged = new UnityObjectEvent();
+        public ControllerInteractionEvent OnGripPressed = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripReleased = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripTouchStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripTouchEnd = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripHairlineStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripHairlineEnd = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripClicked = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripUnclicked = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnGripAxisChanged = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the GripPressed class event.
-        /// </summary>
-        public UnityObjectEvent OnGripPressed = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripReleased class event.
-        /// </summary>
-        public UnityObjectEvent OnGripReleased = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripTouchStart class event.
-        /// </summary>
-        public UnityObjectEvent OnGripTouchStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripTouchEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnGripTouchEnd = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripHairlineStart class event.
-        /// </summary>
-        public UnityObjectEvent OnGripHairlineStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripHairlineEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnGripHairlineEnd = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripClicked class event.
-        /// </summary>
-        public UnityObjectEvent OnGripClicked = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripUnclicked class event.
-        /// </summary>
-        public UnityObjectEvent OnGripUnclicked = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the GripAxisChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnGripAxisChanged = new UnityObjectEvent();
+        public ControllerInteractionEvent OnTouchpadPressed = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTouchpadReleased = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTouchpadTouchStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTouchpadTouchEnd = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnTouchpadAxisChanged = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the TouchpadPressed class event.
-        /// </summary>
-        public UnityObjectEvent OnTouchpadPressed = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TouchpadReleased class event.
-        /// </summary>
-        public UnityObjectEvent OnTouchpadReleased = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TouchpadTouchStart class event.
-        /// </summary>
-        public UnityObjectEvent OnTouchpadTouchStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TouchpadTouchEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnTouchpadTouchEnd = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the TouchpadAxisChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnTouchpadAxisChanged = new UnityObjectEvent();
+        public ControllerInteractionEvent OnButtonOnePressed = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnButtonOneReleased = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnButtonOneTouchStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnButtonOneTouchEnd = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the ButtonOnePressed class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonOnePressed = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ButtonOneReleased class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonOneReleased = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ButtonOneTouchStart class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonOneTouchStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ButtonOneTouchEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonOneTouchEnd = new UnityObjectEvent();
+        public ControllerInteractionEvent OnButtonTwoPressed = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnButtonTwoReleased = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnButtonTwoTouchStart = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnButtonTwoTouchEnd = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the ButtonTwoPressed class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonTwoPressed = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ButtonTwoReleased class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonTwoReleased = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ButtonTwoTouchStart class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonTwoTouchStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ButtonTwoTouchEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnButtonTwoTouchEnd = new UnityObjectEvent();
+        public ControllerInteractionEvent OnStartMenuPressed = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnStartMenuReleased = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the StartMenuPressed class event.
-        /// </summary>
-        public UnityObjectEvent OnStartMenuPressed = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the StartMenuReleased class event.
-        /// </summary>
-        public UnityObjectEvent OnStartMenuReleased = new UnityObjectEvent();
+        public ControllerInteractionEvent OnAliasPointerOn = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasPointerOff = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasPointerSet = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasGrabOn = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasGrabOff = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasUseOn = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasUseOff = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasUIClickOn = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasUIClickOff = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasMenuOn = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnAliasMenuOff = new ControllerInteractionEvent();
 
-        /// <summary>
-        /// Emits the AliasPointerOn class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasPointerOn = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasPointerOff class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasPointerOff = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasPointerSet class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasPointerSet = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasGrabOn class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasGrabOn = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasGrabOff class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasGrabOff = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasUseOn class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasUseOn = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasUseOff class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasUseOff = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasMenuOn class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasUIClickOn = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasMenuOff class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasUIClickOff = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasUIClickOn class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasMenuOn = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the AliasUIClickOff class event.
-        /// </summary>
-        public UnityObjectEvent OnAliasMenuOff = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerEnabled class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerEnabled = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerDisabled class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerDisabled = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerIndexChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerIndexChanged = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerVisible class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerVisible = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerHidden class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerHidden = new UnityObjectEvent();
+        public ControllerInteractionEvent OnControllerEnabled = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnControllerDisabled = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnControllerIndexChanged = new ControllerInteractionEvent();
 
-        private void SetControllerEvents()
+        public ControllerInteractionEvent OnControllerVisible = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnControllerHidden = new ControllerInteractionEvent();
+
+        protected override void AddListeners(VRTK_ControllerEvents component)
         {
-            if (ce == null)
-            {
-                ce = GetComponent<VRTK_ControllerEvents>();
-            }
+            component.TriggerPressed += TriggerPressed;
+            component.TriggerReleased += TriggerReleased;
+            component.TriggerTouchStart += TriggerTouchStart;
+            component.TriggerTouchEnd += TriggerTouchEnd;
+            component.TriggerHairlineStart += TriggerHairlineStart;
+            component.TriggerHairlineEnd += TriggerHairlineEnd;
+            component.TriggerClicked += TriggerClicked;
+            component.TriggerUnclicked += TriggerUnclicked;
+            component.TriggerAxisChanged += TriggerAxisChanged;
+
+            component.GripPressed += GripPressed;
+            component.GripReleased += GripReleased;
+            component.GripTouchStart += GripTouchStart;
+            component.GripTouchEnd += GripTouchEnd;
+            component.GripHairlineStart += GripHairlineStart;
+            component.GripHairlineEnd += GripHairlineEnd;
+            component.GripClicked += GripClicked;
+            component.GripUnclicked += GripUnclicked;
+            component.GripAxisChanged += GripAxisChanged;
+
+            component.TouchpadPressed += TouchpadPressed;
+            component.TouchpadReleased += TouchpadReleased;
+            component.TouchpadTouchStart += TouchpadTouchStart;
+            component.TouchpadTouchEnd += TouchpadTouchEnd;
+            component.TouchpadAxisChanged += TouchpadAxisChanged;
+
+            component.ButtonOnePressed += ButtonOnePressed;
+            component.ButtonOneReleased += ButtonOneReleased;
+            component.ButtonOneTouchStart += ButtonOneTouchStart;
+            component.ButtonOneTouchEnd += ButtonOneTouchEnd;
+
+            component.ButtonTwoPressed += ButtonTwoPressed;
+            component.ButtonTwoReleased += ButtonTwoReleased;
+            component.ButtonTwoTouchStart += ButtonTwoTouchStart;
+            component.ButtonTwoTouchEnd += ButtonTwoTouchEnd;
+
+            component.StartMenuPressed += StartMenuPressed;
+            component.StartMenuReleased += StartMenuReleased;
+
+            component.AliasPointerOn += AliasPointerOn;
+            component.AliasPointerOff += AliasPointerOff;
+            component.AliasPointerSet += AliasPointerSet;
+            component.AliasGrabOn += AliasGrabOn;
+            component.AliasGrabOff += AliasGrabOff;
+            component.AliasUseOn += AliasUseOn;
+            component.AliasUseOff += AliasUseOff;
+            component.AliasUIClickOn += AliasUIClickOn;
+            component.AliasUIClickOff += AliasUIClickOff;
+            component.AliasMenuOn += AliasMenuOn;
+            component.AliasMenuOff += AliasMenuOff;
+
+            component.ControllerEnabled += ControllerEnabled;
+            component.ControllerDisabled += ControllerDisabled;
+            component.ControllerIndexChanged += ControllerIndexChanged;
+
+            component.ControllerVisible += ControllerVisible;
+            component.ControllerHidden += ControllerHidden;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_ControllerEvents component)
         {
-            SetControllerEvents();
-            if (ce == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ControllerEvents_UnityEvents", "VRTK_ControllerEvents", "the same" }));
-                return;
-            }
+            component.TriggerPressed -= TriggerPressed;
+            component.TriggerReleased -= TriggerReleased;
+            component.TriggerTouchStart -= TriggerTouchStart;
+            component.TriggerTouchEnd -= TriggerTouchEnd;
+            component.TriggerHairlineStart -= TriggerHairlineStart;
+            component.TriggerHairlineEnd -= TriggerHairlineEnd;
+            component.TriggerClicked -= TriggerClicked;
+            component.TriggerUnclicked -= TriggerUnclicked;
+            component.TriggerAxisChanged -= TriggerAxisChanged;
 
-            ce.TriggerPressed += TriggerPressed;
-            ce.TriggerReleased += TriggerReleased;
-            ce.TriggerTouchStart += TriggerTouchStart;
-            ce.TriggerTouchEnd += TriggerTouchEnd;
-            ce.TriggerHairlineStart += TriggerHairlineStart;
-            ce.TriggerHairlineEnd += TriggerHairlineEnd;
-            ce.TriggerClicked += TriggerClicked;
-            ce.TriggerUnclicked += TriggerUnclicked;
-            ce.TriggerAxisChanged += TriggerAxisChanged;
+            component.GripPressed -= GripPressed;
+            component.GripReleased -= GripReleased;
+            component.GripTouchStart -= GripTouchStart;
+            component.GripTouchEnd -= GripTouchEnd;
+            component.GripHairlineStart -= GripHairlineStart;
+            component.GripHairlineEnd -= GripHairlineEnd;
+            component.GripClicked -= GripClicked;
+            component.GripUnclicked -= GripUnclicked;
+            component.GripAxisChanged -= GripAxisChanged;
 
-            ce.GripPressed += GripPressed;
-            ce.GripReleased += GripReleased;
-            ce.GripTouchStart += GripTouchStart;
-            ce.GripTouchEnd += GripTouchEnd;
-            ce.GripHairlineStart += GripHairlineStart;
-            ce.GripHairlineEnd += GripHairlineEnd;
-            ce.GripClicked += GripClicked;
-            ce.GripUnclicked += GripUnclicked;
-            ce.GripAxisChanged += GripAxisChanged;
+            component.TouchpadPressed -= TouchpadPressed;
+            component.TouchpadReleased -= TouchpadReleased;
+            component.TouchpadTouchStart -= TouchpadTouchStart;
+            component.TouchpadTouchEnd -= TouchpadTouchEnd;
+            component.TouchpadAxisChanged -= TouchpadAxisChanged;
 
-            ce.TouchpadPressed += TouchpadPressed;
-            ce.TouchpadReleased += TouchpadReleased;
-            ce.TouchpadTouchStart += TouchpadTouchStart;
-            ce.TouchpadTouchEnd += TouchpadTouchEnd;
-            ce.TouchpadAxisChanged += TouchpadAxisChanged;
+            component.ButtonOnePressed -= ButtonOnePressed;
+            component.ButtonOneReleased -= ButtonOneReleased;
+            component.ButtonOneTouchStart -= ButtonOneTouchStart;
+            component.ButtonOneTouchEnd -= ButtonOneTouchEnd;
 
-            ce.ButtonOnePressed += ButtonOnePressed;
-            ce.ButtonOneReleased += ButtonOneReleased;
-            ce.ButtonOneTouchStart += ButtonOneTouchStart;
-            ce.ButtonOneTouchEnd += ButtonOneTouchEnd;
+            component.ButtonTwoPressed -= ButtonTwoPressed;
+            component.ButtonTwoReleased -= ButtonTwoReleased;
+            component.ButtonTwoTouchStart -= ButtonTwoTouchStart;
+            component.ButtonTwoTouchEnd -= ButtonTwoTouchEnd;
 
-            ce.ButtonTwoPressed += ButtonTwoPressed;
-            ce.ButtonTwoReleased += ButtonTwoReleased;
-            ce.ButtonTwoTouchStart += ButtonTwoTouchStart;
-            ce.ButtonTwoTouchEnd += ButtonTwoTouchEnd;
+            component.StartMenuPressed -= StartMenuPressed;
+            component.StartMenuReleased -= StartMenuReleased;
 
-            ce.StartMenuPressed += StartMenuPressed;
-            ce.StartMenuReleased += StartMenuReleased;
+            component.AliasPointerOn -= AliasPointerOn;
+            component.AliasPointerOff -= AliasPointerOff;
+            component.AliasPointerSet -= AliasPointerSet;
+            component.AliasGrabOn -= AliasGrabOn;
+            component.AliasGrabOff -= AliasGrabOff;
+            component.AliasUseOn -= AliasUseOn;
+            component.AliasUseOff -= AliasUseOff;
+            component.AliasUIClickOn -= AliasUIClickOn;
+            component.AliasUIClickOff -= AliasUIClickOff;
+            component.AliasMenuOn -= AliasMenuOn;
+            component.AliasMenuOff -= AliasMenuOff;
 
-            ce.AliasPointerOn += AliasPointerOn;
-            ce.AliasPointerOff += AliasPointerOff;
-            ce.AliasPointerSet += AliasPointerSet;
-            ce.AliasGrabOn += AliasGrabOn;
-            ce.AliasGrabOff += AliasGrabOff;
-            ce.AliasUseOn += AliasUseOn;
-            ce.AliasUseOff += AliasUseOff;
-            ce.AliasUIClickOn += AliasUIClickOn;
-            ce.AliasUIClickOff += AliasUIClickOff;
-            ce.AliasMenuOn += AliasMenuOn;
-            ce.AliasMenuOff += AliasMenuOff;
+            component.ControllerEnabled -= ControllerEnabled;
+            component.ControllerDisabled -= ControllerDisabled;
+            component.ControllerIndexChanged -= ControllerIndexChanged;
 
-            ce.ControllerEnabled += ControllerEnabled;
-            ce.ControllerDisabled += ControllerDisabled;
-            ce.ControllerIndexChanged += ControllerIndexChanged;
-
-            ce.ControllerVisible += ControllerVisible;
-            ce.ControllerHidden += ControllerHidden;
+            component.ControllerVisible -= ControllerVisible;
+            component.ControllerHidden -= ControllerHidden;
         }
 
         private void TriggerPressed(object o, ControllerInteractionEventArgs e)
@@ -533,72 +431,6 @@
         private void ControllerHidden(object o, ControllerInteractionEventArgs e)
         {
             OnControllerHidden.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (ce == null)
-            {
-                return;
-            }
-
-            ce.TriggerPressed -= TriggerPressed;
-            ce.TriggerReleased -= TriggerReleased;
-            ce.TriggerTouchStart -= TriggerTouchStart;
-            ce.TriggerTouchEnd -= TriggerTouchEnd;
-            ce.TriggerHairlineStart -= TriggerHairlineStart;
-            ce.TriggerHairlineEnd -= TriggerHairlineEnd;
-            ce.TriggerClicked -= TriggerClicked;
-            ce.TriggerUnclicked -= TriggerUnclicked;
-            ce.TriggerAxisChanged -= TriggerAxisChanged;
-
-            ce.GripPressed -= GripPressed;
-            ce.GripReleased -= GripReleased;
-            ce.GripTouchStart -= GripTouchStart;
-            ce.GripTouchEnd -= GripTouchEnd;
-            ce.GripHairlineStart -= GripHairlineStart;
-            ce.GripHairlineEnd -= GripHairlineEnd;
-            ce.GripClicked -= GripClicked;
-            ce.GripUnclicked -= GripUnclicked;
-            ce.GripAxisChanged -= GripAxisChanged;
-
-            ce.TouchpadPressed -= TouchpadPressed;
-            ce.TouchpadReleased -= TouchpadReleased;
-            ce.TouchpadTouchStart -= TouchpadTouchStart;
-            ce.TouchpadTouchEnd -= TouchpadTouchEnd;
-            ce.TouchpadAxisChanged -= TouchpadAxisChanged;
-
-            ce.ButtonOnePressed -= ButtonOnePressed;
-            ce.ButtonOneReleased -= ButtonOneReleased;
-            ce.ButtonOneTouchStart -= ButtonOneTouchStart;
-            ce.ButtonOneTouchEnd -= ButtonOneTouchEnd;
-
-            ce.ButtonTwoPressed -= ButtonTwoPressed;
-            ce.ButtonTwoReleased -= ButtonTwoReleased;
-            ce.ButtonTwoTouchStart -= ButtonTwoTouchStart;
-            ce.ButtonTwoTouchEnd -= ButtonTwoTouchEnd;
-
-            ce.StartMenuPressed -= StartMenuPressed;
-            ce.StartMenuReleased -= StartMenuReleased;
-
-            ce.AliasPointerOn -= AliasPointerOn;
-            ce.AliasPointerOff -= AliasPointerOff;
-            ce.AliasPointerSet -= AliasPointerSet;
-            ce.AliasGrabOn -= AliasGrabOn;
-            ce.AliasGrabOff -= AliasGrabOff;
-            ce.AliasUseOn -= AliasUseOn;
-            ce.AliasUseOff -= AliasUseOff;
-            ce.AliasUIClickOn -= AliasUIClickOn;
-            ce.AliasUIClickOff -= AliasUIClickOff;
-            ce.AliasMenuOn -= AliasMenuOn;
-            ce.AliasMenuOff -= AliasMenuOff;
-
-            ce.ControllerEnabled -= ControllerEnabled;
-            ce.ControllerDisabled -= ControllerDisabled;
-            ce.ControllerIndexChanged -= ControllerIndexChanged;
-
-            ce.ControllerVisible -= ControllerVisible;
-            ce.ControllerHidden -= ControllerHidden;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_DashTeleport))]
-    public class VRTK_DashTeleport_UnityEvents : MonoBehaviour
+    public sealed class VRTK_DashTeleport_UnityEvents : VRTK_UnityEvents<VRTK_DashTeleport>
     {
-        private VRTK_DashTeleport dt;
+        [Serializable]
+        public sealed class DashTeleportEvent : UnityEvent<object, DashTeleportEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, DashTeleportEventArgs> { };
+        public DashTeleportEvent OnWillDashThruObjects = new DashTeleportEvent();
+        public DashTeleportEvent OnDashedThruObjects = new DashTeleportEvent();
 
-        /// <summary>
-        /// Emits the WillDashThruObjects class event.
-        /// </summary>
-        public UnityObjectEvent OnWillDashThruObjects = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the DashedThruObjects class event.
-        /// </summary>
-        public UnityObjectEvent OnDashedThruObjects = new UnityObjectEvent();
-
-        private void SetDashTeleport()
+        protected override void AddListeners(VRTK_DashTeleport component)
         {
-            if (dt == null)
-            {
-                dt = GetComponent<VRTK_DashTeleport>();
-            }
+            component.WillDashThruObjects += WillDashThruObjects;
+            component.DashedThruObjects += DashedThruObjects;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_DashTeleport component)
         {
-            SetDashTeleport();
-            if (dt == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_DashTeleport_UnityEvents", "VRTK_DashTeleport", "the same" }));
-                return;
-            }
-
-            dt.WillDashThruObjects += WillDashThruObjects;
-            dt.DashedThruObjects += DashedThruObjects;
+            component.WillDashThruObjects -= WillDashThruObjects;
+            component.DashedThruObjects -= DashedThruObjects;
         }
 
         private void WillDashThruObjects(object o, DashTeleportEventArgs e)
@@ -49,17 +31,6 @@
         private void DashedThruObjects(object o, DashTeleportEventArgs e)
         {
             OnDashedThruObjects.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (dt == null)
-            {
-                return;
-            }
-
-            dt.WillDashThruObjects -= WillDashThruObjects;
-            dt.DashedThruObjects -= DashedThruObjects;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
@@ -1,49 +1,29 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_DestinationMarker))]
-    public class VRTK_DestinationMarker_UnityEvents : MonoBehaviour
+    public sealed class VRTK_DestinationMarker_UnityEvents : VRTK_UnityEvents<VRTK_DestinationMarker>
     {
-        private VRTK_DestinationMarker dm;
+        [Serializable]
+        public sealed class DestinationMarkerEvent : UnityEvent<object, DestinationMarkerEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, DestinationMarkerEventArgs> { };
+        public DestinationMarkerEvent OnDestinationMarkerEnter = new DestinationMarkerEvent();
+        public DestinationMarkerEvent OnDestinationMarkerExit = new DestinationMarkerEvent();
+        public DestinationMarkerEvent OnDestinationMarkerSet = new DestinationMarkerEvent();
 
-        /// <summary>
-        /// Emits the DestinationMarkerEnter class event.
-        /// </summary>
-        public UnityObjectEvent OnDestinationMarkerEnter = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the DestinationMarkerExit class event.
-        /// </summary>
-        public UnityObjectEvent OnDestinationMarkerExit = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the DestinationMarkerSet class event.
-        /// </summary>
-        public UnityObjectEvent OnDestinationMarkerSet = new UnityObjectEvent();
-
-        private void SetDestinationMarker()
+        protected override void AddListeners(VRTK_DestinationMarker component)
         {
-            if (dm == null)
-            {
-                dm = GetComponent<VRTK_DestinationMarker>();
-            }
+            component.DestinationMarkerEnter += DestinationMarkerEnter;
+            component.DestinationMarkerExit += DestinationMarkerExit;
+            component.DestinationMarkerSet += DestinationMarkerSet;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_DestinationMarker component)
         {
-            SetDestinationMarker();
-            if (dm == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_DestinationMarker_UnityEvents", "VRTK_DestinationMarker", "the same" }));
-                return;
-            }
-
-            dm.DestinationMarkerEnter += DestinationMarkerEnter;
-            dm.DestinationMarkerExit += DestinationMarkerExit;
-            dm.DestinationMarkerSet += DestinationMarkerSet;
+            component.DestinationMarkerEnter -= DestinationMarkerEnter;
+            component.DestinationMarkerExit -= DestinationMarkerExit;
+            component.DestinationMarkerSet -= DestinationMarkerSet;
         }
 
         private void DestinationMarkerEnter(object o, DestinationMarkerEventArgs e)
@@ -59,18 +39,6 @@
         private void DestinationMarkerSet(object o, DestinationMarkerEventArgs e)
         {
             OnDestinationMarkerSet.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (dm == null)
-            {
-                return;
-            }
-
-            dm.DestinationMarkerEnter -= DestinationMarkerEnter;
-            dm.DestinationMarkerExit -= DestinationMarkerExit;
-            dm.DestinationMarkerSet -= DestinationMarkerSet;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_HeadsetCollision))]
-    public class VRTK_HeadsetCollision_UnityEvents : MonoBehaviour
+    public sealed class VRTK_HeadsetCollision_UnityEvents : VRTK_UnityEvents<VRTK_HeadsetCollision>
     {
-        private VRTK_HeadsetCollision hc;
+        [Serializable]
+        public sealed class HeadsetCollisionEvent : UnityEvent<object, HeadsetCollisionEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, HeadsetCollisionEventArgs> { };
+        public HeadsetCollisionEvent OnHeadsetCollisionDetect = new HeadsetCollisionEvent();
+        public HeadsetCollisionEvent OnHeadsetCollisionEnded = new HeadsetCollisionEvent();
 
-        /// <summary>
-        /// Emits the HeadsetCollisionDetect class event.
-        /// </summary>
-        public UnityObjectEvent OnHeadsetCollisionDetect = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the HeadsetCollisionEnded class event.
-        /// </summary>
-        public UnityObjectEvent OnHeadsetCollisionEnded = new UnityObjectEvent();
-
-        private void SetHeadsetCollision()
+        protected override void AddListeners(VRTK_HeadsetCollision component)
         {
-            if (hc == null)
-            {
-                hc = GetComponent<VRTK_HeadsetCollision>();
-            }
+            component.HeadsetCollisionDetect += HeadsetCollisionDetect;
+            component.HeadsetCollisionEnded += HeadsetCollisionEnded;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_HeadsetCollision component)
         {
-            SetHeadsetCollision();
-            if (hc == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetCollision_UnityEvents", "VRTK_HeadsetCollision", "the same" }));
-                return;
-            }
-
-            hc.HeadsetCollisionDetect += HeadsetCollisionDetect;
-            hc.HeadsetCollisionEnded += HeadsetCollisionEnded;
+            component.HeadsetCollisionDetect -= HeadsetCollisionDetect;
+            component.HeadsetCollisionEnded -= HeadsetCollisionEnded;
         }
 
         private void HeadsetCollisionDetect(object o, HeadsetCollisionEventArgs e)
@@ -49,17 +31,6 @@
         private void HeadsetCollisionEnded(object o, HeadsetCollisionEventArgs e)
         {
             OnHeadsetCollisionEnded.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (hc == null)
-            {
-                return;
-            }
-
-            hc.HeadsetCollisionDetect -= HeadsetCollisionDetect;
-            hc.HeadsetCollisionEnded -= HeadsetCollisionEnded;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetControllerAware_UnityEvents.cs
@@ -1,55 +1,35 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_HeadsetControllerAware))]
-    public class VRTK_HeadsetControllerAware_UnityEvents : MonoBehaviour
+    public sealed class VRTK_HeadsetControllerAware_UnityEvents : VRTK_UnityEvents<VRTK_HeadsetControllerAware>
     {
-        private VRTK_HeadsetControllerAware hca;
+        [Serializable]
+        public sealed class HeadsetControllerAwareEvent : UnityEvent<object, HeadsetControllerAwareEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, HeadsetControllerAwareEventArgs> { };
+        public HeadsetControllerAwareEvent OnControllerObscured = new HeadsetControllerAwareEvent();
+        public HeadsetControllerAwareEvent OnControllerUnobscured = new HeadsetControllerAwareEvent();
 
-        /// <summary>
-        /// Emits the ControllerObscured class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerObscured = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerUnobscured class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerUnobscured = new UnityObjectEvent();
+        public HeadsetControllerAwareEvent OnControllerGlanceEnter = new HeadsetControllerAwareEvent();
+        public HeadsetControllerAwareEvent OnControllerGlanceExit = new HeadsetControllerAwareEvent();
 
-        /// <summary>
-        /// Emits the ControllerGlanceEnter class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerGlanceEnter = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerGlanceExit class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerGlanceExit = new UnityObjectEvent();
-
-        private void SetHeadsetControllerAware()
+        protected override void AddListeners(VRTK_HeadsetControllerAware component)
         {
-            if (hca == null)
-            {
-                hca = GetComponent<VRTK_HeadsetControllerAware>();
-            }
+            component.ControllerObscured += ControllerObscured;
+            component.ControllerUnobscured += ControllerUnobscured;
+
+            component.ControllerGlanceEnter += ControllerGlanceEnter;
+            component.ControllerGlanceExit += ControllerGlanceExit;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_HeadsetControllerAware component)
         {
-            SetHeadsetControllerAware();
-            if (hca == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetControllerAware_UnityEvents", "VRTK_HeadsetControllerAware", "the same" }));
-                return;
-            }
+            component.ControllerObscured -= ControllerObscured;
+            component.ControllerUnobscured -= ControllerUnobscured;
 
-            hca.ControllerObscured += ControllerObscured;
-            hca.ControllerUnobscured += ControllerUnobscured;
-            hca.ControllerGlanceEnter += ControllerGlanceEnter;
-            hca.ControllerGlanceExit += ControllerGlanceExit;
+            component.ControllerGlanceEnter -= ControllerGlanceEnter;
+            component.ControllerGlanceExit -= ControllerGlanceExit;
         }
 
         private void ControllerObscured(object o, HeadsetControllerAwareEventArgs e)
@@ -70,19 +50,6 @@
         private void ControllerGlanceExit(object o, HeadsetControllerAwareEventArgs e)
         {
             OnControllerGlanceExit.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (hca == null)
-            {
-                return;
-            }
-
-            hca.ControllerObscured -= ControllerObscured;
-            hca.ControllerUnobscured -= ControllerUnobscured;
-            hca.ControllerGlanceEnter -= ControllerGlanceEnter;
-            hca.ControllerGlanceExit -= ControllerGlanceExit;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
@@ -1,54 +1,35 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_HeadsetFade))]
-    public class VRTK_HeadsetFade_UnityEvents : MonoBehaviour
+    public sealed class VRTK_HeadsetFade_UnityEvents : VRTK_UnityEvents<VRTK_HeadsetFade>
     {
-        private VRTK_HeadsetFade hf;
+        [Serializable]
+        public sealed class HeadsetFadeEvent : UnityEvent<object, HeadsetFadeEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, HeadsetFadeEventArgs> { };
+        public HeadsetFadeEvent OnHeadsetFadeStart = new HeadsetFadeEvent();
+        public HeadsetFadeEvent OnHeadsetFadeComplete = new HeadsetFadeEvent();
 
-        /// <summary>
-        /// Emits the HeadsetFadeStart class event.
-        /// </summary>
-        public UnityObjectEvent OnHeadsetFadeStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the HeadsetFadeComplete class event.
-        /// </summary>
-        public UnityObjectEvent OnHeadsetFadeComplete = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the HeadsetUnfadeStart class event.
-        /// </summary>
-        public UnityObjectEvent OnHeadsetUnfadeStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the HeadsetUnfadeComplete class event.
-        /// </summary>
-        public UnityObjectEvent OnHeadsetUnfadeComplete = new UnityObjectEvent();
+        public HeadsetFadeEvent OnHeadsetUnfadeStart = new HeadsetFadeEvent();
+        public HeadsetFadeEvent OnHeadsetUnfadeComplete = new HeadsetFadeEvent();
 
-        private void SetHeadsetFade()
+        protected override void AddListeners(VRTK_HeadsetFade component)
         {
-            if (hf == null)
-            {
-                hf = GetComponent<VRTK_HeadsetFade>();
-            }
+            component.HeadsetFadeStart += HeadsetFadeStart;
+            component.HeadsetFadeComplete += HeadsetFadeComplete;
+
+            component.HeadsetUnfadeStart += HeadsetUnfadeStart;
+            component.HeadsetUnfadeComplete += HeadsetUnfadeComplete;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_HeadsetFade component)
         {
-            SetHeadsetFade();
-            if (hf == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_HeadsetFade_UnityEvents", "VRTK_HeadsetFade", "the same" }));
-                return;
-            }
+            component.HeadsetFadeStart -= HeadsetFadeStart;
+            component.HeadsetFadeComplete -= HeadsetFadeComplete;
 
-            hf.HeadsetFadeStart += HeadsetFadeStart;
-            hf.HeadsetFadeComplete += HeadsetFadeComplete;
-            hf.HeadsetUnfadeStart += HeadsetUnfadeStart;
-            hf.HeadsetUnfadeComplete += HeadsetUnfadeComplete;
+            component.HeadsetUnfadeStart -= HeadsetUnfadeStart;
+            component.HeadsetUnfadeComplete -= HeadsetUnfadeComplete;
         }
 
         private void HeadsetFadeStart(object o, HeadsetFadeEventArgs e)
@@ -69,19 +50,6 @@
         private void HeadsetUnfadeComplete(object o, HeadsetFadeEventArgs e)
         {
             OnHeadsetUnfadeComplete.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (hf == null)
-            {
-                return;
-            }
-
-            hf.HeadsetFadeStart -= HeadsetFadeStart;
-            hf.HeadsetFadeComplete -= HeadsetFadeComplete;
-            hf.HeadsetUnfadeStart -= HeadsetUnfadeStart;
-            hf.HeadsetUnfadeComplete -= HeadsetUnfadeComplete;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_InteractGrab))]
-    public class VRTK_InteractGrab_UnityEvents : MonoBehaviour
+    public sealed class VRTK_InteractGrab_UnityEvents : VRTK_UnityEvents<VRTK_InteractGrab>
     {
-        private VRTK_InteractGrab ig;
+        [Serializable]
+        public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, ObjectInteractEventArgs> { };
+        public ObjectInteractEvent OnControllerGrabInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerUngrabInteractableObject = new ObjectInteractEvent();
 
-        /// <summary>
-        /// Emits the ControllerGrabInteractableObject class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerGrabInteractableObject = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerUngrabInteractableObject class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerUngrabInteractableObject = new UnityObjectEvent();
-
-        private void SetInteractGrab()
+        protected override void AddListeners(VRTK_InteractGrab component)
         {
-            if (ig == null)
-            {
-                ig = GetComponent<VRTK_InteractGrab>();
-            }
+            component.ControllerGrabInteractableObject += ControllerGrabInteractableObject;
+            component.ControllerUngrabInteractableObject += ControllerUngrabInteractableObject;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_InteractGrab component)
         {
-            SetInteractGrab();
-            if (ig == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractGrab_UnityEvents", "VRTK_InteractGrab", "the same" }));
-                return;
-            }
-
-            ig.ControllerGrabInteractableObject += ControllerGrabInteractableObject;
-            ig.ControllerUngrabInteractableObject += ControllerUngrabInteractableObject;
+            component.ControllerGrabInteractableObject -= ControllerGrabInteractableObject;
+            component.ControllerUngrabInteractableObject -= ControllerUngrabInteractableObject;
         }
 
         private void ControllerGrabInteractableObject(object o, ObjectInteractEventArgs e)
@@ -49,17 +31,6 @@
         private void ControllerUngrabInteractableObject(object o, ObjectInteractEventArgs e)
         {
             OnControllerUngrabInteractableObject.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (ig == null)
-            {
-                return;
-            }
-
-            ig.ControllerGrabInteractableObject -= ControllerGrabInteractableObject;
-            ig.ControllerUngrabInteractableObject -= ControllerUngrabInteractableObject;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_InteractTouch))]
-    public class VRTK_InteractTouch_UnityEvents : MonoBehaviour
+    public sealed class VRTK_InteractTouch_UnityEvents : VRTK_UnityEvents<VRTK_InteractTouch>
     {
-        private VRTK_InteractTouch it;
+        [Serializable]
+        public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, ObjectInteractEventArgs> { };
+        public ObjectInteractEvent OnControllerTouchInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerUntouchInteractableObject = new ObjectInteractEvent();
 
-        /// <summary>
-        /// Emits the ControllerTouchInteractableObject class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerTouchInteractableObject = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerUntouchInteractableObject class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerUntouchInteractableObject = new UnityObjectEvent();
-
-        private void SetInteractTouch()
+        protected override void AddListeners(VRTK_InteractTouch component)
         {
-            if (it == null)
-            {
-                it = GetComponent<VRTK_InteractTouch>();
-            }
+            component.ControllerTouchInteractableObject += ControllerTouchInteractableObject;
+            component.ControllerUntouchInteractableObject += ControllerUntouchInteractableObject;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_InteractTouch component)
         {
-            SetInteractTouch();
-            if (it == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractTouch_UnityEvents", "VRTK_InteractTouch", "the same" }));
-                return;
-            }
-
-            it.ControllerTouchInteractableObject += ControllerTouchInteractableObject;
-            it.ControllerUntouchInteractableObject += ControllerUntouchInteractableObject;
+            component.ControllerTouchInteractableObject -= ControllerTouchInteractableObject;
+            component.ControllerUntouchInteractableObject -= ControllerUntouchInteractableObject;
         }
 
         private void ControllerTouchInteractableObject(object o, ObjectInteractEventArgs e)
@@ -49,17 +31,6 @@
         private void ControllerUntouchInteractableObject(object o, ObjectInteractEventArgs e)
         {
             OnControllerUntouchInteractableObject.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (it == null)
-            {
-                return;
-            }
-
-            it.ControllerTouchInteractableObject -= ControllerTouchInteractableObject;
-            it.ControllerUntouchInteractableObject -= ControllerUntouchInteractableObject;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_InteractUse))]
-    public class VRTK_InteractUse_UnityEvents : MonoBehaviour
+    public sealed class VRTK_InteractUse_UnityEvents : VRTK_UnityEvents<VRTK_InteractUse>
     {
-        private VRTK_InteractUse iu;
+        [Serializable]
+        public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, ObjectInteractEventArgs> { };
+        public ObjectInteractEvent OnControllerUseInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerUnuseInteractableObject = new ObjectInteractEvent();
 
-        /// <summary>
-        /// Emits the ControllerUseInteractableObject class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerUseInteractableObject = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ControllerUnuseInteractableObject class event.
-        /// </summary>
-        public UnityObjectEvent OnControllerUnuseInteractableObject = new UnityObjectEvent();
-
-        private void SetInteractUse()
+        protected override void AddListeners(VRTK_InteractUse component)
         {
-            if (iu == null)
-            {
-                iu = GetComponent<VRTK_InteractUse>();
-            }
+            component.ControllerUseInteractableObject += ControllerUseInteractableObject;
+            component.ControllerUnuseInteractableObject += ControllerUnuseInteractableObject;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_InteractUse component)
         {
-            SetInteractUse();
-            if (iu == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractUse_UnityEvents", "VRTK_InteractUse", "the same" }));
-                return;
-            }
-
-            iu.ControllerUseInteractableObject += ControllerUseInteractableObject;
-            iu.ControllerUnuseInteractableObject += ControllerUnuseInteractableObject;
+            component.ControllerUseInteractableObject -= ControllerUseInteractableObject;
+            component.ControllerUnuseInteractableObject -= ControllerUnuseInteractableObject;
         }
 
         private void ControllerUseInteractableObject(object o, ObjectInteractEventArgs e)
@@ -49,17 +31,6 @@
         private void ControllerUnuseInteractableObject(object o, ObjectInteractEventArgs e)
         {
             OnControllerUnuseInteractableObject.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (iu == null)
-            {
-                return;
-            }
-
-            iu.ControllerUseInteractableObject -= ControllerUseInteractableObject;
-            iu.ControllerUnuseInteractableObject -= ControllerUnuseInteractableObject;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -1,84 +1,59 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_InteractableObject))]
-    public class VRTK_InteractableObject_UnityEvents : MonoBehaviour
+    public sealed class VRTK_InteractableObject_UnityEvents : VRTK_UnityEvents<VRTK_InteractableObject>
     {
-        private VRTK_InteractableObject io;
+        [Serializable]
+        public sealed class InteractableObjectEvent : UnityEvent<object, InteractableObjectEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, InteractableObjectEventArgs> { };
+        public InteractableObjectEvent OnTouch = new InteractableObjectEvent();
+        public InteractableObjectEvent OnUntouch = new InteractableObjectEvent();
 
-        /// <summary>
-        /// Emits the InteractableObjectTouched class event.
-        /// </summary>
-        public UnityObjectEvent OnTouch = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectUntouched class event.
-        /// </summary>
-        public UnityObjectEvent OnUntouch = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectGrabbed class event.
-        /// </summary>
-        public UnityObjectEvent OnGrab = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectUngrabbed class event.
-        /// </summary>
-        public UnityObjectEvent OnUngrab = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectUsed class event.
-        /// </summary>
-        public UnityObjectEvent OnUse = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectUnused class event.
-        /// </summary>
-        public UnityObjectEvent OnUnuse = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectEnteredSnapDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnEnterSnapDropZone = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectExitedSnapDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnExitSnapDropZone = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectSnappedToDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnSnapToDropZone = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the InteractableObjectUnsnappedFromDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnUnsnapFromDropZone = new UnityObjectEvent();
+        public InteractableObjectEvent OnGrab = new InteractableObjectEvent();
+        public InteractableObjectEvent OnUngrab = new InteractableObjectEvent();
 
-        private void SetInteractableObject()
+        public InteractableObjectEvent OnUse = new InteractableObjectEvent();
+        public InteractableObjectEvent OnUnuse = new InteractableObjectEvent();
+
+        public InteractableObjectEvent OnEnterSnapDropZone = new InteractableObjectEvent();
+        public InteractableObjectEvent OnExitSnapDropZone = new InteractableObjectEvent();
+        public InteractableObjectEvent OnSnapToDropZone = new InteractableObjectEvent();
+        public InteractableObjectEvent OnUnsnapFromDropZone = new InteractableObjectEvent();
+
+        protected override void AddListeners(VRTK_InteractableObject component)
         {
-            if (io == null)
-            {
-                io = GetComponent<VRTK_InteractableObject>();
-            }
+            component.InteractableObjectTouched += Touch;
+            component.InteractableObjectUntouched += UnTouch;
+
+            component.InteractableObjectGrabbed += Grab;
+            component.InteractableObjectUngrabbed += UnGrab;
+
+            component.InteractableObjectUsed += Use;
+            component.InteractableObjectUnused += Unuse;
+
+            component.InteractableObjectEnteredSnapDropZone += EnterSnapDropZone;
+            component.InteractableObjectExitedSnapDropZone += ExitSnapDropZone;
+            component.InteractableObjectSnappedToDropZone += SnapToDropZone;
+            component.InteractableObjectUnsnappedFromDropZone += UnsnapFromDropZone;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_InteractableObject component)
         {
-            SetInteractableObject();
-            if (io == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_InteractableObject_UnityEvents", "VRTK_InteractableObject", "the same" }));
-                return;
-            }
+            component.InteractableObjectTouched -= Touch;
+            component.InteractableObjectUntouched -= UnTouch;
 
-            io.InteractableObjectTouched += Touch;
-            io.InteractableObjectUntouched += UnTouch;
-            io.InteractableObjectGrabbed += Grab;
-            io.InteractableObjectUngrabbed += UnGrab;
-            io.InteractableObjectUsed += Use;
-            io.InteractableObjectUnused += Unuse;
-            io.InteractableObjectEnteredSnapDropZone += EnterSnapDropZone;
-            io.InteractableObjectExitedSnapDropZone += ExitSnapDropZone;
-            io.InteractableObjectSnappedToDropZone += SnapToDropZone;
-            io.InteractableObjectUnsnappedFromDropZone += UnsnapFromDropZone;
+            component.InteractableObjectGrabbed -= Grab;
+            component.InteractableObjectUngrabbed -= UnGrab;
+
+            component.InteractableObjectUsed -= Use;
+            component.InteractableObjectUnused -= Unuse;
+
+            component.InteractableObjectEnteredSnapDropZone -= EnterSnapDropZone;
+            component.InteractableObjectExitedSnapDropZone -= ExitSnapDropZone;
+            component.InteractableObjectSnappedToDropZone -= SnapToDropZone;
+            component.InteractableObjectUnsnappedFromDropZone -= UnsnapFromDropZone;
         }
 
         private void Touch(object o, InteractableObjectEventArgs e)
@@ -129,25 +104,6 @@
         private void UnsnapFromDropZone(object o, InteractableObjectEventArgs e)
         {
             OnUnsnapFromDropZone.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (io == null)
-            {
-                return;
-            }
-
-            io.InteractableObjectTouched -= Touch;
-            io.InteractableObjectUntouched -= UnTouch;
-            io.InteractableObjectGrabbed -= Grab;
-            io.InteractableObjectUngrabbed -= UnGrab;
-            io.InteractableObjectUsed -= Use;
-            io.InteractableObjectUnused -= Unuse;
-            io.InteractableObjectEnteredSnapDropZone -= EnterSnapDropZone;
-            io.InteractableObjectExitedSnapDropZone -= ExitSnapDropZone;
-            io.InteractableObjectSnappedToDropZone -= SnapToDropZone;
-            io.InteractableObjectUnsnappedFromDropZone -= UnsnapFromDropZone;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectControl_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectControl_UnityEvents.cs
@@ -1,45 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_ObjectControl))]
-    public class VRTK_ObjectControl_UnityEvents : MonoBehaviour
+    public sealed class VRTK_ObjectControl_UnityEvents : VRTK_UnityEvents<VRTK_ObjectControl>
     {
-        private VRTK_ObjectControl oc;
+        [Serializable]
+        public sealed class ObjectControlEvent : UnityEvent<object, ObjectControlEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, ObjectControlEventArgs> { };
+        public ObjectControlEvent OnXAxisChanged = new ObjectControlEvent();
+        public ObjectControlEvent OnYAxisChanged = new ObjectControlEvent();
 
-        /// <summary>
-        /// Emits the XAxisChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnXAxisChanged = new UnityObjectEvent();
-
-        /// <summary>
-        /// Emits the YAxisChanged class event.
-        /// </summary>
-        public UnityObjectEvent OnYAxisChanged = new UnityObjectEvent();
-
-        private void SetObjectControl()
+        protected override void AddListeners(VRTK_ObjectControl component)
         {
-            if (oc == null)
-            {
-                oc = GetComponent<VRTK_ObjectControl>();
-            }
+            component.XAxisChanged += XAxisChanged;
+            component.YAxisChanged += YAxisChanged;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_ObjectControl component)
         {
-            SetObjectControl();
-            if (oc == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_ObjectControl_UnityEvents", "VRTK_ObjectControl", "the same" }));
-                return;
-            }
-
-            oc.XAxisChanged += XAxisChanged;
-            oc.YAxisChanged += YAxisChanged;
+            component.XAxisChanged -= XAxisChanged;
+            component.YAxisChanged -= YAxisChanged;
         }
 
         private void XAxisChanged(object o, ObjectControlEventArgs e)
@@ -50,17 +31,6 @@
         private void YAxisChanged(object o, ObjectControlEventArgs e)
         {
             OnYAxisChanged.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (oc == null)
-            {
-                return;
-            }
-
-            oc.XAxisChanged -= XAxisChanged;
-            oc.YAxisChanged -= YAxisChanged;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
@@ -1,44 +1,26 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_PlayerClimb))]
-    public class VRTK_PlayerClimb_UnityEvents : MonoBehaviour
+    public sealed class VRTK_PlayerClimb_UnityEvents : VRTK_UnityEvents<VRTK_PlayerClimb>
     {
-        private VRTK_PlayerClimb pc;
+        [Serializable]
+        public sealed class PlayerClimbEvent : UnityEvent<object, PlayerClimbEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, PlayerClimbEventArgs> { };
+        public PlayerClimbEvent OnPlayerClimbStarted = new PlayerClimbEvent();
+        public PlayerClimbEvent OnPlayerClimbEnded = new PlayerClimbEvent();
 
-        /// <summary>
-        /// Emits the PlayerClimbStarted class event.
-        /// </summary>
-        public UnityObjectEvent OnPlayerClimbStarted = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the PlayerClimbEnded class event.
-        /// </summary>
-        public UnityObjectEvent OnPlayerClimbEnded = new UnityObjectEvent();
-
-        private void SetPlayerClimb()
+        protected override void AddListeners(VRTK_PlayerClimb component)
         {
-            if (pc == null)
-            {
-                pc = GetComponent<VRTK_PlayerClimb>();
-            }
+            component.PlayerClimbStarted += PlayerClimbStarted;
+            component.PlayerClimbEnded += PlayerClimbEnded;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_PlayerClimb component)
         {
-            SetPlayerClimb();
-            if (pc == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_PlayerClimb_UnityEvents", "VRTK_PlayerClimb", "the same" }));
-                return;
-            }
-
-            pc.PlayerClimbStarted += PlayerClimbStarted;
-            pc.PlayerClimbEnded += PlayerClimbEnded;
+            component.PlayerClimbStarted -= PlayerClimbStarted;
+            component.PlayerClimbEnded -= PlayerClimbEnded;
         }
 
         private void PlayerClimbStarted(object o, PlayerClimbEventArgs e)
@@ -49,17 +31,6 @@
         private void PlayerClimbEnded(object o, PlayerClimbEventArgs e)
         {
             OnPlayerClimbEnded.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (pc == null)
-            {
-                return;
-            }
-
-            pc.PlayerClimbStarted -= PlayerClimbStarted;
-            pc.PlayerClimbEnded -= PlayerClimbEnded;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_SnapDropZone_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_SnapDropZone_UnityEvents.cs
@@ -1,54 +1,35 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_SnapDropZone))]
-    public class VRTK_SnapDropZone_UnityEvents : MonoBehaviour
+    public sealed class VRTK_SnapDropZone_UnityEvents : VRTK_UnityEvents<VRTK_SnapDropZone>
     {
-        private VRTK_SnapDropZone sdz;
+        [Serializable]
+        public sealed class SnapDropZoneEvent : UnityEvent<object, SnapDropZoneEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, SnapDropZoneEventArgs> { };
+        public SnapDropZoneEvent OnObjectEnteredSnapDropZone = new SnapDropZoneEvent();
+        public SnapDropZoneEvent OnObjectExitedSnapDropZone = new SnapDropZoneEvent();
 
-        /// <summary>
-        /// Emits the ObjectEnteredSnapDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnObjectEnteredSnapDropZone = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ObjectExitedSnapDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnObjectExitedSnapDropZone = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ObjectSnappedToDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnObjectSnappedToDropZone = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the ObjectUnsnappedFromDropZone class event.
-        /// </summary>
-        public UnityObjectEvent OnObjectUnsnappedFromDropZone = new UnityObjectEvent();
+        public SnapDropZoneEvent OnObjectSnappedToDropZone = new SnapDropZoneEvent();
+        public SnapDropZoneEvent OnObjectUnsnappedFromDropZone = new SnapDropZoneEvent();
 
-        private void SetSnapDropZone()
+        protected override void AddListeners(VRTK_SnapDropZone component)
         {
-            if (sdz == null)
-            {
-                sdz = GetComponent<VRTK_SnapDropZone>();
-            }
+            component.ObjectEnteredSnapDropZone += ObjectEnteredSnapDropZone;
+            component.ObjectExitedSnapDropZone += ObjectExitedSnapDropZone;
+
+            component.ObjectSnappedToDropZone += ObjectSnappedToDropZone;
+            component.ObjectUnsnappedFromDropZone += ObjectUnsnappedFromDropZone;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_SnapDropZone component)
         {
-            SetSnapDropZone();
-            if (sdz == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_SnapDropZone_UnityEvents", "VRTK_SnapDropZone", "the same" }));
-                return;
-            }
+            component.ObjectEnteredSnapDropZone -= ObjectEnteredSnapDropZone;
+            component.ObjectExitedSnapDropZone -= ObjectExitedSnapDropZone;
 
-            sdz.ObjectEnteredSnapDropZone += ObjectEnteredSnapDropZone;
-            sdz.ObjectExitedSnapDropZone += ObjectExitedSnapDropZone;
-            sdz.ObjectSnappedToDropZone += ObjectSnappedToDropZone;
-            sdz.ObjectUnsnappedFromDropZone += ObjectUnsnappedFromDropZone;
+            component.ObjectSnappedToDropZone -= ObjectSnappedToDropZone;
+            component.ObjectUnsnappedFromDropZone -= ObjectUnsnappedFromDropZone;
         }
 
         private void ObjectEnteredSnapDropZone(object o, SnapDropZoneEventArgs e)
@@ -69,19 +50,6 @@
         private void ObjectUnsnappedFromDropZone(object o, SnapDropZoneEventArgs e)
         {
             OnObjectUnsnappedFromDropZone.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (sdz == null)
-            {
-                return;
-            }
-
-            sdz.ObjectEnteredSnapDropZone -= ObjectEnteredSnapDropZone;
-            sdz.ObjectExitedSnapDropZone -= ObjectExitedSnapDropZone;
-            sdz.ObjectSnappedToDropZone -= ObjectSnappedToDropZone;
-            sdz.ObjectUnsnappedFromDropZone -= ObjectUnsnappedFromDropZone;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIPointer_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIPointer_UnityEvents.cs
@@ -1,58 +1,35 @@
 ﻿namespace VRTK.UnityEventHelper
 {
-    using UnityEngine;
     using UnityEngine.Events;
+    using System;
 
-    [RequireComponent(typeof(VRTK_UIPointer))]
-    public class VRTK_UIPointer_UnityEvents : MonoBehaviour
+    public sealed class VRTK_UIPointer_UnityEvents : VRTK_UnityEvents<VRTK_UIPointer>
     {
-        private VRTK_UIPointer uip;
+        [Serializable]
+        public sealed class UIPointerEvent : UnityEvent<object, UIPointerEventArgs> { }
 
-        [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<object, UIPointerEventArgs> { };
+        public UIPointerEvent OnUIPointerElementEnter = new UIPointerEvent();
+        public UIPointerEvent OnUIPointerElementExit = new UIPointerEvent();
+        public UIPointerEvent OnUIPointerElementClick = new UIPointerEvent();
+        public UIPointerEvent OnUIPointerElementDragStart = new UIPointerEvent();
+        public UIPointerEvent OnUIPointerElementDragEnd = new UIPointerEvent();
 
-        /// <summary>
-        /// Emits the UIPointerElementEnter class event.
-        /// </summary>
-        public UnityObjectEvent OnUIPointerElementEnter = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the UIPointerElementExit class event.
-        /// </summary>
-        public UnityObjectEvent OnUIPointerElementExit = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the UIPointerElementClick class event.
-        /// </summary>
-        public UnityObjectEvent OnUIPointerElementClick = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the UIPointerElementDragStart class event.
-        /// </summary>
-        public UnityObjectEvent OnUIPointerElementDragStart = new UnityObjectEvent();
-        /// <summary>
-        /// Emits the UIPointerElementDragEnd class event.
-        /// </summary>
-        public UnityObjectEvent OnUIPointerElementDragEnd = new UnityObjectEvent();
-
-        private void SetUIPointer()
+        protected override void AddListeners(VRTK_UIPointer component)
         {
-            if (uip == null)
-            {
-                uip = GetComponent<VRTK_UIPointer>();
-            }
+            component.UIPointerElementEnter += UIPointerElementEnter;
+            component.UIPointerElementExit += UIPointerElementExit;
+            component.UIPointerElementClick += UIPointerElementClick;
+            component.UIPointerElementDragStart += UIPointerElementDragStart;
+            component.UIPointerElementDragEnd += UIPointerElementDragEnd;
         }
 
-        private void OnEnable()
+        protected override void RemoveListeners(VRTK_UIPointer component)
         {
-            SetUIPointer();
-            if (uip == null)
-            {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, new string[] { "VRTK_UIPointer_UnityEvents", "VRTK_UIPointer", "the same" }));
-                return;
-            }
-            uip.UIPointerElementEnter += UIPointerElementEnter;
-            uip.UIPointerElementExit += UIPointerElementExit;
-            uip.UIPointerElementClick += UIPointerElementClick;
-            uip.UIPointerElementDragStart += UIPointerElementDragStart;
-            uip.UIPointerElementDragEnd += UIPointerElementDragEnd;
+            component.UIPointerElementEnter -= UIPointerElementEnter;
+            component.UIPointerElementExit -= UIPointerElementExit;
+            component.UIPointerElementClick -= UIPointerElementClick;
+            component.UIPointerElementDragStart -= UIPointerElementDragStart;
+            component.UIPointerElementDragEnd -= UIPointerElementDragEnd;
         }
 
         private void UIPointerElementEnter(object o, UIPointerEventArgs e)
@@ -78,20 +55,6 @@
         private void UIPointerElementDragEnd(object o, UIPointerEventArgs e)
         {
             OnUIPointerElementDragEnd.Invoke(o, e);
-        }
-
-        private void OnDisable()
-        {
-            if (uip == null)
-            {
-                return;
-            }
-
-            uip.UIPointerElementEnter -= UIPointerElementEnter;
-            uip.UIPointerElementExit -= UIPointerElementExit;
-            uip.UIPointerElementClick -= UIPointerElementClick;
-            uip.UIPointerElementDragStart -= UIPointerElementDragStart;
-            uip.UIPointerElementDragEnd -= UIPointerElementDragEnd;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UnityEvents.cs
@@ -1,0 +1,36 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+
+    public abstract class VRTK_UnityEvents<T> : MonoBehaviour where T : Component
+    {
+        private T component;
+
+        protected abstract void AddListeners(T component);
+        protected abstract void RemoveListeners(T component);
+
+        protected virtual void OnEnable()
+        {
+            component = GetComponent<T>();
+
+            if (component != null)
+            {
+                AddListeners(component);
+            }
+            else
+            {
+                string eventsScriptName = GetType().Name;
+                string scriptName = component.GetType().Name;
+                VRTK_Logger.Error(string.Format("The {0} script requires to be attached to a GameObject that contains a {1} script.", eventsScriptName, scriptName));
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (component != null)
+            {
+                RemoveListeners(component);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UnityEvents.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 554c9c8139a844ed9d63e5e2fd3e33ea
+timeCreated: 1490445353


### PR DESCRIPTION
A new abstract superclass `VRTK_UnityEvents` has been added to simplify
and standardize the various existing UnityEvents scripts. Additionally
all the xml docs have been removed from the UnityEvents scripts because
they add nothing to the documentation (the documentation already refers
to have a look at the respective scripts' documentation to learn more
about the events).