### PR TITLE
fix(SDKSetup): changes because of auto populate not serializing

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -278,6 +278,10 @@ namespace VRTK
 #endif
             VRTK_SDK_Bridge.InvalidateCaches();
 
+#if UNITY_EDITOR
+            Undo.RecordObject(this, "Populate Object References");
+#endif
+
             actualBoundaries = null;
             actualHeadset = null;
             actualLeftController = null;


### PR DESCRIPTION
Whenever the auto populate action run the changes done were not
saved. The fix is to let Unity know about the changes so it will
mark the scene as dirty.

This fixes #1187.