### PR TITLE
fix(Logger): usage when serialization runs

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_Logger.cs
@@ -1,10 +1,13 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+#if UNITY_EDITOR
+    using UnityEditor;
+#endif
     using System;
     using System.Collections.Generic;
-    using System.Text.RegularExpressions;
     using System.Linq;
+    using System.Text.RegularExpressions;
 
     public class VRTK_Logger : MonoBehaviour
     {
@@ -52,6 +55,9 @@
         public LogLevels minLevel = LogLevels.Trace;
         public bool throwExceptions = true;
 
+#if UNITY_EDITOR
+        [InitializeOnLoadMethod]
+#endif
         public static void CreateIfNotExists()
         {
             if (instance == null)
@@ -149,7 +155,7 @@
                 case LogLevels.Fatal:
                     if (instance.throwExceptions)
                     {
-                        throw new System.Exception(message);
+                        throw new Exception(message);
                     }
                     else
                     {


### PR DESCRIPTION
Whenever the Unity serialization runs the serialization callbacks in SDK
Info are run. Since those methods were updated to use the VRTK Logger
Unity now throws errors because it's not allowed to create new game
objects while Unity is serializing. The fix is to always create an
instance of the VRTK Logger in the Editor.