### PR TITLE
fix(SDK): name based controller lookup

### DIFF
--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -98,21 +98,11 @@ namespace VRTK
         /// <returns>The index of the given controller.</returns>
         public override uint GetControllerIndex(GameObject controller)
         {
-            uint index = 0;
-
-            switch (controller.name)
+            if (CheckActualOrScriptAliasControllerIsRightHand(controller))
             {
-                case "Camera":
-                    index = 0;
-                    break;
-                case "RightController":
-                    index = 1;
-                    break;
-                case "LeftController":
-                    index = uint.MaxValue;
-                    break;
+                return 1;
             }
-            return index;
+            return uint.MaxValue;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -99,21 +99,15 @@ namespace VRTK
         /// <returns>The index of the given controller.</returns>
         public override uint GetControllerIndex(GameObject controller)
         {
-            uint index = 0;
-
-            switch (controller.name)
+            if (CheckActualOrScriptAliasControllerIsRightHand(controller))
             {
-                case "Camera":
-                    index = 0;
-                    break;
-                case "RightController":
-                    index = 1;
-                    break;
-                case "LeftController":
-                    index = 2;
-                    break;
+                return 1;
             }
-            return index;
+            if (CheckActualOrScriptAliasControllerIsLeftHand(controller))
+            {
+                return 2;
+            }
+            return uint.MaxValue;
         }
 
         /// <summary>


### PR DESCRIPTION
The Simulator and Daydream Controller SDKs looked up the controller
index by using the names of the game objects. To be more flexible and
allow other names, too, this fix uses the helper method available in the
base SDK class instead.
Additionally both Controller SDKs no longer return an index for the
headset because Controller SDKs should only care about controllers.

This fixes #1109.