### PR TITLE
fix(Interaction): prevent secondary grab when isGrabbable is false

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -294,7 +294,7 @@ namespace VRTK
 
                     if (controllerAttachPoint == null)
                     {
-                        var autoGenRB = defaultAttachPoint.gameObject.AddComponent<Rigidbody>();
+                        Rigidbody autoGenRB = defaultAttachPoint.gameObject.AddComponent<Rigidbody>();
                         autoGenRB.isKinematic = true;
                         controllerAttachPoint = autoGenRB;
                     }
@@ -304,7 +304,7 @@ namespace VRTK
 
         protected virtual bool IsObjectGrabbable(GameObject obj)
         {
-            var objScript = obj.GetComponent<VRTK_InteractableObject>();
+            VRTK_InteractableObject objScript = obj.GetComponent<VRTK_InteractableObject>();
             return (interactTouch.IsObjectInteractable(obj) && objScript != null && (objScript.isGrabbable || objScript.PerformSecondaryAction()));
         }
 
@@ -312,7 +312,7 @@ namespace VRTK
         {
             if (obj != null)
             {
-                var objScript = obj.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject objScript = obj.GetComponent<VRTK_InteractableObject>();
                 return (objScript && objScript.holdButtonToGrab);
             }
             return false;
@@ -351,7 +351,7 @@ namespace VRTK
             grabbedObject = interactTouch.GetTouchedObject();
             if (grabbedObject != null)
             {
-                var grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
                 ChooseGrabSequence(grabbedObjectScript);
                 ToggleControllerVisibility(false);
                 OnControllerGrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
@@ -411,7 +411,7 @@ namespace VRTK
             if (grabbedObject != null)
             {
                 GameObject grabbingObject = controllerReference.scriptAlias;
-                var grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
                 if (!influencingGrabbedObject)
                 {
                     grabbedObjectScript.grabAttachMechanicScript.StopGrab(applyGrabbingObjectVelocity);
@@ -451,7 +451,7 @@ namespace VRTK
         {
             if (grabbedObject != null)
             {
-                var grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
                 return (grabbedObjectScript && !grabbedObjectScript.IsDroppable() ? grabbedObject : null);
             }
             return null;
@@ -461,7 +461,7 @@ namespace VRTK
         {
             if (grabbedObject != null && initialGrabAttempt)
             {
-                var doHaptics = grabbedObject.GetComponentInParent<VRTK_InteractHaptics>();
+                VRTK_InteractHaptics doHaptics = grabbedObject.GetComponentInParent<VRTK_InteractHaptics>();
                 if (doHaptics != null)
                 {
                     doHaptics.HapticsOnGrab(controllerReference);
@@ -494,7 +494,7 @@ namespace VRTK
         {
             GameObject grabbingObject = controllerReference.scriptAlias;
             bool initialGrabAttempt = false;
-            var objectToGrabScript = objectToGrab.GetComponent<VRTK_InteractableObject>();
+            VRTK_InteractableObject objectToGrabScript = objectToGrab.GetComponent<VRTK_InteractableObject>();
             if (grabbedObject == null && interactTouch != null && IsObjectGrabbable(interactTouch.GetTouchedObject()) && objectToGrabScript && objectToGrabScript.grabAttachMechanicScript.ValidGrab(controllerAttachPoint))
             {
                 InitGrabbedObject();

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -707,10 +707,10 @@ namespace VRTK
         /// <summary>
         /// The PerformSecondaryAction method returns whether the object has a secondary action that can be performed when grabbing the object with a secondary controller.
         /// </summary>
-        /// <returns>Returns true if the obejct has a secondary action, returns false if it has no secondary action or is swappable.</returns>
+        /// <returns>Returns true if the object has a secondary action, returns false if it has no secondary action or is swappable.</returns>
         public virtual bool PerformSecondaryAction()
         {
-            return (!GetSecondaryGrabbingObject() && secondaryGrabActionScript != null ? secondaryGrabActionScript.IsActionable() : false);
+            return (GetGrabbingObject() != null && GetSecondaryGrabbingObject() == null && secondaryGrabActionScript != null ? secondaryGrabActionScript.IsActionable() : false);
         }
 
         /// <summary>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3379,7 +3379,7 @@ The IsSwappable method returns whether the object can be grabbed with one contro
   * Parameters
    * _none_
   * Returns
-   * `bool` - Returns true if the obejct has a secondary action, returns false if it has no secondary action or is swappable.
+   * `bool` - Returns true if the object has a secondary action, returns false if it has no secondary action or is swappable.
 
 The PerformSecondaryAction method returns whether the object has a secondary action that can be performed when grabbing the object with a secondary controller.
 


### PR DESCRIPTION
There was an issue that if a secondary grab mechanic was set then it
was still possible to grab an object even if the `isGrabbable` option
was set to false.

This was due to the `PerformSecondaryAction` method would not take
into consideration if a primary grab had already occurred. The fix
is to check if a primary grab has occurred in that method.