### PR TITLE
fix(Simulator): missing headset fade implementations

### DIFF
--- a/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
@@ -109,7 +109,7 @@ namespace VRTK
         /// <param name="fadeOverlay">Determines whether to use an overlay on the fade.</param>
         public override void HeadsetFade(Color color, float duration, bool fadeOverlay = false)
         {
-
+            VRTK_ScreenFade.Start(color, duration);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace VRTK
         /// <returns>Returns true if the headset has fade functionality on it.</returns>
         public override bool HasHeadsetFade(Transform obj)
         {
-            return false;
+            return obj.GetComponentInChildren<VRTK_ScreenFade>() != null;
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace VRTK
         /// <param name="camera">The Transform to with the camera on to add the fade functionality to.</param>
         public override void AddHeadsetFade(Transform camera)
         {
-            if (camera && !camera.GetComponent<VRTK_ScreenFade>())
+            if (camera != null && camera.GetComponent<VRTK_ScreenFade>() == null)
             {
                 camera.gameObject.AddComponent<VRTK_ScreenFade>();
             }


### PR DESCRIPTION
#1068 added headset fading to the Simulator SDK but actually missed two
other methods that need to be implemented for it to work correctly. This
fix implements those methods.