### PR TITLE
feat(Locomotion): allow force destination in force teleport method

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -143,7 +143,8 @@ namespace VRTK
         /// <param name="target">The Transform of the destination object.</param>
         /// <param name="destinationPosition">The world position to teleport to.</param>
         /// <param name="destinationRotation">The world rotation to teleport to.</param>
-        public virtual void ForceTeleport(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null)
+        /// <param name="forceDestinationPosition">If true then the given destination position should not be altered by anything consuming the payload.</param>
+        public virtual void ForceTeleport(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null, bool forceDestinationPosition = false)
         {
             DestinationMarkerEventArgs teleportArgs = new DestinationMarkerEventArgs();
             teleportArgs.distance = Vector3.Distance(new Vector3(headset.position.x, playArea.position.y, headset.position.z), destinationPosition);
@@ -151,7 +152,7 @@ namespace VRTK
             teleportArgs.raycastHit = new RaycastHit();
             teleportArgs.destinationPosition = destinationPosition;
             teleportArgs.destinationRotation = destinationRotation;
-            teleportArgs.forceDestinationPosition = false;
+            teleportArgs.forceDestinationPosition = forceDestinationPosition;
             teleportArgs.enableTeleport = true;
             ForceTeleport(teleportArgs);
         }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1742,14 +1742,15 @@ The ValidLocation method determines if the given target is a location that can b
 
 The ForceTeleport/1 method forces the teleport to update position without needing to listen for a Destination Marker event.
 
-#### ForceTeleport/3
+#### ForceTeleport/4
 
-  > `public virtual void ForceTeleport(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null)`
+  > `public virtual void ForceTeleport(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null, bool forceDestinationPosition = false)`
 
   * Parameters
    * `Transform target` - The Transform of the destination object.
    * `Vector3 destinationPosition` - The world position to teleport to.
    * `Quaternion? destinationRotation` - The world rotation to teleport to.
+   * `bool forceDestinationPosition` - If true then the given destination position should not be altered by anything consuming the payload.
   * Returns
    * _none_
 


### PR DESCRIPTION
The `ForceTeleport` method now also has an optional
`forceDestinationPosition` option to ensure the actual provided
location is used when forcing the new teleport location.