### PR TITLE
docs(Deprecation): remove internal deprecation warnings

### DIFF
--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Button.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Button.cs
@@ -24,7 +24,7 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Controls/3D/VRTK_Button")]
     public class VRTK_Button : VRTK_Control
     {
-
+#pragma warning disable 0618
         [Serializable]
         [Obsolete("`VRTK_Control.ButtonEvents` has been replaced with delegate events. `VRTK_Button_UnityEvents` is now required to access Unity events. This method will be removed in a future version of VRTK.")]
         public class ButtonEvents
@@ -466,5 +466,6 @@ namespace VRTK
         {
             return (-activationDir.normalized * buttonStrength);
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Control.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Control.cs
@@ -29,6 +29,7 @@ namespace VRTK
     [ExecuteInEditMode]
     public abstract class VRTK_Control : MonoBehaviour
     {
+#pragma warning disable 0618
         [Serializable]
         [Obsolete("`VRTK_Control.ValueChangedEvent` has been replaced with delegate events. `VRTK_Control_UnityEvents` is now required to access Unity events. This method will be removed in a future version of VRTK.")]
         public class ValueChangedEvent : UnityEvent<float, float> { }
@@ -270,5 +271,6 @@ namespace VRTK
                 io.enabled = value > MIN_OPENING_DISTANCE;
             }
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -42,6 +42,7 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Interactions/VRTK_ControllerEvents")]
     public class VRTK_ControllerEvents : MonoBehaviour
     {
+#pragma warning disable 0618
         /// <summary>
         /// Button types
         /// </summary>
@@ -1948,5 +1949,6 @@ namespace VRTK
                 hairGripDelta = VRTK_SDK_Bridge.GetGripHairlineDeltaOnIndex(controllerIndex);
             }
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -17,6 +17,7 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport")]
     public class VRTK_HeightAdjustTeleport : VRTK_BasicTeleport
     {
+#pragma warning disable 0618
         [Header("Height Adjust Settings")]
 
         [Tooltip("A custom raycaster to use when raycasting to find floors.")]
@@ -60,5 +61,6 @@ namespace VRTK
             }
             return newY;
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
@@ -11,8 +11,10 @@ namespace VRTK
     /// <param name="direction">The direction of the axis.</param>
     public struct TouchpadMovementAxisEventArgs
     {
+#pragma warning disable 0618
         public VRTK_TouchpadMovement.AxisMovementType movementType;
         public VRTK_TouchpadMovement.AxisMovementDirection direction;
+#pragma warning restore 0618
     }
 
     /// <summary>
@@ -20,7 +22,9 @@ namespace VRTK
     /// </summary>
     /// <param name="sender">this object</param>
     /// <param name="e"><see cref="TouchpadMovementAxisEventArgs"/></param>
+#pragma warning disable 0618
     public delegate void TouchpadMovementAxisEventHandler(VRTK_TouchpadMovement sender, TouchpadMovementAxisEventArgs e);
+#pragma warning restore 0618
 
     /// <summary>
     /// Adds the ability to move and rotate the play area and the player by using the touchpad. 

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -16,6 +16,7 @@ namespace VRTK
     /// </remarks>
     public abstract class VRTK_BasePointerRenderer : MonoBehaviour
     {
+#pragma warning disable 0618
         /// <summary>
         /// States of Pointer Visibility.
         /// </summary>
@@ -525,5 +526,6 @@ namespace VRTK
                 playareaCursor.SetPlayAreaCursorTransform(location);
             }
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
@@ -19,6 +19,7 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Pointers/Pointer Renderers/VRTK_BezierPointerRenderer")]
     public class VRTK_BezierPointerRenderer : VRTK_BasePointerRenderer
     {
+#pragma warning disable 0618
         [Header("Bezier Pointer Appearance Settings")]
 
         [Tooltip("The maximum length of the projected beam. The x value is the length of the forward beam, the y value is the length of the downward beam.")]
@@ -375,5 +376,6 @@ namespace VRTK
                 ChangeColor(invalidCollisionColor);
             }
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -15,6 +15,7 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Pointers/Pointer Renderers/VRTK_StraightPointerRenderer")]
     public class VRTK_StraightPointerRenderer : VRTK_BasePointerRenderer
     {
+#pragma warning disable 0618
         [Header("Straight Pointer Appearance Settings")]
 
         [Tooltip("The maximum length the pointer tracer can reach.")]
@@ -239,5 +240,6 @@ namespace VRTK
                 UpdateDependencies(actualCursor.transform.position);
             }
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -40,6 +40,7 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Presence/VRTK_BodyPhysics")]
     public class VRTK_BodyPhysics : VRTK_DestinationMarker
     {
+#pragma warning disable 0618
         /// <summary>
         /// Options for testing if a play space fall is valid
         /// </summary>
@@ -1093,5 +1094,6 @@ namespace VRTK
                 bodyRigidbody.AddRelativeForce(appliedMomentum, ForceMode.VelocityChange);
             }
         }
+#pragma warning restore 0618
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
@@ -3,6 +3,7 @@
     using UnityEngine.Events;
     using System;
 
+#pragma warning disable 0618
     public sealed class VRTK_ControllerActions_UnityEvents : VRTK_UnityEvents<VRTK_ControllerActions>
     {
         [Serializable]
@@ -33,4 +34,5 @@
             OnControllerModelInvisible.Invoke(o, e);
         }
     }
+#pragma warning restore 0618
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -7,6 +7,7 @@
     [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_ControllerEvents_UnityEvents")]
     public sealed class VRTK_ControllerEvents_UnityEvents : VRTK_UnityEvents<VRTK_ControllerEvents>
     {
+#pragma warning disable 0618
         [Serializable]
         public sealed class ControllerInteractionEvent : UnityEvent<object, ControllerInteractionEventArgs> { }
 
@@ -434,5 +435,6 @@
         {
             OnControllerHidden.Invoke(o, e);
         }
+#pragma warning restore 0618
     }
 }


### PR DESCRIPTION
The deprecated symbols correctly use the C# Obsolete Attribute, but
internal usage of deprecated things in VRTK meant warning messages were
loggeed in IDEs and Unity's console all the time.
Since those internal usages are of no interest to users of VRTK this
change tells the IDE and Unity to ignore those.