### PR TITLE
feat(Pointer): add ability to hide play area cursor on invalid location

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -424,7 +424,7 @@ namespace VRTK
         {
             if (playareaCursor)
             {
-                playareaCursor.SetMaterialColor(givenColor);
+                playareaCursor.SetMaterialColor(givenColor, IsValidCollision());
             }
         }
 

--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -400,7 +400,7 @@ namespace VRTK
         {
             if (playAreaCursor)
             {
-                playAreaCursor.SetMaterialColor(color);
+                playAreaCursor.SetMaterialColor(color, true);
             }
         }
 

--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -14,10 +14,12 @@ namespace VRTK
     {
         [Tooltip("Determines the size of the play area cursor and collider. If the values are left as zero then the Play Area Cursor will be sized to the calibrated Play Area space.")]
         public Vector2 playAreaCursorDimensions = Vector2.zero;
-        [Tooltip("If this is ticked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `DestinationMarkerSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.")]
+        [Tooltip("If this is checked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `DestinationMarkerSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.")]
         public bool handlePlayAreaCursorCollisions = false;
-        [Tooltip("If this is ticked then if the user's headset is outside of the play area cursor bounds then it is considered a collision even if the play area isn't colliding with anything.")]
+        [Tooltip("If this is checked then if the user's headset is outside of the play area cursor bounds then it is considered a collision even if the play area isn't colliding with anything.")]
         public bool headsetOutOfBoundsIsCollision = false;
+        [Tooltip("If this is checked then the play area cursor will be displayed when the location is invalid.")]
+        public bool displayOnInvalidLocation = true;
         [Tooltip("A specified VRTK_PolicyList to use to determine whether the play area cursor collisions will be acted upon.")]
         public VRTK_PolicyList targetListPolicy;
 
@@ -85,10 +87,13 @@ namespace VRTK
         /// The SetMaterialColor method sets the current material colour on the play area cursor.
         /// </summary>
         /// <param name="color">The colour to update the play area cursor material to.</param>
-        public virtual void SetMaterialColor(Color color)
+        /// <param name="validity">Determines if the colour being set is based from a valid location or invalid location.</param>
+        public virtual void SetMaterialColor(Color color, bool validity)
         {
             if (validLocationObject == null)
             {
+                ToggleVisibility(!(!validity && !displayOnInvalidLocation));
+
                 if (usePointerColor)
                 {
                     for (int i = 0; i < playAreaCursorBoundaries.Length; i++)
@@ -277,7 +282,7 @@ namespace VRTK
             }
             if (playAreaCursorInvalidChild != null)
             {
-                playAreaCursorInvalidChild.SetActive(!state);
+                playAreaCursorInvalidChild.SetActive((displayOnInvalidLocation ? !state : false));
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1199,8 +1199,9 @@ The Play Area Cursor is used in conjunction with a Pointer script and displays a
 ### Inspector Parameters
 
  * **Play Area Cursor Dimensions:** Determines the size of the play area cursor and collider. If the values are left as zero then the Play Area Cursor will be sized to the calibrated Play Area space.
- * **Handle Play Area Cursor Collisions:** If this is ticked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `DestinationMarkerSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.
- * **Headset Out Of Bounds Is Collision:** If this is ticked then if the user's headset is outside of the play area cursor bounds then it is considered a collision even if the play area isn't colliding with anything.
+ * **Handle Play Area Cursor Collisions:** If this is checked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `DestinationMarkerSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.
+ * **Headset Out Of Bounds Is Collision:** If this is checked then if the user's headset is outside of the play area cursor bounds then it is considered a collision even if the play area isn't colliding with anything.
+ * **Display On Invalid Location:** If this is checked then the play area cursor will be displayed when the location is invalid.
  * **Target List Policy:** A specified VRTK_PolicyList to use to determine whether the play area cursor collisions will be acted upon.
  * **Use Pointer Color:** If this is checked then the pointer hit/miss colours will also be used to change the colour of the play area cursor when colliding/not colliding.
  * **Valid Location Object:** A custom GameObject to use for the play area cursor representation for when the location is valid.
@@ -1241,12 +1242,13 @@ The SetHeadsetPositionCompensation method determines whether the offset position
 
 The SetPlayAreaCursorCollision method determines whether play area collisions should be taken into consideration with the play area cursor.
 
-#### SetMaterialColor/1
+#### SetMaterialColor/2
 
-  > `public virtual void SetMaterialColor(Color color)`
+  > `public virtual void SetMaterialColor(Color color, bool validity)`
 
   * Parameters
    * `Color color` - The colour to update the play area cursor material to.
+   * `bool validity` - Determines if the colour being set is based from a valid location or invalid location.
   * Returns
    * _none_
 


### PR DESCRIPTION
A new option has been added to the Play Area Cursor script that will
hide the play area cursor if the cursor location is invalid (e.g. it
does not match the policy list or a play area collision has occurred).

This is useful for only showing the play area cursor when the user
is able to move to the new destination.