### PR TITLE
fix(SDK): find inactive game objects and components

### DIFF
--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -172,7 +172,7 @@ namespace VRTK
             controller = GetSDKManagerControllerRightHand(actual);
             if ((controller == null) && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<GvrControllerVisualManager>("/Controller");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<GvrControllerVisualManager>("Controller");
             }
             if (controller != null)
             {

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
@@ -36,7 +36,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                var ovrManager = FindObjectOfType<OVRManager>();
+                var ovrManager = VRTK_SharedMethods.FindEvenInactiveComponent<OVRManager>();
                 if (ovrManager)
                 {
                     cachedPlayArea = ovrManager.transform;
@@ -107,7 +107,7 @@ namespace VRTK
         {
             if (avatarContainer == null)
             {
-                avatarContainer = FindObjectOfType<OvrAvatar>();
+                avatarContainer = VRTK_SharedMethods.FindEvenInactiveComponent<OvrAvatar>();
                 if (avatarContainer != null && avatarContainer.GetComponent<VRTK_TransformFollow>() == null)
                 {
                     var objectFollow = avatarContainer.gameObject.AddComponent<VRTK_TransformFollow>();

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
@@ -191,7 +191,7 @@ namespace VRTK
             var controller = GetSDKManagerControllerLeftHand(actual);
             if (!controller && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("/TrackingSpace/LeftHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/LeftHandAnchor");
             }
             return controller;
         }
@@ -206,7 +206,7 @@ namespace VRTK
             var controller = GetSDKManagerControllerRightHand(actual);
             if (!controller && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("/TrackingSpace/RightHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/RightHandAnchor");
             }
             return controller;
         }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRHeadset.cs
@@ -52,7 +52,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                cachedHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("/TrackingSpace/CenterEyeAnchor").transform;
+                cachedHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/CenterEyeAnchor").transform;
             }
             return cachedHeadset;
         }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -33,7 +33,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                var steamVRPlayArea = FindObjectOfType<SteamVR_PlayArea>();
+                var steamVRPlayArea = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_PlayArea>();
                 if (steamVRPlayArea)
                 {
                     cachedPlayArea = steamVRPlayArea.transform;

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -190,7 +190,7 @@ namespace VRTK
             var controller = GetSDKManagerControllerLeftHand(actual);
             if (!controller && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("/Controller (left)");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("Controller (left)");
             }
             return controller;
         }
@@ -205,7 +205,7 @@ namespace VRTK
             var controller = GetSDKManagerControllerRightHand(actual);
             if (!controller && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("/Controller (right)");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("Controller (right)");
             }
             return controller;
         }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -44,9 +44,9 @@ namespace VRTK
             if (cachedHeadset == null)
             {
 #if (UNITY_5_4_OR_NEWER)
-                var foundCamera = FindObjectOfType<SteamVR_Camera>();
+                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
 #else
-                var foundCamera = FindObjectOfType<SteamVR_GameView>();
+                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_GameView>();
 #endif
                 if (foundCamera)
                 {
@@ -65,7 +65,7 @@ namespace VRTK
             cachedHeadsetCamera = GetSDKManagerHeadset();
             if (cachedHeadsetCamera == null)
             {
-                var foundCamera = FindObjectOfType<SteamVR_Camera>();
+                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
                 if (foundCamera)
                 {
                     cachedHeadsetCamera = foundCamera.transform;

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRController.cs
@@ -200,7 +200,7 @@ namespace VRTK
             var controller = GetSDKManagerControllerLeftHand(actual);
             if (!controller && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("/TrackingSpace/LeftHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/LeftHandAnchor");
             }
             return controller;
         }
@@ -215,7 +215,7 @@ namespace VRTK
             var controller = GetSDKManagerControllerRightHand(actual);
             if (!controller && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("/TrackingSpace/RightHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/RightHandAnchor");
             }
             return controller;
         }

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRHeadset.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRHeadset.cs
@@ -78,7 +78,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                var foundCamera = FindObjectOfType<TrackedHead>();
+                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<TrackedHead>();
                 if (foundCamera)
                 {
                     cachedHeadset = foundCamera.transform;


### PR DESCRIPTION
The SDK classes need to search for some game objects or components. This
fix makes sure that the search for active as well as inactive game
objects and components always works.