### PR TITLE
chore(Structure): suppress internal obsolete warnings

### DIFF
--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Button.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Button.cs
@@ -272,7 +272,9 @@ namespace VRTK
                     /// <obsolete>
                     /// This is an obsolete call that will be removed in a future version
                     /// </obsolete>
+#pragma warning disable 0618
                     events.OnPush.Invoke();
+#pragma warning restore 0618
 
                     OnPushed(SetControlEvent());
                 }

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Control.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Control.cs
@@ -182,7 +182,9 @@ namespace VRTK
                     /// <obsolete>
                     /// This is an obsolete call that will be removed in a future version
                     /// </obsolete>
+#pragma warning disable 0618
                     defaultEvents.OnValueChanged.Invoke(GetValue(), GetNormalizedValue());
+#pragma warning restore 0618
 
                     OnValueChanged(SetControlEvent());
                 }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -1748,6 +1748,10 @@ namespace VRTK
             return angle;
         }
 
+        /// <obsolete>
+        /// This is an obsolete method that will be removed in a future version
+        /// </obsolete>
+#pragma warning disable 0618
         protected virtual void EmitAlias(ButtonAlias type, bool touchDown, float buttonPressure, ref bool buttonBool)
         {
             if (pointerToggleButton == type)
@@ -1828,6 +1832,7 @@ namespace VRTK
                 }
             }
         }
+#pragma warning restore 0618
 
         protected virtual bool Vector2ShallowEquals(Vector2 vectorA, Vector2 vectorB)
         {

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -54,7 +54,9 @@ namespace VRTK
             Vector3 rayStartPositionOffset = Vector3.up * heightOffset;
             Ray ray = new Ray(tipPosition + rayStartPositionOffset, -playArea.up);
             RaycastHit rayCollidedWith;
+#pragma warning disable 0618
             if (target && VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity))
+#pragma warning restore 0618
             {
                 newY = (tipPosition.y - rayCollidedWith.distance) + heightOffset;
             }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_TouchpadMovement.cs
@@ -11,8 +11,10 @@ namespace VRTK
     /// <param name="direction">The direction of the axis.</param>
     public struct TouchpadMovementAxisEventArgs
     {
+#pragma warning disable 0618
         public VRTK_TouchpadMovement.AxisMovementType movementType;
         public VRTK_TouchpadMovement.AxisMovementDirection direction;
+#pragma warning restore 0618
     }
 
     /// <summary>
@@ -20,7 +22,9 @@ namespace VRTK
     /// </summary>
     /// <param name="sender">this object</param>
     /// <param name="e"><see cref="TouchpadMovementAxisEventArgs"/></param>
+#pragma warning disable 0618
     public delegate void TouchpadMovementAxisEventHandler(VRTK_TouchpadMovement sender, TouchpadMovementAxisEventArgs e);
+#pragma warning restore 0618
 
     /// <summary>
     /// Adds the ability to move and rotate the play area and the player by using the touchpad. 

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BezierPointerRenderer.cs
@@ -207,7 +207,9 @@ namespace VRTK
             Ray pointerRaycast = new Ray(origin.position, useForward);
 
             RaycastHit collidedWith;
+#pragma warning disable 0618
             bool hasRayHit = VRTK_CustomRaycast.Raycast(customRaycast, pointerRaycast, out collidedWith, layersToIgnore, calculatedLength);
+#pragma warning restore 0618
 
             float contactDistance = 0f;
             //reset if beam not hitting or hitting new target
@@ -238,7 +240,9 @@ namespace VRTK
             Ray projectedBeamDownRaycast = new Ray(jointPosition, Vector3.down);
             RaycastHit collidedWith;
 
+#pragma warning disable 0618
             bool downRayHit = VRTK_CustomRaycast.Raycast(customRaycast, projectedBeamDownRaycast, out collidedWith, layersToIgnore, maximumLength.y);
+#pragma warning restore 0618
 
             if (!downRayHit || (destinationHit.collider && destinationHit.collider != collidedWith.collider))
             {
@@ -288,13 +292,17 @@ namespace VRTK
                     Ray checkCollisionRay = new Ray(currentPoint, nextPointDirection);
                     RaycastHit checkCollisionHit;
 
+#pragma warning disable 0618
                     if (VRTK_CustomRaycast.Raycast(customRaycast, checkCollisionRay, out checkCollisionHit, layersToIgnore, nextPointDistance))
+#pragma warning restore 0618
                     {
                         Vector3 collisionPoint = checkCollisionRay.GetPoint(checkCollisionHit.distance);
                         Ray downwardCheckRay = new Ray(collisionPoint + (Vector3.up * 0.01f), Vector3.down);
                         RaycastHit downwardCheckHit;
 
+#pragma warning disable 0618
                         if (VRTK_CustomRaycast.Raycast(customRaycast, downwardCheckRay, out downwardCheckHit, layersToIgnore, float.PositiveInfinity))
+#pragma warning restore 0618
                         {
                             destinationHit = downwardCheckHit;
                             newDownPosition = downwardCheckRay.GetPoint(downwardCheckHit.distance); ;

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -179,7 +179,9 @@ namespace VRTK
             Transform origin = GetOrigin();
             Ray pointerRaycast = new Ray(origin.position, origin.forward);
             RaycastHit pointerCollidedWith;
+#pragma warning disable 0618
             bool rayHit = VRTK_CustomRaycast.Raycast(customRaycast, pointerRaycast, out pointerCollidedWith, layersToIgnore, maximumLength);
+#pragma warning restore 0618
 
             CheckRayMiss(rayHit, pointerCollidedWith);
             CheckRayHit(rayHit, pointerCollidedWith);

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -575,7 +575,9 @@ namespace VRTK
             RaycastHit standingDownRayCollision;
 
             //Determine the current valid floor that the user is standing over
+#pragma warning disable 0618
             currentValidFloorObject = (VRTK_CustomRaycast.Raycast(customRaycast, standingDownRay, out standingDownRayCollision, layersToIgnore, Mathf.Infinity) ? standingDownRayCollision.collider.gameObject : null);
+#pragma warning restore 0618
 
             //Don't bother checking for lean if body collisions are disabled
             if (headset == null || playArea == null || !enableBodyCollisions)
@@ -594,7 +596,9 @@ namespace VRTK
 
             // Cast a ray forward just outside the body collider radius to see if anything is blocking your path
             // If nothing is blocking your path and you're currently standing over a valid floor
+#pragma warning disable 0618
             if (!VRTK_CustomRaycast.Raycast(customRaycast, forwardRay, out forwardRayCollision, layersToIgnore, forwardLength) && currentValidFloorObject != null)
+#pragma warning restore 0618
             {
                 CalculateLean(standingDownRayStartPosition, forwardLength, standingDownRayCollision.distance);
             }
@@ -613,7 +617,9 @@ namespace VRTK
             RaycastHit downRayCollision;
 
             //Cast a ray down from the end of the forward ray position
+#pragma warning disable 0618
             if (VRTK_CustomRaycast.Raycast(customRaycast, downRay, out downRayCollision, layersToIgnore, Mathf.Infinity))
+#pragma warning restore 0618
             {
                 //Determine the difference between the original down ray and the projected forward a bit downray
                 float rayDownDelta = VRTK_SharedMethods.RoundFloat(originalRayDistance - downRayCollision.distance, decimalPrecision);
@@ -948,7 +954,9 @@ namespace VRTK
         {
             Ray ray = new Ray(controllerObj.transform.position, -playArea.up);
             RaycastHit rayCollidedWith;
+#pragma warning disable 0618
             VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity);
+#pragma warning restore 0618
             return controllerObj.transform.position.y - rayCollidedWith.distance;
         }
 
@@ -990,7 +998,9 @@ namespace VRTK
             {
                 Ray ray = new Ray(headset.transform.position, -playArea.up);
                 RaycastHit rayCollidedWith;
+#pragma warning disable 0618
                 bool rayHit = VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity);
+#pragma warning restore 0618
                 hitFloorYDelta = playArea.position.y - rayCollidedWith.point.y;
 
                 if (initialFloorDrop && (ValidDrop(rayHit, rayCollidedWith, rayCollidedWith.point.y) || retogglePhysicsOnCanFall))

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
@@ -2,7 +2,7 @@
 {
     using UnityEngine.Events;
     using System;
-
+#pragma warning disable 0618
     public sealed class VRTK_ControllerActions_UnityEvents : VRTK_UnityEvents<VRTK_ControllerActions>
     {
         [Serializable]
@@ -33,4 +33,5 @@
             OnControllerModelInvisible.Invoke(o, e);
         }
     }
+#pragma warning restore 0618
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -109,6 +109,7 @@
             component.StartMenuPressed += StartMenuPressed;
             component.StartMenuReleased += StartMenuReleased;
 
+#pragma warning disable 0618
             component.AliasPointerOn += AliasPointerOn;
             component.AliasPointerOff += AliasPointerOff;
             component.AliasPointerSet += AliasPointerSet;
@@ -120,6 +121,7 @@
             component.AliasUIClickOff += AliasUIClickOff;
             component.AliasMenuOn += AliasMenuOn;
             component.AliasMenuOff += AliasMenuOff;
+#pragma warning restore 0618
 
             component.ControllerEnabled += ControllerEnabled;
             component.ControllerDisabled += ControllerDisabled;
@@ -170,6 +172,7 @@
             component.StartMenuPressed -= StartMenuPressed;
             component.StartMenuReleased -= StartMenuReleased;
 
+#pragma warning disable 0618
             component.AliasPointerOn -= AliasPointerOn;
             component.AliasPointerOff -= AliasPointerOff;
             component.AliasPointerSet -= AliasPointerSet;
@@ -181,6 +184,7 @@
             component.AliasUIClickOff -= AliasUIClickOff;
             component.AliasMenuOn -= AliasMenuOn;
             component.AliasMenuOff -= AliasMenuOff;
+#pragma warning restore 0618
 
             component.ControllerEnabled -= ControllerEnabled;
             component.ControllerDisabled -= ControllerDisabled;


### PR DESCRIPTION
As a number of core VRTK scripts and methods have been deprecated, it
meant that existing VRTK scripts that still relied on those elements
were using deprecated items.

Usually, when something is deprecated it is replaced with a new item
that can be used in place of the old, however, with some of the
elements that have been deprecated in VRTK, this was not possible.

For example, the `Layers To Ignore` parameter has been replaced with
a more complex Custom Raycast script so a direct replacement is not
possible as it is a paradigm change in how things work. The original
`Layers To Ignore` cannot simply be removed from the internal scripts
as this would break existing behaviour (and therefore not be a valid
deprecation).

This meant that deprecation warning messages were being output to
the console and as there were many of these internal deprecation
cases, the console was being filled with warning messages, which
was annoying and unsightly.

The fix is to wrap any internal use of an obsolete item in the
`#pragma warning disable 0618` tag to ensure any internal deprecation
messages are suppressed.

When the deprecated items are finally removed, these additional
tags will also be removed as the offending lines will no longer raise
any deprecation warning methods.