### PR TITLE
fix(ScreenFade): ensure alpha does not get locked at 1f - fixes #1186

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_ScreenFade.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_ScreenFade.cs
@@ -55,7 +55,7 @@
 
             if (currentColor.a > 0 && fadeMaterial)
             {
-                currentColor.a = (currentColor.a > 0.98f ? 1f : currentColor.a);
+                currentColor.a = (targetColor.a > currentColor.a && currentColor.a > 0.98f ? 1f : currentColor.a);
                 fadeMaterial.color = currentColor;
                 fadeMaterial.SetPass(0);
                 GL.PushMatrix();


### PR DESCRIPTION
There was a bug where the alpha would not get set fully to 1f so
a fix was introduced to force it to 1f if the alpha was over 0.98f.

However, this created another bug where when the alpha should go from
1f to lower it would keep getting reset to 1f.

This fix checks to see if the alpha is being changed up towards the
1f value before attempting to force the alpha to 1f above 0.98f.