### PR TITLE
feat(SnapDropZone): add custom material property for zone highlighter

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -65,6 +65,8 @@ namespace VRTK
         public float snapDuration = 0f;
         [Tooltip("If this is checked then the scaled size of the snap drop zone will be applied to the object that is snapped to it.")]
         public bool applyScalingOnSnap = false;
+        [Tooltip("A custom material to use on the highlighted object. The highlight color will be applied to this material.")]
+        public Material customMaterial;
         [Tooltip("The colour to use when showing the snap zone is active.")]
         public Color highlightColor;
         [Tooltip("The highlight object will always be displayed when the snap drop zone is available even if a valid item isn't being hovered over.")]
@@ -685,6 +687,10 @@ namespace VRTK
             if (existingHighlighter == null)
             {
                 highlightObject.AddComponent<VRTK_MaterialColorSwapHighlighter>();
+                if (customMaterial)
+                {
+                    highlightObject.GetComponent<VRTK_MaterialColorSwapHighlighter>().customMaterial = customMaterial;
+                }
             }
             else
             {


### PR DESCRIPTION
There is now a an optional property for adding a custom
material to the snap zone. If present this material will
be passed to the zones highlighter component.