### PR TITLE
fix(Interaction): recognize touchpad axis movement on oculus touch

### DIFF
--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -275,6 +275,15 @@ namespace VRTK
         public abstract Vector3 GetAngularVelocity(VRTK_ControllerReference controllerReference);
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public abstract bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity);
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -301,6 +301,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return (!isTouched || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+        }
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -233,6 +233,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return (!isTouched || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+        }
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
+++ b/Assets/VRTK/SDK/OculusVR/SDK_OculusVRController.cs
@@ -395,6 +395,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return (VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+        }
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -338,6 +338,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return (!isTouched || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+        }
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -377,6 +377,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return (!isTouched || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+        }
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -169,6 +169,11 @@
             return GetControllerSDK().GetAngularVelocity(controllerReference);
         }
 
+        public static bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return GetControllerSDK().IsTouchpadStatic(isTouched, currentAxisValues, previousAxisValues, compareFidelity);
+        }
+
         public static Vector2 GetControllerAxis(SDK_BaseController.ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
         {
             return GetControllerSDK().GetButtonAxis(buttonType, controllerReference);

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseVRController.cs
@@ -401,6 +401,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+        /// </summary>
+        /// <param name="currentAxisValues"></param>
+        /// <param name="previousAxisValues"></param>
+        /// <param name="compareFidelity"></param>
+        /// <returns>Returns true if the touchpad is not currently being touched or moved.</returns>
+        public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)
+        {
+            return (!isTouched || VRTK_SharedMethods.Vector2ShallowCompare(currentAxisValues, previousAxisValues, compareFidelity));
+        }
+
+        /// <summary>
         /// The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
         /// </summary>
         /// <param name="buttonType">The type of button to check for the axis on.</param>

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -1176,7 +1176,7 @@ namespace VRTK
 
             //Trigger Axis
             currentTriggerAxis.x = ((!triggerTouched && triggerAxisZeroOnUntouch) || currentTriggerAxis.x < triggerForceZeroThreshold ? 0f : currentTriggerAxis.x);
-            if (Vector2ShallowEquals(triggerAxis, currentTriggerAxis))
+            if (VRTK_SharedMethods.Vector2ShallowCompare(triggerAxis, currentTriggerAxis, axisFidelity))
             {
                 triggerAxisChanged = false;
             }
@@ -1241,7 +1241,7 @@ namespace VRTK
 
             //Grip Axis
             currentGripAxis.x = ((!gripTouched && gripAxisZeroOnUntouch) || currentGripAxis.x < gripForceZeroThreshold ? 0f : currentGripAxis.x);
-            if (Vector2ShallowEquals(gripAxis, currentGripAxis))
+            if (VRTK_SharedMethods.Vector2ShallowCompare(gripAxis, currentGripAxis, axisFidelity))
             {
                 gripAxisChanged = false;
             }
@@ -1278,7 +1278,7 @@ namespace VRTK
             }
 
             //Touchpad Axis
-            if (!touchpadTouched || Vector2ShallowEquals(touchpadAxis, currentTouchpadAxis))
+            if (VRTK_SDK_Bridge.IsTouchpadStatic(touchpadTouched, touchpadAxis, currentTouchpadAxis, axisFidelity))
             {
                 touchpadAxisChanged = false;
             }
@@ -1839,13 +1839,6 @@ namespace VRTK
             }
         }
 #pragma warning restore 0618
-
-        protected virtual bool Vector2ShallowEquals(Vector2 vectorA, Vector2 vectorB)
-        {
-            var distanceVector = vectorA - vectorB;
-            return Math.Round(Mathf.Abs(distanceVector.x), axisFidelity, MidpointRounding.AwayFromZero) < float.Epsilon
-                   && Math.Round(Mathf.Abs(distanceVector.y), axisFidelity, MidpointRounding.AwayFromZero) < float.Epsilon;
-        }
 
         protected virtual void DisableEvents()
         {

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -5,6 +5,7 @@ namespace VRTK
 #if UNITY_EDITOR
     using UnityEditor;
 #endif
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -161,7 +162,7 @@ namespace VRTK
         /// <returns>The new colour with the darken applied.</returns>
         public static Color ColorDarken(Color color, float percent)
         {
-            return new Color(ColorPercent(color.r, percent), ColorPercent(color.g, percent), ColorPercent(color.b, percent), color.a);
+            return new Color(NumberPercent(color.r, percent), NumberPercent(color.g, percent), NumberPercent(color.b, percent), color.a);
         }
 
         /// <summary>
@@ -409,7 +410,7 @@ namespace VRTK
         /// </remarks>
         /// <typeparam name="T">The component type to search for. Must be a subclass of <see cref="Object"/>.</typeparam>
         /// <returns>All the found components. If no component is found an empty array is returned.</returns>
-        public static T[] FindEvenInactiveComponents<T>() where T : Object
+        public static T[] FindEvenInactiveComponents<T>() where T : UnityEngine.Object
         {
             return Resources.FindObjectsOfTypeAll<T>()
 #if UNITY_EDITOR
@@ -477,7 +478,27 @@ namespace VRTK
 #endif
         }
 
-        private static float ColorPercent(float value, float percent)
+        /// <summary>
+        /// The Vector2ShallowCompare method compares two given Vector2 objects based on the given fidelity, which is the equivalent of comparing rounded Vector2 elements to determine if the Vector2 elements are equal.
+        /// </summary>
+        /// <param name="vectorA">The Vector2 to compare against.</param>
+        /// <param name="vectorB">The Vector2 to compare with</param>
+        /// <param name="compareFidelity">The number of decimal places to use when doing the comparison on the float elements within the Vector2.</param>
+        /// <returns>Returns true if the given Vector2 objects match based on the given fidelity.</returns>
+        public static bool Vector2ShallowCompare(Vector2 vectorA, Vector2 vectorB, int compareFidelity)
+        {
+            var distanceVector = vectorA - vectorB;
+            return (Math.Round(Mathf.Abs(distanceVector.x), compareFidelity, MidpointRounding.AwayFromZero) < float.Epsilon &&
+                    Math.Round(Mathf.Abs(distanceVector.y), compareFidelity, MidpointRounding.AwayFromZero) < float.Epsilon);
+        }
+
+        /// <summary>
+        /// The NumberPercent method is used to determine the percentage of a given value.
+        /// </summary>
+        /// <param name="value">The value to determine the percentage from</param>
+        /// <param name="percent">The percentage to find within the given value.</param>
+        /// <returns>A float containing the percentage value based on the given input.</returns>
+        public static float NumberPercent(float value, float percent)
         {
             percent = Mathf.Clamp(percent, 0f, 100f);
             return (percent == 0f ? value : (value - (percent / 100f)));

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6262,7 +6262,7 @@ Finds the first  with a given name and an ancestor that has a specific component
 
 #### FindEvenInactiveComponents<T>/0
 
-  > `public static T[] FindEvenInactiveComponents<T>() where T : Object`
+  > `public static T[] FindEvenInactiveComponents<T>() where T : UnityEngine.Object`
 
   * Type Params
    * `T[]` - The component type to search for. Must be a subclass of .
@@ -6308,6 +6308,31 @@ The GenerateVRTKObjectName method is used to create a standard name string for a
    * `float` - The total GPU time utilized last frame as measured by the VR subsystem.
 
 The GetGPUTimeLastFrame retrieves the time spent by the GPU last frame, in seconds, as reported by the VR SDK.
+
+#### Vector2ShallowCompare/3
+
+  > `public static bool Vector2ShallowCompare(Vector2 vectorA, Vector2 vectorB, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 vectorA` - The Vector2 to compare against.
+   * `Vector2 vectorB` - The Vector2 to compare with
+   * `int compareFidelity` - The number of decimal places to use when doing the comparison on the float elements within the Vector2.
+  * Returns
+   * `bool` - Returns true if the given Vector2 objects match based on the given fidelity.
+
+The Vector2ShallowCompare method compares two given Vector2 objects based on the given fidelity, which is the equivalent of comparing rounded Vector2 elements to determine if the Vector2 elements are equal.
+
+#### NumberPercent/2
+
+  > `public static float NumberPercent(float value, float percent)`
+
+  * Parameters
+   * `float value` - The value to determine the percentage from
+   * `float percent` - The percentage to find within the given value.
+  * Returns
+   * `float` - A float containing the percentage value based on the given input.
+
+The NumberPercent method is used to determine the percentage of a given value.
 
 ---
 
@@ -7231,6 +7256,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
 
+#### IsTouchpadStatic/4
+
+  > `public abstract bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity);`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+
 #### GetButtonAxis/2
 
   > `public abstract Vector2 GetButtonAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference);`
@@ -7793,6 +7831,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
 
+#### IsTouchpadStatic/4
+
+  > `public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+
 #### GetButtonAxis/2
 
   > `public override Vector2 GetButtonAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -8348,6 +8399,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
    * `Vector3` - A Vector3 containing the current angular velocity of the tracked object.
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
+
+#### IsTouchpadStatic/4
+
+  > `public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
 
 #### GetButtonAxis/2
 
@@ -8913,6 +8977,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
 
+#### IsTouchpadStatic/4
+
+  > `public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+
 #### GetButtonAxis/2
 
   > `public override Vector2 GetButtonAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -9476,6 +9553,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
    * `Vector3` - A Vector3 containing the current angular velocity of the tracked object.
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
+
+#### IsTouchpadStatic/4
+
+  > `public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
 
 #### GetButtonAxis/2
 
@@ -10051,6 +10141,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
 
+#### IsTouchpadStatic/4
+
+  > `public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
+
 #### GetButtonAxis/2
 
   > `public override Vector2 GetButtonAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -10613,6 +10716,19 @@ The GetVelocity method is used to determine the current velocity of the tracked 
    * `Vector3` - A Vector3 containing the current angular velocity of the tracked object.
 
 The GetAngularVelocity method is used to determine the current angular velocity of the tracked object on the given controller reference.
+
+#### IsTouchpadStatic/4
+
+  > `public override bool IsTouchpadStatic(bool isTouched, Vector2 currentAxisValues, Vector2 previousAxisValues, int compareFidelity)`
+
+  * Parameters
+   * `Vector2 currentAxisValues` -
+   * `Vector2 previousAxisValues` -
+   * `int compareFidelity` -
+  * Returns
+   * `bool` - Returns true if the touchpad is not currently being touched or moved.
+
+The IsTouchpadStatic method is used to determine if the touchpad is currently not being moved.
 
 #### GetButtonAxis/2
 


### PR DESCRIPTION
The Controller Events script was not recognizing the thumbstick axis
changes on the Oculus Touch controllers unless the touch sensitive
pad at the top of the thumbstick was being touched.

This is because the Controller Events script would force set the
touchpad axis to not being moved if no touch of the button was
found.

This works fine on the Vive wand and is wanted as the vive wand
touchpad axis can wander and report changes in axis when it's
not being touched. But for the Oculus Touch, this additional check
is counter productive.

To fix the issue, the check to see if the touchpad is static or not
has been abstracted into the Controller SDK so each SDK can handle
how they want to determine if the touchpad axis is static or not.

The private method used for comparing the touchpad axis values has now
also been moved to the Shared Methods script as it is a useful generic
method that is now also used by the Controller SDK.