### PR TITLE
Set actualTracer's localScale to vector3.zero when it is spawned

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -122,6 +122,7 @@ namespace VRTK
             else
             {
                 actualTracer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                actualTracer.transform.localScale = Vector3.zero;
                 actualTracer.GetComponent<BoxCollider>().isTrigger = true;
                 actualTracer.AddComponent<Rigidbody>().isKinematic = true;
                 actualTracer.layer = LayerMask.NameToLayer("Ignore Raycast");


### PR DESCRIPTION
When creating the actualTracer by using Cube primitive, the localScale shall be set to 0 to hide the object. Otherwise, the first frame will draw a white box and only after the update function is invoked, the tracer will change to correct position and scale.