### PR TITLE
fix(SharedMethods): standalone build errors

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -420,10 +420,8 @@ namespace VRTK
                             .Where(@object => @object.gameObject.scene == activeScene)
 #if UNITY_EDITOR
                             .Where(@object => !AssetDatabase.Contains(@object))
-                            .ToArray();
-#else
-                ;
 #endif
+                            .ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
The Shared Methods script was throwing errors when compiling for a
build. The fix is to wrap that in an #ifdef correctly.