### PR TITLE
fix(Gripping): Grip release on non-grip joint break. - fixes #1269

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseJointGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseJointGrabAttach.cs
@@ -79,7 +79,10 @@ namespace VRTK.GrabAttachMechanics
 
         protected virtual void OnJointBreak(float force)
         {
-            ForceReleaseGrab();
+			if (controllerAttachJoint == null)
+			{
+				ForceReleaseGrab();
+			}
         }
 
         protected virtual void CreateJoint(GameObject obj)


### PR DESCRIPTION
Currently if joint on an object other than the gripping joint breaks, the grip is released. This shouldn't happen.

The grip should only be released if the gripping joint breaks. This change band-aids this issue. It should actually check that the grip joint generated the OnJointBreak, but I see no way of doing this.