### PR TITLE
fix(SDKManager): allow `-vrmode none` to load Simulator SDK Setup

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -546,9 +546,24 @@ namespace VRTK
                         setups,
                         setup => setup.usedVRDeviceNames.Contains(VRSettings.loadedDeviceName)
                     );
-                    index = index == -1 ? 0 : index;
+                }
+                else
+                {
+                    // If '-vrmode none' was used try to load the respective SDK Setup
+                    string[] commandLineArgs = Environment.GetCommandLineArgs();
+                    int commandLineArgIndex = Array.IndexOf(commandLineArgs, "-vrmode", 1);
+                    if (commandLineArgIndex != -1
+                        && commandLineArgIndex + 1 < commandLineArgs.Length
+                        && commandLineArgs[commandLineArgIndex + 1].ToLowerInvariant() == "none")
+                    {
+                        index = Array.FindIndex(
+                            setups,
+                            setup => setup.usedVRDeviceNames.All(vrDeviceName => vrDeviceName == "None")
+                        );
+                    }
                 }
 
+                index = index == -1 ? 0 : index;
                 TryLoadSDKSetup(index, false, setups.ToArray());
             }
         }


### PR DESCRIPTION
The SDK Manager supports Unity's standalone build command line
argument `-vrmode DEVICETYPE`. This fix makes sure `-vrmode none` is
supported in addition to the other available VR devices. If no
`-vrmode` argument is used the SDK Manager's SDK Setups list is
still used by trying one after the other in order.