### PR TITLE
feat(DestinationMarker): add hover event

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerPointerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerPointerEvents_ListenerExample.cs
@@ -4,6 +4,8 @@
 
     public class VRTK_ControllerPointerEvents_ListenerExample : MonoBehaviour
     {
+        public bool showHoverState = false;
+
         private void Start()
         {
             if (GetComponent<VRTK_DestinationMarker>() == null)
@@ -14,6 +16,10 @@
 
             //Setup controller event listeners
             GetComponent<VRTK_DestinationMarker>().DestinationMarkerEnter += new DestinationMarkerEventHandler(DoPointerIn);
+            if (showHoverState)
+            {
+                GetComponent<VRTK_DestinationMarker>().DestinationMarkerHover += new DestinationMarkerEventHandler(DoPointerHover);
+            }
             GetComponent<VRTK_DestinationMarker>().DestinationMarkerExit += new DestinationMarkerEventHandler(DoPointerOut);
             GetComponent<VRTK_DestinationMarker>().DestinationMarkerSet += new DestinationMarkerEventHandler(DoPointerDestinationSet);
         }
@@ -33,6 +39,11 @@
         private void DoPointerOut(object sender, DestinationMarkerEventArgs e)
         {
             DebugLogger(e.controllerIndex, "POINTER OUT", e.target, e.raycastHit, e.distance, e.destinationPosition);
+        }
+
+        private void DoPointerHover(object sender, DestinationMarkerEventArgs e)
+        {
+            DebugLogger(e.controllerIndex, "POINTER HOVER", e.target, e.raycastHit, e.distance, e.destinationPosition);
         }
 
         private void DoPointerDestinationSet(object sender, DestinationMarkerEventArgs e)

--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -148,7 +148,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The PointerEnter method emits a DestinationMarkerEnter event when the pointer enters a valid object.
+        /// The PointerEnter method emits a DestinationMarkerEnter event when the pointer first enters a valid object, it emits a DestinationMarkerHover for every following frame that the pointer stays over the valid object.
         /// </summary>
         /// <param name="givenHit">The valid collision.</param>
         public virtual void PointerEnter(RaycastHit givenHit)
@@ -156,7 +156,15 @@ namespace VRTK
             if (enabled && givenHit.transform != null && controllerIndex < uint.MaxValue)
             {
                 SetHoverSelectionTimer(givenHit.collider);
-                OnDestinationMarkerEnter(SetDestinationMarkerEvent(givenHit.distance, givenHit.transform, givenHit, givenHit.point, controllerIndex, false, GetCursorRotation()));
+                DestinationMarkerEventArgs destinationEventArgs = SetDestinationMarkerEvent(givenHit.distance, givenHit.transform, givenHit, givenHit.point, controllerIndex, false, GetCursorRotation());
+                if (pointerRenderer != null && givenHit.collider != pointerRenderer.GetDestinationHit().collider)
+                {
+                    OnDestinationMarkerEnter(destinationEventArgs);
+                }
+                else
+                {
+                    OnDestinationMarkerHover(destinationEventArgs);
+                }
                 StartUseAction(givenHit.transform);
             }
         }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
@@ -10,12 +10,14 @@
 
         public DestinationMarkerEvent OnDestinationMarkerEnter = new DestinationMarkerEvent();
         public DestinationMarkerEvent OnDestinationMarkerExit = new DestinationMarkerEvent();
+        public DestinationMarkerEvent OnDestinationMarkerHover = new DestinationMarkerEvent();
         public DestinationMarkerEvent OnDestinationMarkerSet = new DestinationMarkerEvent();
 
         protected override void AddListeners(VRTK_DestinationMarker component)
         {
             component.DestinationMarkerEnter += DestinationMarkerEnter;
             component.DestinationMarkerExit += DestinationMarkerExit;
+            component.DestinationMarkerHover += DestinationMarkerHover;
             component.DestinationMarkerSet += DestinationMarkerSet;
         }
 
@@ -23,6 +25,7 @@
         {
             component.DestinationMarkerEnter -= DestinationMarkerEnter;
             component.DestinationMarkerExit -= DestinationMarkerExit;
+            component.DestinationMarkerHover -= DestinationMarkerHover;
             component.DestinationMarkerSet -= DestinationMarkerSet;
         }
 
@@ -34,6 +37,11 @@
         private void DestinationMarkerExit(object o, DestinationMarkerEventArgs e)
         {
             OnDestinationMarkerExit.Invoke(o, e);
+        }
+
+        private void DestinationMarkerHover(object o, DestinationMarkerEventArgs e)
+        {
+            OnDestinationMarkerHover.Invoke(o, e);
         }
 
         private void DestinationMarkerSet(object o, DestinationMarkerEventArgs e)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -936,8 +936,8 @@ It is utilised by the `VRTK_BasePointer` for dealing with pointer events when th
 
 ### Class Events
 
- * `DestinationMarkerEnter` - Emitted when a collision with another game object has occurred.
- * `DestinationMarkerExit` - Emitted when the collision with the other game object finishes.
+ * `DestinationMarkerEnter` - Emitted when a collision with another collider has first occurred.
+ * `DestinationMarkerExit` - Emitted when the collision with the other collider ends.
  * `DestinationMarkerSet` - Emitted when the destination marker is active in the scene to determine the last destination position (useful for selecting and teleporting).
 
 ### Unity Events
@@ -991,6 +991,17 @@ The SetNavMeshCheckDistance method sets the max distance the destination marker 
    * _none_
 
 The SetHeadsetPositionCompensation method determines whether the offset position of the headset from the centre of the play area should be taken into consideration when setting the destination marker. If `true` then it will take the offset position into consideration.
+
+#### SetForceHoverOnRepeatedEnter/1
+
+  > `public virtual void SetForceHoverOnRepeatedEnter(bool state)`
+
+  * Parameters
+   * `bool state` - The state of whether to force the hover on or off.
+  * Returns
+   * _none_
+
+The SetForceHoverOnRepeatedEnter method is used to set whether the Enter event will forciably call the Hover event if the existing colliding object is the same as it was the previous enter call.
 
 ---
 
@@ -1074,7 +1085,7 @@ The IsSelectionButtonPressed method returns whether the configured activation bu
   * Returns
    * _none_
 
-The PointerEnter method emits a DestinationMarkerEnter event when the pointer enters a valid object.
+The PointerEnter method emits a DestinationMarkerEnter event when the pointer first enters a valid object, it emits a DestinationMarkerHover for every following frame that the pointer stays over the valid object.
 
 #### PointerExit/1
 


### PR DESCRIPTION
The destination marker now also has a hover event state that can
be used to determine if the destination marker is still hovering over
the existing target collider. This enables the Enter event to only
be emitted when the destination marker first enters the collider.

This provides a cleaner solution as Enter/Exit can now be called
only once whilst hover can be called multiple times if required.

The VRTK_Pointer has been updated to call hover if the collider
hasn't changed, and to call enter if the collider does change.

As the Enter event is no longer emitted every frame, this may cause
issues with solutions that were listening for the Enter event for
changes in the destination marker position.

This can still be achieved by calling
`SetForceHoverOnRepeatedEnter(false)` on the destination marker
which will not do the additional check when calling the Enter event
that propagates the continued enter to the Hover event.