### PR TITLE
chore(Structure): ensure vrtk components can be injected into scripts

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractControllerAppearance.cs
@@ -14,18 +14,21 @@ namespace VRTK
     public class VRTK_InteractControllerAppearance : MonoBehaviour
     {
         [Header("Touch Visibility")]
+
         [Tooltip("Hides the controller model when a valid touch occurs.")]
         public bool hideControllerOnTouch = false;
         [Tooltip("The amount of seconds to wait before hiding the controller on touch.")]
         public float hideDelayOnTouch = 0f;
 
         [Header("Grab Visibility")]
+
         [Tooltip("Hides the controller model when a valid grab occurs.")]
         public bool hideControllerOnGrab = false;
         [Tooltip("The amount of seconds to wait before hiding the controller on grab.")]
         public float hideDelayOnGrab = 0f;
 
         [Header("Use Visibility")]
+
         [Tooltip("Hides the controller model when a valid use occurs.")]
         public bool hideControllerOnUse = false;
         [Tooltip("The amount of seconds to wait before hiding the controller on use.")]

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -10,6 +10,7 @@ namespace VRTK
     public class VRTK_InteractHaptics : MonoBehaviour
     {
         [Header("Haptics On Touch")]
+
         [Tooltip("Denotes how strong the rumble in the controller will be on touch.")]
         [Range(0, 1)]
         public float strengthOnTouch = 0;
@@ -19,6 +20,7 @@ namespace VRTK
         public float intervalOnTouch = minInterval;
 
         [Header("Haptics On Grab")]
+
         [Tooltip("Denotes how strong the rumble in the controller will be on grab.")]
         [Range(0, 1)]
         public float strengthOnGrab = 0;
@@ -28,6 +30,7 @@ namespace VRTK
         public float intervalOnGrab = minInterval;
 
         [Header("Haptics On Use")]
+
         [Tooltip("Denotes how strong the rumble in the controller will be on use.")]
         [Range(0, 1)]
         public float strengthOnUse = 0;

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
@@ -32,8 +32,17 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Locomotion/VRTK_PlayerClimb")]
     public class VRTK_PlayerClimb : MonoBehaviour
     {
+        [Header("Climb Settings")]
+
         [Tooltip("Will scale movement up and down based on the player transform's scale.")]
         public bool usePlayerScale = true;
+
+        [Header("Custom Settings")]
+
+        [Tooltip("The VRTK Body Physics script to use for dealing with climbing and falling. If this is left blank then the script will need to be applied to the same GameObject.")]
+        public VRTK_BodyPhysics bodyPhysics;
+        [Tooltip("The VRTK Teleport script to use when snapping to nearest floor on release. If this is left blank then a Teleport script will need to be applied to the same GameObject.")]
+        public VRTK_BasicTeleport teleporter;
 
         /// <summary>
         /// Emitted when player climbing has started.
@@ -51,18 +60,14 @@ namespace VRTK
         protected GameObject grabbingController;
         protected GameObject climbingObject;
         protected Quaternion climbingObjectLastRotation;
-        protected VRTK_BodyPhysics bodyPhysics;
         protected bool isClimbing;
         protected bool useGrabbedObjectRotation;
 
-        protected virtual void Awake()
-        {
-            playArea = VRTK_DeviceFinder.PlayAreaTransform();
-            bodyPhysics = GetComponent<VRTK_BodyPhysics>();
-        }
-
         protected virtual void OnEnable()
         {
+            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+            bodyPhysics = (bodyPhysics != null ? bodyPhysics : GetComponentInChildren<VRTK_BodyPhysics>());
+            teleporter = (teleporter != null ? teleporter : GetComponentInChildren<VRTK_BasicTeleport>());
             InitListeners(true);
         }
 
@@ -127,16 +132,15 @@ namespace VRTK
 
         protected virtual void InitTeleportListener(bool state)
         {
-            var teleportComponent = GetComponent<VRTK_BasicTeleport>();
-            if (teleportComponent)
+            if (teleporter != null)
             {
                 if (state)
                 {
-                    teleportComponent.Teleporting += new TeleportEventHandler(OnTeleport);
+                    teleporter.Teleporting += new TeleportEventHandler(OnTeleport);
                 }
                 else
                 {
-                    teleportComponent.Teleporting -= new TeleportEventHandler(OnTeleport);
+                    teleporter.Teleporting -= new TeleportEventHandler(OnTeleport);
                 }
             }
         }

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -102,6 +102,8 @@ namespace VRTK
         [Range(1, 10)]
         [Tooltip("The amount of rounding on the play area Y position to be applied when checking if falling is occuring.")]
         public int fallCheckPrecision = 5;
+        [Tooltip("The VRTK Teleport script to use when snapping to floor. If this is left blank then a Teleport script will need to be applied to the same GameObject.")]
+        public VRTK_BasicTeleport teleporter;
 
         /// <summary>
         /// Emitted when a fall begins.
@@ -139,7 +141,6 @@ namespace VRTK
         protected GameObject currentCollidingObject = null;
         protected GameObject currentValidFloorObject = null;
 
-        protected VRTK_BasicTeleport teleporter;
         protected float lastFrameFloorY;
         protected float hitFloorYDelta = 0f;
         protected bool initialFloorDrop = false;
@@ -688,10 +689,10 @@ namespace VRTK
         {
             initialFloorDrop = false;
             retogglePhysicsOnCanFall = false;
-            teleporter = GetComponent<VRTK_BasicTeleport>();
+            teleporter = (teleporter != null ? teleporter : GetComponentInChildren<VRTK_BasicTeleport>());
             if (teleporter != null)
             {
-                teleporter.Teleported += Teleporter_Teleported;
+                teleporter.Teleported += Teleported;
             }
         }
 
@@ -699,11 +700,11 @@ namespace VRTK
         {
             if (teleporter != null)
             {
-                teleporter.Teleported -= Teleporter_Teleported;
+                teleporter.Teleported -= Teleported;
             }
         }
 
-        protected virtual void Teleporter_Teleported(object sender, DestinationMarkerEventArgs e)
+        protected virtual void Teleported(object sender, DestinationMarkerEventArgs e)
         {
             initialFloorDrop = false;
             StopFall();

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollisionFade.cs
@@ -18,6 +18,8 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Presence/VRTK_HeadsetCollisionFade")]
     public class VRTK_HeadsetCollisionFade : MonoBehaviour
     {
+        [Header("Collision Fade Settings")]
+
         [Tooltip("The amount of time to wait until a fade occurs.")]
         public float timeTillFade = 0f;
         [Tooltip("The fade blink speed on collision.")]
@@ -25,13 +27,17 @@ namespace VRTK
         [Tooltip("The colour to fade the headset to on collision.")]
         public Color fadeColor = Color.black;
 
-        protected VRTK_HeadsetCollision headsetCollision;
-        protected VRTK_HeadsetFade headsetFade;
+        [Header("Custom Settings")]
+
+        [Tooltip("The VRTK Headset Collision script to use when determining headset collisions. If this is left blank then the script will need to be applied to the same GameObject.")]
+        public VRTK_HeadsetCollision headsetCollision;
+        [Tooltip("The VRTK Headset Fade script to use when fading the headset. If this is left blank then the script will need to be applied to the same GameObject.")]
+        public VRTK_HeadsetFade headsetFade;
 
         protected virtual void OnEnable()
         {
-            headsetFade = GetComponent<VRTK_HeadsetFade>();
-            headsetCollision = GetComponent<VRTK_HeadsetCollision>();
+            headsetFade = (headsetFade != null ? headsetFade : GetComponentInChildren<VRTK_HeadsetFade>());
+            headsetCollision = (headsetCollision != null ? headsetCollision : GetComponentInChildren<VRTK_HeadsetCollision>());
 
             headsetCollision.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollisionDetect);
             headsetCollision.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1924,6 +1924,8 @@ The Player Climb allows player movement based on grabbing of `VRTK_InteractableO
 ### Inspector Parameters
 
  * **Use Player Scale:** Will scale movement up and down based on the player transform's scale.
+ * **Body Physics:** The VRTK Body Physics script to use for dealing with climbing and falling. If this is left blank then the script will need to be applied to the same GameObject.
+ * **Teleporter:** The VRTK Teleport script to use when snapping to nearest floor on release. If this is left blank then a Teleport script will need to be applied to the same GameObject.
 
 ### Class Events
 
@@ -4592,6 +4594,8 @@ The Headset Collision Fade uses a composition of the Headset Collision and Heads
  * **Time Till Fade:** The amount of time to wait until a fade occurs.
  * **Blink Transition Speed:** The fade blink speed on collision.
  * **Fade Color:** The colour to fade the headset to on collision.
+ * **Headset Collision:** The VRTK Headset Collision script to use when determining headset collisions. If this is left blank then the script will need to be applied to the same GameObject.
+ * **Headset Fade:** The VRTK Headset Fade script to use when fading the headset. If this is left blank then the script will need to be applied to the same GameObject.
 
 ### Example
 
@@ -4733,6 +4737,7 @@ To allow for peeking over a ledge and not falling, a fall restiction can happen 
  * **Blink Y Threshold:** The `y` distance between the floor and the headset that must change before a fade transition is initiated. If the new user location is at a higher distance than the threshold then the headset blink transition will activate on teleport. If the new user location is within the threshold then no blink transition will happen, which is useful for walking up slopes, meshes and terrains to prevent constant blinking.
  * **Floor Height Tolerance:** The amount the `y` position needs to change by between the current floor `y` position and the previous floor `y` position before a change in floor height is considered to have occurred. A higher value here will mean that a `Drop To Floor` will be less likely to happen if the `y` of the floor beneath the user hasn't changed as much as the given threshold.
  * **Fall Check Precision:** The amount of rounding on the play area Y position to be applied when checking if falling is occuring.
+ * **Teleporter:** The VRTK Teleport script to use when snapping to floor. If this is left blank then a Teleport script will need to be applied to the same GameObject.
 
 ### Class Variables
 


### PR DESCRIPTION
Rather than have VRTK scripts simply assume another VRTK script is on
the same GameObject (or on an ancestor or descendant GameObject) it is
now possible to inject the dependent script via a public inspector
property.

This makes it easier specify which component the script should be using
rather than it always just getting the first component it finds on the
checked GameObject.