### PR TITLE
feat(Controller): add audio haptics

### DIFF
--- a/Assets/VRTK/Editor/VRTK_InteractHapticsEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_InteractHapticsEditor.cs
@@ -1,0 +1,82 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using UnityEditor;
+
+    [CustomEditor(typeof(VRTK_InteractHaptics))]
+    public class VRTK_InteractHapticsEditor : Editor
+    {
+        SerializedProperty clipOnTouch;
+        SerializedProperty strengthOnTouch;
+        SerializedProperty durationOnTouch;
+        SerializedProperty intervalOnTouch;
+
+        SerializedProperty clipOnGrab;
+        SerializedProperty strengthOnGrab;
+        SerializedProperty durationOnGrab;
+        SerializedProperty intervalOnGrab;
+
+        SerializedProperty clipOnUse;
+        SerializedProperty strengthOnUse;
+        SerializedProperty durationOnUse;
+        SerializedProperty intervalOnUse;
+
+        private void OnEnable()
+        {
+            clipOnTouch = serializedObject.FindProperty("clipOnTouch");
+            strengthOnTouch = serializedObject.FindProperty("strengthOnTouch");
+            durationOnTouch = serializedObject.FindProperty("durationOnTouch");
+            intervalOnTouch = serializedObject.FindProperty("intervalOnTouch");
+
+            clipOnGrab = serializedObject.FindProperty("clipOnGrab");
+            strengthOnGrab = serializedObject.FindProperty("strengthOnGrab");
+            durationOnGrab = serializedObject.FindProperty("durationOnGrab");
+            intervalOnGrab = serializedObject.FindProperty("intervalOnGrab");
+
+            clipOnUse = serializedObject.FindProperty("clipOnUse");
+            strengthOnUse = serializedObject.FindProperty("strengthOnUse");
+            durationOnUse = serializedObject.FindProperty("durationOnUse");
+            intervalOnUse = serializedObject.FindProperty("intervalOnUse");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Haptics On Touch", EditorStyles.boldLabel);
+
+            EditorGUILayout.ObjectField(clipOnTouch, typeof(AudioClip));
+            if (clipOnTouch.objectReferenceValue == null)
+            {
+                EditorGUILayout.PropertyField(strengthOnTouch);
+                EditorGUILayout.PropertyField(durationOnTouch);
+                EditorGUILayout.PropertyField(intervalOnTouch);
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Haptics On Grab", EditorStyles.boldLabel);
+
+            EditorGUILayout.ObjectField(clipOnGrab, typeof(AudioClip));
+            if (clipOnGrab.objectReferenceValue == null)
+            {
+                EditorGUILayout.PropertyField(strengthOnGrab);
+                EditorGUILayout.PropertyField(durationOnGrab);
+                EditorGUILayout.PropertyField(intervalOnGrab);
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Haptics On Use", EditorStyles.boldLabel);
+
+            EditorGUILayout.ObjectField(clipOnUse, typeof(AudioClip));
+            if (clipOnUse.objectReferenceValue == null)
+            {
+                EditorGUILayout.PropertyField(strengthOnUse);
+                EditorGUILayout.PropertyField(durationOnUse);
+                EditorGUILayout.PropertyField(intervalOnUse);
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_InteractHapticsEditor.cs.meta
+++ b/Assets/VRTK/Editor/VRTK_InteractHapticsEditor.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: cfdda54b43a24dc783d4af3b8da86c86
-timeCreated: 1494692433
+guid: fded6ec3e21e98e4a99a2c8cd7cb3599
+timeCreated: 1494692514
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2

--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -248,11 +248,18 @@ namespace VRTK
         public abstract void SetControllerRenderModelWheel(GameObject renderModel, bool state);
 
         /// <summary>
-        /// The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
         /// </summary>
         /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
         public abstract void HapticPulse(VRTK_ControllerReference controllerReference, float strength = 0.5f);
+
+        /// <summary>
+        /// The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="clip">The audio clip to use for the haptic pattern.</param>
+        public abstract bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip);
 
         /// <summary>
         /// The GetHapticModifiers method is used to return modifiers for the duration and interval if the SDK handles it slightly differently.
@@ -402,5 +409,7 @@ namespace VRTK
     {
         public float durationModifier = 1f;
         public float intervalModifier = 1f;
+        public ushort maxHapticVibration = 1;
+        public int hapticsBufferSize = 8192;
     }
 }

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -263,12 +263,23 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
         /// </summary>
         /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
         public override void HapticPulse(VRTK_ControllerReference controllerReference, float strength = 0.5f)
         {
+        }
+
+        /// <summary>
+        /// The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="clip">The audio clip to use for the haptic pattern.</param>
+        public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
+        {
+            //Return true so it just always prevents doing a fallback routine.
+            return true;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -196,12 +196,23 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
         /// </summary>
         /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
         public override void HapticPulse(VRTK_ControllerReference controllerReference, float strength = 0.5f)
         {
+        }
+
+        /// <summary>
+        /// The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="clip">The audio clip to use for the haptic pattern.</param>
+        public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
+        {
+            //Return true so it just always prevents doing a fallback routine.
+            return true;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -282,12 +282,23 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
         /// </summary>
         /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
         public override void HapticPulse(VRTK_ControllerReference controllerReference, float strength = 0.5f)
         {
+        }
+
+        /// <summary>
+        /// The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="clip">The audio clip to use for the haptic pattern.</param>
+        public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
+        {
+            //Return true so it just always prevents doing a fallback routine.
+            return true;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -345,7 +345,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
         /// </summary>
         /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
@@ -361,12 +361,25 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="clip">The audio clip to use for the haptic pattern.</param>
+        public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
+        {
+            //SteamVR doesn't support audio haptics so return false to do a fallback.
+            return false;
+        }
+
+        /// <summary>
         /// The GetHapticModifiers method is used to return modifiers for the duration and interval if the SDK handles it slightly differently.
         /// </summary>
         /// <returns>An SDK_ControllerHapticModifiers object with a given `durationModifier` and an `intervalModifier`.</returns>
         public override SDK_ControllerHapticModifiers GetHapticModifiers()
         {
-            return new SDK_ControllerHapticModifiers();
+            SDK_ControllerHapticModifiers modifiers = new SDK_ControllerHapticModifiers();
+            modifiers.maxHapticVibration = maxHapticVibration;
+            return modifiers;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -142,6 +142,11 @@
             GetControllerSDK().HapticPulse(controllerReference, strength);
         }
 
+        public static bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
+        {
+            return GetControllerSDK().HapticPulse(controllerReference, clip);
+        }
+
         public static SDK_ControllerHapticModifiers GetHapticModifiers()
         {
             return GetControllerSDK().GetHapticModifiers();

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -324,7 +324,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+        /// The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
         /// </summary>
         /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
         /// <param name="strength">The intensity of the rumble of the controller motor. `0` to `1`.</param>
@@ -346,6 +346,17 @@ namespace VRTK
                 }
                 input.StartVibration(convertedStrength, 0.5f);
             }
+        }
+
+        /// <summary>
+        /// The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the tracked object to initiate the haptic pulse on.</param>
+        /// <param name="clip">The audio clip to use for the haptic pattern.</param>
+        public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
+        {
+            //Ximmerse doesn't support audio haptics so return false to do a fallback.
+            return false;
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -12,6 +12,8 @@ namespace VRTK
     {
         [Header("Haptics On Touch")]
 
+        [Tooltip("Denotes the audio clip to use to rumble the controller on touch.")]
+        public AudioClip clipOnTouch;
         [Tooltip("Denotes how strong the rumble in the controller will be on touch.")]
         [Range(0, 1)]
         public float strengthOnTouch = 0;
@@ -22,6 +24,8 @@ namespace VRTK
 
         [Header("Haptics On Grab")]
 
+        [Tooltip("Denotes the audio clip to use to rumble the controller on grab.")]
+        public AudioClip clipOnGrab;
         [Tooltip("Denotes how strong the rumble in the controller will be on grab.")]
         [Range(0, 1)]
         public float strengthOnGrab = 0;
@@ -32,6 +36,8 @@ namespace VRTK
 
         [Header("Haptics On Use")]
 
+        [Tooltip("Denotes the audio clip to use to rumble the controller on use.")]
+        public AudioClip clipOnUse;
         [Tooltip("Denotes how strong the rumble in the controller will be on use.")]
         [Range(0, 1)]
         public float strengthOnUse = 0;
@@ -58,7 +64,11 @@ namespace VRTK
         /// <param name="controllerReference">The reference to the controller to activate the haptic feedback on.</param>
         public virtual void HapticsOnTouch(VRTK_ControllerReference controllerReference)
         {
-            if (strengthOnTouch > 0 && durationOnTouch > 0f)
+            if (clipOnTouch != null)
+            {
+                VRTK_ControllerHaptics.TriggerHapticPulse(controllerReference, clipOnTouch);
+            }
+            else if (strengthOnTouch > 0 && durationOnTouch > 0f)
             {
                 TriggerHapticPulse(controllerReference, strengthOnTouch, durationOnTouch, intervalOnTouch);
             }
@@ -80,7 +90,11 @@ namespace VRTK
         /// <param name="controllerReference">The reference to the controller to activate the haptic feedback on.</param>
         public virtual void HapticsOnGrab(VRTK_ControllerReference controllerReference)
         {
-            if (strengthOnGrab > 0 && durationOnGrab > 0f)
+            if (clipOnGrab != null)
+            {
+                VRTK_ControllerHaptics.TriggerHapticPulse(controllerReference, clipOnGrab);
+            }
+            else if (strengthOnGrab > 0 && durationOnGrab > 0f)
             {
                 TriggerHapticPulse(controllerReference, strengthOnGrab, durationOnGrab, intervalOnGrab);
             }
@@ -102,7 +116,11 @@ namespace VRTK
         /// <param name="controllerReference">The reference to the controller to activate the haptic feedback on.</param>
         public virtual void HapticsOnUse(VRTK_ControllerReference controllerReference)
         {
-            if (strengthOnUse > 0 && durationOnUse > 0f)
+            if (clipOnUse != null)
+            {
+                VRTK_ControllerHaptics.TriggerHapticPulse(controllerReference, clipOnUse);
+            }
+            else if (strengthOnUse > 0 && durationOnUse > 0f)
             {
                 TriggerHapticPulse(controllerReference, strengthOnUse, durationOnUse, intervalOnUse);
             }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2560,6 +2560,18 @@ The TriggerHapticPulse/2 method calls a single haptic pulse call on the controll
 
 The TriggerHapticPulse/4 method calls a haptic pulse for a specified amount of time rather than just a single tick. Each pulse can be separated by providing a `pulseInterval` to pause between each haptic pulse.
 
+#### TriggerHapticPulse/2
+
+  > `public static void TriggerHapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to activate the haptic feedback on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The TriggerHapticPulse/2 method calls a haptic pulse based on a given audio clip.
+
 #### CancelHapticPulse/1
 
   > `public static void CancelHapticPulse(VRTK_ControllerReference controllerReference)`
@@ -3484,12 +3496,15 @@ The Interact Haptics script is attached on the same GameObject as an Interactabl
 
 ### Inspector Parameters
 
+ * **Clip On Touch:** Denotes the audio clip to use to rumble the controller on touch.
  * **Strength On Touch:** Denotes how strong the rumble in the controller will be on touch.
  * **Duration On Touch:** Denotes how long the rumble in the controller will last on touch.
  * **Interval On Touch:** Denotes interval betweens rumble in the controller on touch.
+ * **Clip On Grab:** Denotes the audio clip to use to rumble the controller on grab.
  * **Strength On Grab:** Denotes how strong the rumble in the controller will be on grab.
  * **Duration On Grab:** Denotes how long the rumble in the controller will last on grab.
  * **Interval On Grab:** Denotes interval betweens rumble in the controller on grab.
+ * **Clip On Use:** Denotes the audio clip to use to rumble the controller on use.
  * **Strength On Use:** Denotes how strong the rumble in the controller will be on use.
  * **Duration On Use:** Denotes how long the rumble in the controller will last on use.
  * **Interval On Use:** Denotes interval betweens rumble in the controller on use.
@@ -7447,7 +7462,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public abstract bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip);`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 
@@ -8022,7 +8049,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 
@@ -8591,7 +8630,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 
@@ -9179,7 +9230,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 
@@ -9540,6 +9603,17 @@ The Oculus Controller SDK script provides a bridge to SDK methods that deal with
 
 ### Class Methods
 
+#### OnAfterSetupLoad/1
+
+  > `public override void OnAfterSetupLoad(VRTK_SDKSetup setup)`
+
+  * Parameters
+   * `VRTK_SDKSetup setup` - The SDK Setup which is using this SDK.
+  * Returns
+   * _none_
+
+This method is called just after loading the  that's using this SDK.
+
 #### ProcessUpdate/2
 
   > `public override void ProcessUpdate(VRTK_ControllerReference controllerReference, Dictionary<string, object> options)`
@@ -9756,7 +9830,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 
@@ -10343,7 +10429,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 
@@ -10919,7 +11017,19 @@ The SetControllerRenderModelWheel method sets the state of the scroll wheel on t
   * Returns
    * _none_
 
-The HapticPulse method is used to initiate a simple haptic pulse on the tracked object of the given index.
+The HapticPulse/2 method is used to initiate a simple haptic pulse on the tracked object of the given controller reference.
+
+#### HapticPulse/2
+
+  > `public override bool HapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the tracked object to initiate the haptic pulse on.
+   * `AudioClip clip` - The audio clip to use for the haptic pattern.
+  * Returns
+   * _none_
+
+The HapticPulse/2 method is used to initiate a haptic pulse based on an audio clip on the tracked object of the given controller reference.
 
 #### GetHapticModifiers/0
 


### PR DESCRIPTION
The audio haptics vibrate the controller based on an AudioClip
which uses the audio clip data for the pattern of the vibration.

This is useful for providing more customised vibrations.

The InteractHaptics script has been updated now to accept an
audio clip as a parameter for touch/grab/use and comes with a
custom editor to hide the default settings if a clip is provided.

An additional fix has also been added for the Oculus SDK which
was preventing the default haptic pulse from working due to
the way the OVRHapticsClip was being set up before the Oculus
SDK was available.