### PR TITLE
fix(SceneChanger): wrong SDK usage and errors

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/SceneChanger.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/SceneChanger.cs
@@ -64,6 +64,7 @@
                 {
                     nextSceneIndex = 0;
                 }
+                VRTK_SDKManager.instance.UnloadSDKSetup();
                 SceneManager.LoadScene(nextSceneIndex);
             }
 
@@ -74,6 +75,7 @@
                 {
                     previousSceneIndex = SceneManager.sceneCountInBuildSettings - 1;
                 }
+                VRTK_SDKManager.instance.UnloadSDKSetup();
                 SceneManager.LoadScene(previousSceneIndex);
             }
         }


### PR DESCRIPTION
Since the introduction of SDK Setups using the Scene Changer
strangely forced the next loaded scene to use the wrong SDK Setup.
Sometimes a loaded scene would result in exceptions being thrown
from various Simulator classes.
The fix is to unload the currently used SDK Setup to turn off any
used SDK and force Unity to shut down any used SDK plugins.