### PR TITLE
feat(SnapDropZone): add getter method for drop zone object

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -226,6 +226,24 @@ namespace VRTK
             return currentValidSnapObjects.Contains(checkObject);
         }
 
+        /// <summary>
+        /// The GetHoveringObjects method returns a List of valid GameObjects that are currently hovering (but not snapped) in the snap drop zone area.
+        /// </summary>
+        /// <returns>The List of valid GameObjects that are hovering (but not snapped) in the snap drop zone area.</returns>
+        public virtual List<GameObject> GetHoveringObjects()
+        {
+            return currentValidSnapObjects;
+        }
+
+        /// <summary>
+        /// The GetCurrentSnappedObejct method returns the GameObject that is currently snapped in the snap drop zone area.
+        /// </summary>
+        /// <returns>The GameObject that is currently snapped in the snap drop zone area.</returns>
+        public virtual GameObject GetCurrentSnappedObject()
+        {
+            return currentSnappedObject;
+        }
+
         protected virtual void Awake()
         {
             if (Application.isPlaying)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -391,6 +391,28 @@ The ValidSnappableObjectIsHovering method determines if any valid objects are cu
 
 The IsObjectHovering method determines if the given GameObject is currently howvering (but not snapped) in the snap drop zone area.
 
+#### GetHoveringObjects/0
+
+  > `public virtual List<GameObject> GetHoveringObjects()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `List<GameObject>` - The List of valid GameObjects that are hovering (but not snapped) in the snap drop zone area.
+
+The GetHoveringObjects method returns a List of valid GameObjects that are currently hovering (but not snapped) in the snap drop zone area.
+
+#### GetCurrentSnappedObject/0
+
+  > `public virtual GameObject GetCurrentSnappedObject()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `GameObject` - The GameObject that is currently snapped in the snap drop zone area.
+
+The GetCurrentSnappedObejct method returns the GameObject that is currently snapped in the snap drop zone area.
+
 ### Example
 
 `VRTK/Examples/041_Controller_ObjectSnappingToDropZones` uses the `VRTK_SnapDropZone` prefab to set up pre-determined snap zones for a range of objects and demonstrates how only objects of certain types can be snapped into certain areas.


### PR DESCRIPTION
Two new methods have been added to get the current hovered objects
and the current snapped object from within a snap drop zone.

Previously, the only way of knowing what was in a snap drop zone was
to register for the event when an item was hovered or snapped into
the zone.

Now these two new methods provide a way of directly accessing the
info on the snap drop zone without needing to use the event.