### PR TITLE
fix(DeviceFinder): headset type recognition

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -36,7 +36,8 @@ namespace VRTK
             OculusRift,
             OculusRiftCV1,
             Vive,
-            ViveMV
+            ViveMV,
+            ViveDVT
         }
 
         /// <summary>
@@ -340,7 +341,33 @@ namespace VRTK
                 case "Vive MV":
                     returnValue = (summary ? Headsets.Vive : Headsets.ViveMV);
                     break;
+                case "Vive DVT":
+                    returnValue = (summary ? Headsets.Vive : Headsets.ViveDVT);
+                    break;
             }
+
+            if (returnValue == Headsets.Unknown)
+            {
+                VRTK_Logger.Warn(
+                    string.Format("Your headset is of type '{0}' which VRTK doesn't know about yet. Please report this headset type to the maintainers of VRTK."
+                                  + (summary ? " Falling back to a slower check to summarize the headset type now." : ""),
+                                  checkValue)
+                );
+
+                if (summary)
+                {
+                    checkValue = checkValue.ToLowerInvariant();
+                    if (checkValue.Contains("rift"))
+                    {
+                        return Headsets.OculusRift;
+                    }
+                    if (checkValue.Contains("vive"))
+                    {
+                        return Headsets.Vive;
+                    }
+                }
+            }
+
             return returnValue;
         }
 


### PR DESCRIPTION
The headset type recognition has a fixed list of known headsets.
This list is missing a special Vive Pre model that is reported as
"Vive DVT".
This fix adds that headset and modifies the recognition to also tell
the user to report any new headset type so it can be added to VRTK.
Additionally a slower check is done when a summarization is
requested to support types VRTK doesn't know about yet.

This fixes #1113.