### PR TITLE
fix(AdaptiveQuality): index out of bounds when using Oculus Utilities

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -481,6 +481,11 @@ namespace VRTK
 
         private void UpdateRenderScale()
         {
+            if (allRenderScales.Count == 0)
+            {
+                return;
+            }
+
             if (!scaleRenderViewport)
             {
                 renderViewportScaleSetting.currentValue = defaultRenderViewportScaleLevel;


### PR DESCRIPTION
> LateUpdate: LateUpdate is called once per frame, after Update has
> finished. Any calculations that are performed in Update will have
> completed when LateUpdate begins.

This is not the case anymore in Unity 5.5.3f1 when using the Oculus
SDK. The fix is to make sure `UpdateRenderScaleLevels` was called
before accessing `allRenderScales` in `UpdateRenderScale`.