### PR TITLE
fix(Locomotion): emit dash teleport events at the correct time

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -163,27 +163,44 @@ namespace VRTK
         {
             if (enableTeleport && ValidLocation(e.target, e.destinationPosition) && e.enableTeleport)
             {
-                OnTeleporting(sender, e);
+                StartTeleport(sender, e);
                 Vector3 newPosition = GetNewPosition(e.destinationPosition, e.target, e.forceDestinationPosition);
                 CalculateBlinkDelay(blinkTransitionSpeed, newPosition);
                 Blink(blinkTransitionSpeed);
-                SetNewPosition(newPosition, e.target, e.forceDestinationPosition);
-                SetNewRotation(e.destinationRotation);
-                OnTeleported(sender, e);
+                Vector3 updatedPosition = SetNewPosition(newPosition, e.target, e.forceDestinationPosition);
+                Quaternion updatedRotation = SetNewRotation(e.destinationRotation);
+                ProcessOrientation(sender, e, updatedPosition, updatedRotation);
+                EndTeleport(sender, e);
             }
         }
 
-        protected virtual void SetNewPosition(Vector3 position, Transform target, bool forceDestinationPosition)
+        protected virtual void StartTeleport(object sender, DestinationMarkerEventArgs e)
         {
-            playArea.position = CheckTerrainCollision(position, target, forceDestinationPosition);
+            OnTeleporting(sender, e);
         }
 
-        protected virtual void SetNewRotation(Quaternion? rotation)
+        protected virtual void ProcessOrientation(object sender, DestinationMarkerEventArgs e, Vector3 updatedPosition, Quaternion updatedRotation)
+        {
+        }
+
+        protected virtual void EndTeleport(object sender, DestinationMarkerEventArgs e)
+        {
+            OnTeleported(sender, e);
+        }
+
+        protected virtual Vector3 SetNewPosition(Vector3 position, Transform target, bool forceDestinationPosition)
+        {
+            playArea.position = CheckTerrainCollision(position, target, forceDestinationPosition);
+            return playArea.position;
+        }
+
+        protected virtual Quaternion SetNewRotation(Quaternion? rotation)
         {
             if (rotation != null)
             {
                 playArea.rotation = (Quaternion)rotation;
             }
+            return playArea.rotation;
         }
 
         protected virtual Vector3 GetNewPosition(Vector3 tipPosition, Transform target, bool returnOriginalPosition)

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_DashTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_DashTeleport.cs
@@ -83,13 +83,26 @@ namespace VRTK
             minDistanceForNormalLerp = minSpeedMps * normalLerpTime; // default values give 5.0f
         }
 
-        protected override void SetNewPosition(Vector3 position, Transform target, bool forceDestinationPosition)
+        protected override Vector3 SetNewPosition(Vector3 position, Transform target, bool forceDestinationPosition)
         {
-            Vector3 targetPosition = CheckTerrainCollision(position, target, forceDestinationPosition);
-            StartCoroutine(lerpToPosition(targetPosition, target));
+            return CheckTerrainCollision(position, target, forceDestinationPosition);
         }
 
-        protected virtual IEnumerator lerpToPosition(Vector3 targetPosition, Transform target)
+        protected override void StartTeleport(object sender, DestinationMarkerEventArgs e)
+        {
+            base.StartTeleport(sender, e);
+        }
+
+        protected override void ProcessOrientation(object sender, DestinationMarkerEventArgs e, Vector3 newPosition, Quaternion newRotation)
+        {
+            StartCoroutine(lerpToPosition(sender, e, newPosition));
+        }
+
+        protected override void EndTeleport(object sender, DestinationMarkerEventArgs e)
+        {
+        }
+
+        protected virtual IEnumerator lerpToPosition(object sender, DestinationMarkerEventArgs e, Vector3 targetPosition)
         {
             enableTeleport = false;
             bool gameObjectInTheWay = false;
@@ -107,7 +120,7 @@ namespace VRTK
 
             foreach (RaycastHit hit in allHits)
             {
-                gameObjectInTheWay = hit.collider.gameObject != target.gameObject ? true : false;
+                gameObjectInTheWay = (hit.collider.gameObject != e.target.gameObject ? true : false);
             }
 
             if (gameObjectInTheWay)
@@ -149,6 +162,7 @@ namespace VRTK
                 OnDashedThruObjects(SetDashTeleportEvent(allHits));
             }
 
+            base.EndTeleport(sender, e);
             gameObjectInTheWay = false;
             enableTeleport = true;
         }


### PR DESCRIPTION
Previously, the OnTeleporting and OnTeleported event were being emitted
at the same time in the Dash Teleporter, because the events are both
emitted when the `DoTeleport` method is called. However, as the dash
uses a co-routine to set the position, the destination location can
take a certain amount of time be reached so the OnTeleported event
needed to be emitted after that co-routine had finished.

To fix this, a collection of new overridable methods have been added
that break up the functionality of the `DoTeleport` method and allow
the Dash Teleport script to omit the OnTeleported event and then
manually emit it when required in the co-routine.