### PR TITLE
chore(gitattributes): allow asset diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-# .gitattributes
-
-# Treat them as binary files for GitMerge
-*.unity binary
-*.prefab binary
-*.asset binary


### PR DESCRIPTION
The `.gitattributes` file was set up to treat various Unity assets as
binary files but they are in fact text files. To allow diff'ing the
files git needs to treat these files as text files. Since treating files
as text files is the default this change removes the `.gitattributes`
file completely, as it doesn't do anything else.