### PR TITLE
feat(SDK): add methods to get/set boundary draw status

### DIFF
--- a/Assets/VRTK/SDK/Base/SDK_BaseBoundaries.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseBoundaries.cs
@@ -45,6 +45,18 @@ namespace VRTK
         /// <returns>Returns true if the play area size has been auto calibrated and set by external sensors.</returns>
         public abstract bool IsPlayAreaSizeCalibrated(GameObject playArea);
 
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public abstract bool GetDrawAtRuntime();
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public abstract void SetDrawAtRuntime(bool value);
+
         protected Transform GetSDKManagerPlayArea()
         {
             var sdkManager = VRTK_SDKManager.instance;

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamBoundaries.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamBoundaries.cs
@@ -87,6 +87,23 @@ namespace VRTK
         {
             return true;
         }
+
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public override bool GetDrawAtRuntime()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public override void SetDrawAtRuntime(bool value)
+        {
+        }
 #endif
     }
 }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackBoundaries.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackBoundaries.cs
@@ -66,5 +66,22 @@ namespace VRTK
         {
             return false;
         }
+
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public override bool GetDrawAtRuntime()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public override void SetDrawAtRuntime(bool value)
+        {
+        }
     }
 }

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRBoundaries.cs
@@ -96,6 +96,23 @@ namespace VRTK
             return true;
         }
 
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public override bool GetDrawAtRuntime()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public override void SetDrawAtRuntime(bool value)
+        {
+        }
+
 #if VRTK_DEFINE_SDK_OCULUSVR_AVATAR
         private OvrAvatar avatarContainer;
 

--- a/Assets/VRTK/SDK/Simulator/SDK_SimBoundaries.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimBoundaries.cs
@@ -74,5 +74,22 @@ namespace VRTK
         {
             return true;
         }
+
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public override bool GetDrawAtRuntime()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public override void SetDrawAtRuntime(bool value)
+        {
+        }
     }
 }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -17,6 +17,8 @@ namespace VRTK
 #endif
     {
 #if VRTK_DEFINE_SDK_STEAMVR
+        protected SteamVR_PlayArea cachedSteamVRPlayArea;
+
         /// <summary>
         /// The InitBoundaries method is run on start of scene and can be used to initialse anything on game start.
         /// </summary>
@@ -34,8 +36,9 @@ namespace VRTK
             if (cachedPlayArea == null)
             {
                 var steamVRPlayArea = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_PlayArea>();
-                if (steamVRPlayArea)
+                if (steamVRPlayArea != null)
                 {
+                    cachedSteamVRPlayArea = steamVRPlayArea;
                     cachedPlayArea = steamVRPlayArea.transform;
                 }
             }
@@ -49,8 +52,8 @@ namespace VRTK
         /// <returns>A Vector3 array of the points in the scene that represent the play area boundaries.</returns>
         public override Vector3[] GetPlayAreaVertices(GameObject playArea)
         {
-            var area = playArea.GetComponent<SteamVR_PlayArea>();
-            if (area)
+            SteamVR_PlayArea area = GetCachedSteamVRPlayArea();
+            if (area != null)
             {
                 return area.vertices;
             }
@@ -64,8 +67,8 @@ namespace VRTK
         /// <returns>The thickness of the drawn border.</returns>
         public override float GetPlayAreaBorderThickness(GameObject playArea)
         {
-            var area = playArea.GetComponent<SteamVR_PlayArea>();
-            if (area)
+            SteamVR_PlayArea area = GetCachedSteamVRPlayArea();
+            if (area != null)
             {
                 return area.borderThickness;
             }
@@ -79,8 +82,46 @@ namespace VRTK
         /// <returns>Returns true if the play area size has been auto calibrated and set by external sensors.</returns>
         public override bool IsPlayAreaSizeCalibrated(GameObject playArea)
         {
-            var area = playArea.GetComponent<SteamVR_PlayArea>();
-            return (area.size == SteamVR_PlayArea.Size.Calibrated);
+            SteamVR_PlayArea area = GetCachedSteamVRPlayArea();
+            return (area != null && area.size == SteamVR_PlayArea.Size.Calibrated);
+        }
+
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public override bool GetDrawAtRuntime()
+        {
+            SteamVR_PlayArea area = GetCachedSteamVRPlayArea();
+            return (area != null ? area.drawInGame : false);
+        }
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public override void SetDrawAtRuntime(bool value)
+        {
+            SteamVR_PlayArea area = GetCachedSteamVRPlayArea();
+            if (area != null)
+            {
+                area.drawInGame = value;
+                area.enabled = true;
+            }
+        }
+
+        protected virtual SteamVR_PlayArea GetCachedSteamVRPlayArea()
+        {
+            if (cachedSteamVRPlayArea == null)
+            {
+                Transform checkPlayArea = GetPlayArea();
+                if (checkPlayArea != null)
+                {
+                    cachedSteamVRPlayArea = checkPlayArea.GetComponent<SteamVR_PlayArea>();
+                }
+            }
+
+            return cachedSteamVRPlayArea;
         }
 #endif
     }

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -422,6 +422,16 @@
             return GetBoundariesSDK().IsPlayAreaSizeCalibrated(playArea);
         }
 
+        public static bool GetDrawAtRuntime()
+        {
+            return GetBoundariesSDK().GetDrawAtRuntime();
+        }
+
+        public static void SetDrawAtRuntime(bool value)
+        {
+            GetBoundariesSDK().SetDrawAtRuntime(value);
+        }
+
         public static bool IsDisplayOnDesktop()
         {
             return GetSystemSDK().IsDisplayOnDesktop();

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRBoundaries.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRBoundaries.cs
@@ -77,6 +77,23 @@ namespace VRTK
         {
             return true;
         }
+
+        /// <summary>
+        /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+        /// </summary>
+        /// <returns>Returns true if the drawn border is being displayed.</returns>
+        public override bool GetDrawAtRuntime()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+        /// </summary>
+        /// <param name="value">The state of whether the drawn border should be displayed or not.</param>
+        public override void SetDrawAtRuntime(bool value)
+        {
+        }
 #endif
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3001,11 +3001,6 @@ Adding the `VRTK_InteractGrab_UnityEvents` component to `VRTK_InteractGrab` obje
 
  * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
 
-### Event Payload
-
- * `uint controllerIndex` - The index of the controller doing the interaction.
- * `GameObject target` - The GameObject of the interactable object that is being interacted with by the controller.
-
 ### Class Methods
 
 #### IsGrabButtonPressed/0
@@ -3093,11 +3088,6 @@ If a valid interactable object is usable then pressing the set `Use` button on t
 Adding the `VRTK_InteractUse_UnityEvents` component to `VRTK_InteractUse` object allows access to `UnityEvents` that will react identically to the Class Events.
 
  * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
-
-### Event Payload
-
- * `uint controllerIndex` - The index of the controller doing the interaction.
- * `GameObject target` - The GameObject of the interactable object that is being interacted with by the controller.
 
 ### Class Methods
 
@@ -7580,6 +7570,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
 
+#### GetDrawAtRuntime/0
+
+  > `public abstract bool GetDrawAtRuntime();`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public abstract void SetDrawAtRuntime(bool value);`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+
 ---
 
 # Fallback SDK (VRTK/SDK/Fallback)
@@ -8578,6 +8590,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
 
+#### GetDrawAtRuntime/0
+
+  > `public override bool GetDrawAtRuntime()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public override void SetDrawAtRuntime(bool value)`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+
 ---
 
 # Simulator SDK (VRTK/SDK/Simulator)
@@ -9567,6 +9601,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
    * `bool` - Returns true if the play area size has been auto calibrated and set by external sensors.
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
+
+#### GetDrawAtRuntime/0
+
+  > `public override bool GetDrawAtRuntime()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public override void SetDrawAtRuntime(bool value)`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
 
 ---
 
@@ -10567,6 +10623,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
 
+#### GetDrawAtRuntime/0
+
+  > `public override bool GetDrawAtRuntime()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public override void SetDrawAtRuntime(bool value)`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+
 ---
 
 # OculusVR SDK (VRTK/SDK/OculusVR)
@@ -11566,6 +11644,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
    * `bool` - Returns true if the play area size has been auto calibrated and set by external sensors.
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
+
+#### GetDrawAtRuntime/0
+
+  > `public override bool GetDrawAtRuntime()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public override void SetDrawAtRuntime(bool value)`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
 
 #### GetAvatar/0
 
@@ -12577,6 +12677,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
 
+#### GetDrawAtRuntime/0
+
+  > `public override bool GetDrawAtRuntime()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public override void SetDrawAtRuntime(bool value)`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
+
 ---
 
 # XimmerseVR SDK (VRTK/SDK/Ximmerse)
@@ -13575,6 +13697,28 @@ The GetPlayAreaBorderThickness returns the thickness of the drawn border for the
    * `bool` - Returns true if the play area size has been auto calibrated and set by external sensors.
 
 The IsPlayAreaSizeCalibrated method returns whether the given play area size has been auto calibrated by external sensors.
+
+#### GetDrawAtRuntime/0
+
+  > `public override bool GetDrawAtRuntime()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the drawn border is being displayed.
+
+The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
+
+#### SetDrawAtRuntime/1
+
+  > `public override void SetDrawAtRuntime(bool value)`
+
+  * Parameters
+   * `bool value` - The state of whether the drawn border should be displayed or not.
+  * Returns
+   * _none_
+
+The SetDrawAtRuntime method sets whether the given play area drawn border should be displayed at runtime.
 
 ---
 


### PR DESCRIPTION
The status of whether a play area boundary is drawn can now be
retrieved and set via the SDK Bridge, which bubbles through to the
relevant SDK to check if the boundaries can be drawn.

At present, only SteamVR allows for checking if the boundary can be
drawn via the `SteamVR_PlayArea.drawInGame` variable.

The SteamVR Boundaries SDK has also been tidied up to cache the
GetComponent call to the SteamVR_PlayArea component.