### PR TITLE
fix(Tooltips): make retry init variables public - fixes #1202

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -76,13 +76,15 @@ namespace VRTK
         public VRTK_HeadsetControllerAware headsetControllerAware;
         [Tooltip("If this is checked then the tooltips will be hidden when the headset is not looking at the controller.")]
         public bool hideWhenNotInView = true;
+        [Tooltip("The total number of initialisation attempts to make when waiting for the button transforms to initialise.")]
+        public int retryInitMaxTries = 10;
+        [Tooltip("The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.")]
+        public float retryInitCounter = 0.1f;
 
         protected TooltipButtons[] availableButtons;
         protected VRTK_ObjectTooltip[] buttonTooltips;
         protected bool[] tooltipStates;
 
-        protected float retryInitCounter = 0.1f;
-        protected int retryInitMaxTries = 5;
         protected int retryInitCurrentTries = 0;
 
         /// <summary>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -216,6 +216,8 @@ There are a number of parameters that can be set on the Prefab which are provide
  * **Controller Events:** The controller to read the controller events from. If this is blank then it will attempt to get a controller events script from the same or parent GameObject.
  * **Headset Controller Aware:** The headset controller aware script to use to see if the headset is looking at the controller. If this is blank then it will attempt to get a controller events script from the same or parent GameObject.
  * **Hide When Not In View:** If this is checked then the tooltips will be hidden when the headset is not looking at the controller.
+ * **Retry Init Max Tries:** The total number of initialisation attempts to make when waiting for the button transforms to initialise.
+ * **Retry Init Counter:** The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.
 
 ### Class Methods
 


### PR DESCRIPTION
The initialisation retry attempts of the Controller Tooltips can now
be customised via the inspector parameters rather than being hidden
variables.

This is useful if they need further tweaking, or no auto initialisation
is required and then they can be disabled.

Sometimes controllers take longer to initialise so it's now possible
to increase the retry attempts to ensure initialisation of the
tooltips still works.