### PR TITLE
fix(SDKManager): standalone build errors

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -768,6 +768,7 @@ namespace VRTK
             }));
         }
 
+#if UNITY_EDITOR
         private static BuildTargetGroup[] GetValidBuildTargetGroups()
         {
             return Enum.GetValues(typeof(BuildTargetGroup)).Cast<BuildTargetGroup>().Where(group =>
@@ -784,7 +785,6 @@ namespace VRTK
             }).ToArray();
         }
 
-#if UNITY_EDITOR
         /// <summary>
         /// Calls <see cref="ManageScriptingDefineSymbols"/> and <see cref="ManageVRSettings"/> (both without forcing) at the appropriate times when in the editor.
         /// </summary>


### PR DESCRIPTION
The SDK Manager used a type from the UnityEditor namespace without
making sure it's only used in the Editor. The fix is to wrap that in
an #ifdef.