### PR TITLE
fix(Pointers): do not raise the DestinationMarkerEnter event every frame

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -169,9 +169,9 @@ namespace VRTK
                 if (pointerCollidedWith.collider && pointerCollidedWith.collider != destinationHit.collider)
                 {
                     PointerEnter(pointerCollidedWith);
-                    ChangeColor(validCollisionColor);
                 }
                 destinationHit = pointerCollidedWith;
+                ChangeColor(validCollisionColor);
             }
         }
 

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -166,10 +166,12 @@ namespace VRTK
         {
             if (rayHit)
             {
-                PointerEnter(pointerCollidedWith);
-
+                if (pointerCollidedWith.collider && pointerCollidedWith.collider != destinationHit.collider)
+                {
+                    PointerEnter(pointerCollidedWith);
+                    ChangeColor(validCollisionColor);
+                }
                 destinationHit = pointerCollidedWith;
-                ChangeColor(validCollisionColor);
             }
         }
 


### PR DESCRIPTION
The DestinationMarker**Exit** event is raised _once_ when the pointer detects no more hits or if a different collider is hit.

The DestinationMarker**Enter** event on the other hand is raised every frame while there is a hit detected (see the flooded console in example scene 003). I think it should only be called once for the initial hit of a collider.

This PR fixes this and makes the Pointer raise these events in pairs. Maybe a different DestinationMarkerPoint event could be raised every frame instead.

