### PR TITLE
fix(Logger): saved to scene in Editor

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs
@@ -56,7 +56,10 @@
         {
             if (instance == null)
             {
-                GameObject loggerObject = new GameObject("[VRTK_Logger]");
+                GameObject loggerObject = new GameObject("[VRTK_Logger]")
+                {
+                    hideFlags = HideFlags.DontSaveInEditor | HideFlags.HideInHierarchy
+                };
                 instance = loggerObject.AddComponent<VRTK_Logger>();
                 instance.minLevel = LogLevels.Trace;
                 instance.throwExceptions = true;
@@ -164,12 +167,12 @@
             if (instance == null)
             {
                 instance = this;
+                DontDestroyOnLoad(gameObject);
             }
             else if (instance != this)
             {
                 Destroy(gameObject);
             }
-            DontDestroyOnLoad(gameObject);
         }
     }
 }


### PR DESCRIPTION
If the Logger was used in the Editor to log something it was added to
scene. This fix makes sure the Logger isn't visible in and is not saved
to the scene when in the Editor.
Additionally the `DontDestroyOnLoad` call has been moved to not be
called when destroying the object anyway.