### PR TITLE
fix(SDK): controller null reference exception

### DIFF
--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -219,7 +219,7 @@ namespace VRTK
         public virtual ControllerHand GetControllerModelHand(GameObject controllerModel)
         {
             VRTK_SDKManager sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
+            if (sdkManager != null && sdkManager.loadedSetup != null)
             {
                 if (controllerModel == sdkManager.loadedSetup.modelAliasLeftController)
                 {


### PR DESCRIPTION
Sometimes the SDK Manager's loaded setup is null so getting the
controller model hand in the base controller class was throwing
null reference exceptions. The fix is to make sure there is a loaded
setup before using it.