### PR TITLE
fix(UIPointer): ensure pointer events are cleaned with invalid state - fixes #1110

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
@@ -235,6 +235,7 @@
             {
                 if (!ValidElement(pointer.pointerEventData.pointerPress))
                 {
+                    pointer.pointerEventData.pointerPress = null;
                     return true;
                 }
 
@@ -266,6 +267,7 @@
             {
                 if (!ValidElement(pointer.pointerEventData.pointerDrag))
                 {
+                    pointer.pointerEventData.pointerDrag = null;
                     return;
                 }
 


### PR DESCRIPTION
The VR Input Model was not cleaning up the pointer event data on
invalid element states, meaning if a canvas was disabled during a
UI action then the pointer event data would be incorrect and would
cause issues.