### PR TITLE
refactor(Simulator): remove duplicated code

### DIFF
--- a/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
@@ -68,16 +68,7 @@ namespace VRTK
         /// <returns>A transform of the object holding the headset camera in the scene.</returns>
         public override Transform GetHeadsetCamera()
         {
-            if (camera == null)
-            {
-                GameObject simPlayer = SDK_InputSimulator.FindInScene();
-                if (simPlayer)
-                {
-                    camera = simPlayer.transform.FindChild("Camera");
-                }
-            }
-
-            return camera;
+            return GetHeadset();
         }
 
         /// <summary>


### PR DESCRIPTION
The Simulator Headset SDK does the same for both the headset getter
methods. This change removes one of the implementations and calls the
other one instead to remove the duplicated code.