### PR TITLE
refactor(Structure): replace FindChild with Find

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Archery/ArrowNotch.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Archery/ArrowNotch.cs
@@ -9,7 +9,7 @@
 
         private void Start()
         {
-            arrow = transform.FindChild("Arrow").gameObject;
+            arrow = transform.Find("Arrow").gameObject;
             obj = GetComponent<VRTK_InteractableObject>();
         }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/FireExtinguisher_Sprayer.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/FireExtinguisher_Sprayer.cs
@@ -37,7 +37,7 @@
         protected override void Awake()
         {
             base.Awake();
-            waterSpray = transform.FindChild("WaterSpray").gameObject;
+            waterSpray = transform.Find("WaterSpray").gameObject;
             particles = waterSpray.GetComponent<ParticleSystem>();
             particles.Stop();
         }

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/LightSaber.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/LightSaber.cs
@@ -55,7 +55,7 @@
             if (beamActive)
             {
                 Color bladeColor = Color.Lerp(activeColor, targetColor, Mathf.PingPong(Time.time, 1));
-                blade.transform.FindChild("Beam").GetComponent<MeshRenderer>().material.color = bladeColor;
+                blade.transform.Find("Beam").GetComponent<MeshRenderer>().material.color = bladeColor;
 
                 if (bladeColor == targetColor)
                 {

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/RealGun.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/RealGun.cs
@@ -111,13 +111,13 @@
             bullet = transform.Find("Bullet").gameObject;
             bullet.SetActive(false);
 
-            trigger = transform.FindChild("TriggerHolder").gameObject;
+            trigger = transform.Find("TriggerHolder").gameObject;
 
-            slide = transform.FindChild("Slide").GetComponent<RealGun_Slide>();
+            slide = transform.Find("Slide").GetComponent<RealGun_Slide>();
             slideRigidbody = slide.GetComponent<Rigidbody>();
             slideCollider = slide.GetComponent<Collider>();
 
-            safetySwitch = transform.FindChild("SafetySwitch").GetComponent<RealGun_SafetySwitch>();
+            safetySwitch = transform.Find("SafetySwitch").GetComponent<RealGun_SafetySwitch>();
             safetySwitchRigidbody = safetySwitch.GetComponent<Rigidbody>();
             safetySwitchCollider = safetySwitch.GetComponent<Collider>();
         }

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/SnapDropZoneGroup_Switcher.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/SnapDropZoneGroup_Switcher.cs
@@ -9,8 +9,8 @@
 
         private void Start()
         {
-            cubeZone = transform.FindChild("Cube_SnapDropZone").gameObject;
-            sphereZone = transform.FindChild("Sphere_SnapDropZone").gameObject;
+            cubeZone = transform.Find("Cube_SnapDropZone").gameObject;
+            sphereZone = transform.Find("Sphere_SnapDropZone").gameObject;
 
             cubeZone.GetComponent<VRTK_SnapDropZone>().ObjectEnteredSnapDropZone += new SnapDropZoneEventHandler(DoCubeZoneSnapped);
             cubeZone.GetComponent<VRTK_SnapDropZone>().ObjectSnappedToDropZone += new SnapDropZoneEventHandler(DoCubeZoneSnapped);

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ConsoleViewer.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ConsoleViewer.cs
@@ -67,9 +67,9 @@ namespace VRTK
                 { LogType.Log, infoMessage },
                 { LogType.Warning, warningMessage }
             };
-            scrollWindow = transform.FindChild("Panel/Scroll View").GetComponent<ScrollRect>();
-            consoleRect = transform.FindChild("Panel/Scroll View/Viewport/Content").GetComponent<RectTransform>();
-            consoleOutput = transform.FindChild("Panel/Scroll View/Viewport/Content/ConsoleOutput").GetComponent<Text>();
+            scrollWindow = transform.Find("Panel/Scroll View").GetComponent<ScrollRect>();
+            consoleRect = transform.Find("Panel/Scroll View/Viewport/Content").GetComponent<RectTransform>();
+            consoleOutput = transform.Find("Panel/Scroll View/Viewport/Content/ConsoleOutput").GetComponent<Text>();
 
             consoleOutput.fontSize = fontSize;
             ClearLog();

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -205,7 +205,7 @@ namespace VRTK
 
             for (int i = 1; i < availableButtons.Length; i++)
             {
-                buttonTooltips[i] = transform.FindChild(availableButtons[i].ToString()).GetComponent<VRTK_ObjectTooltip>();
+                buttonTooltips[i] = transform.Find(availableButtons[i].ToString()).GetComponent<VRTK_ObjectTooltip>();
             }
 
             retryInitCurrentTries = retryInitMaxTries;
@@ -366,7 +366,7 @@ namespace VRTK
                 {
                     SDK_BaseController.ControllerHand controllerHand = VRTK_DeviceFinder.GetControllerHand(controllerEvents.gameObject);
                     string elementPath = VRTK_SDK_Bridge.GetControllerElementPath(findElement, controllerHand, true);
-                    returnTransform = (elementPath != null ? modelController.transform.FindChild(elementPath) : null);
+                    returnTransform = (elementPath != null ? modelController.transform.Find(elementPath) : null);
                 }
             }
 

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ObjectTooltip.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ObjectTooltip.cs
@@ -91,15 +91,15 @@ namespace VRTK
 
         protected virtual void SetContainer()
         {
-            transform.FindChild("TooltipCanvas").GetComponent<RectTransform>().sizeDelta = containerSize;
-            Transform tmpContainer = transform.FindChild("TooltipCanvas/UIContainer");
+            transform.Find("TooltipCanvas").GetComponent<RectTransform>().sizeDelta = containerSize;
+            Transform tmpContainer = transform.Find("TooltipCanvas/UIContainer");
             tmpContainer.GetComponent<RectTransform>().sizeDelta = containerSize;
             tmpContainer.GetComponent<Image>().color = containerColor;
         }
 
         protected virtual void SetText(string name)
         {
-            Text tmpText = transform.FindChild("TooltipCanvas/" + name).GetComponent<Text>();
+            Text tmpText = transform.Find("TooltipCanvas/" + name).GetComponent<Text>();
             tmpText.material = Resources.Load("UIText") as Material;
             tmpText.text = displayText.Replace("\\n", "\n");
             tmpText.color = fontColor;
@@ -108,7 +108,7 @@ namespace VRTK
 
         protected virtual void SetLine()
         {
-            line = transform.FindChild("Line").GetComponent<LineRenderer>();
+            line = transform.Find("Line").GetComponent<LineRenderer>();
             line.material = Resources.Load("TooltipLine") as Material;
             line.material.color = lineColor;
 #if UNITY_5_5_OR_NEWER

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -163,7 +163,7 @@ namespace VRTK
                 DeleteHighlightObject();
             }
             //Always remove editor highlight object at runtime
-            ChooseDestroyType(transform.FindChild(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME)));
+            ChooseDestroyType(transform.Find(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME)));
             highlightEditorObject = null;
 
             GenerateObjects();
@@ -410,26 +410,26 @@ namespace VRTK
         {
             if (highlightEditorObject == null)
             {
-                Transform forceFindHighlightEditorObject = transform.FindChild(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME));
+                Transform forceFindHighlightEditorObject = transform.Find(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME));
                 highlightEditorObject = (forceFindHighlightEditorObject ? forceFindHighlightEditorObject.gameObject : null);
             }
 
             if (highlightObject == null)
             {
-                Transform forceFindHighlightObject = transform.FindChild(ObjectPath(HIGHLIGHT_OBJECT_NAME));
+                Transform forceFindHighlightObject = transform.Find(ObjectPath(HIGHLIGHT_OBJECT_NAME));
                 highlightObject = (forceFindHighlightObject ? forceFindHighlightObject.gameObject : null);
             }
 
             if (highlightContainer == null)
             {
-                Transform forceFindHighlightContainer = transform.FindChild(HIGHLIGHT_CONTAINER_NAME);
+                Transform forceFindHighlightContainer = transform.Find(HIGHLIGHT_CONTAINER_NAME);
                 highlightContainer = (forceFindHighlightContainer ? forceFindHighlightContainer.gameObject : null);
             }
         }
 
         protected virtual void GenerateContainer()
         {
-            if (highlightContainer == null || transform.FindChild(HIGHLIGHT_CONTAINER_NAME) == null)
+            if (highlightContainer == null || transform.Find(HIGHLIGHT_CONTAINER_NAME) == null)
             {
                 highlightContainer = new GameObject(HIGHLIGHT_CONTAINER_NAME);
                 highlightContainer.transform.SetParent(transform);
@@ -441,7 +441,7 @@ namespace VRTK
 
         protected virtual void SetContainer()
         {
-            Transform findContainer = transform.FindChild(HIGHLIGHT_CONTAINER_NAME);
+            Transform findContainer = transform.Find(HIGHLIGHT_CONTAINER_NAME);
             if (findContainer != null)
             {
                 highlightContainer = findContainer.gameObject;
@@ -674,13 +674,13 @@ namespace VRTK
         protected virtual void GenerateHighlightObject()
         {
             //If there is a given highlight prefab and no existing highlight object then create a new highlight object
-            if (highlightObjectPrefab != null && highlightObject == null && transform.FindChild(ObjectPath(HIGHLIGHT_OBJECT_NAME)) == null)
+            if (highlightObjectPrefab != null && highlightObject == null && transform.Find(ObjectPath(HIGHLIGHT_OBJECT_NAME)) == null)
             {
                 CopyObject(highlightObjectPrefab, ref highlightObject, HIGHLIGHT_OBJECT_NAME);
             }
 
             //if highlight object exists but not in the variable then force grab it
-            Transform checkForChild = transform.FindChild(ObjectPath(HIGHLIGHT_OBJECT_NAME));
+            Transform checkForChild = transform.Find(ObjectPath(HIGHLIGHT_OBJECT_NAME));
             if (checkForChild != null && highlightObject == null)
             {
                 highlightObject = checkForChild.gameObject;
@@ -701,7 +701,7 @@ namespace VRTK
 
         protected virtual void DeleteHighlightObject()
         {
-            ChooseDestroyType(transform.FindChild(HIGHLIGHT_CONTAINER_NAME));
+            ChooseDestroyType(transform.Find(HIGHLIGHT_CONTAINER_NAME));
             highlightContainer = null;
             highlightObject = null;
             objectHighlighter = null;
@@ -709,7 +709,7 @@ namespace VRTK
 
         protected virtual void GenerateEditorHighlightObject()
         {
-            if (highlightObject != null && highlightEditorObject == null && transform.FindChild(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME)) == null)
+            if (highlightObject != null && highlightEditorObject == null && transform.Find(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME)) == null)
             {
                 CopyObject(highlightObject, ref highlightEditorObject, HIGHLIGHT_EDITOR_OBJECT_NAME);
                 foreach (Renderer renderer in highlightEditorObject.GetComponentsInChildren<Renderer>())

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -252,10 +252,10 @@ namespace VRTK
                 switch (hand)
                 {
                     case ControllerHand.Left:
-                        model = simPlayer.transform.FindChild(string.Format("{0}/Hand", LEFT_HAND_CONTROLLER_NAME)).gameObject;
+                        model = simPlayer.transform.Find(string.Format("{0}/Hand", LEFT_HAND_CONTROLLER_NAME)).gameObject;
                         break;
                     case ControllerHand.Right:
-                        model = simPlayer.transform.FindChild(string.Format("{0}/Hand", RIGHT_HAND_CONTROLLER_NAME)).gameObject;
+                        model = simPlayer.transform.Find(string.Format("{0}/Hand", RIGHT_HAND_CONTROLLER_NAME)).gameObject;
                         break;
                 }
             }
@@ -269,7 +269,7 @@ namespace VRTK
         /// <returns>A GameObject containing the object that has a render model for the controller.</returns>
         public override GameObject GetControllerRenderModel(VRTK_ControllerReference controllerReference)
         {
-            return controllerReference.scriptAlias.transform.parent.FindChild("Hand").gameObject;
+            return controllerReference.scriptAlias.transform.parent.Find("Hand").gameObject;
         }
 
         /// <summary>
@@ -417,8 +417,8 @@ namespace VRTK
             GameObject simPlayer = SDK_InputSimulator.FindInScene();
             if (simPlayer != null)
             {
-                rightController = simPlayer.transform.FindChild(RIGHT_HAND_CONTROLLER_NAME).GetComponent<SDK_ControllerSim>();
-                leftController = simPlayer.transform.FindChild(LEFT_HAND_CONTROLLER_NAME).GetComponent<SDK_ControllerSim>();
+                rightController = simPlayer.transform.Find(RIGHT_HAND_CONTROLLER_NAME).GetComponent<SDK_ControllerSim>();
+                leftController = simPlayer.transform.Find(LEFT_HAND_CONTROLLER_NAME).GetComponent<SDK_ControllerSim>();
             }
         }
 
@@ -563,10 +563,10 @@ namespace VRTK
                 switch (hand)
                 {
                     case ControllerHand.Right:
-                        controller = simPlayer.transform.FindChild(RIGHT_HAND_CONTROLLER_NAME).gameObject;
+                        controller = simPlayer.transform.Find(RIGHT_HAND_CONTROLLER_NAME).gameObject;
                         break;
                     case ControllerHand.Left:
-                        controller = simPlayer.transform.FindChild(LEFT_HAND_CONTROLLER_NAME).gameObject;
+                        controller = simPlayer.transform.Find(LEFT_HAND_CONTROLLER_NAME).gameObject;
                         break;
                     default:
                         break;

--- a/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimHeadset.cs
@@ -59,7 +59,7 @@ namespace VRTK
                 GameObject simPlayer = SDK_InputSimulator.FindInScene();
                 if (simPlayer)
                 {
-                    camera = simPlayer.transform.FindChild("Camera");
+                    camera = simPlayer.transform.Find("Camera");
                 }
             }
 

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -203,7 +203,7 @@ namespace VRTK.Highlighters
             }
             else if (givenOutlineModelPath != "")
             {
-                var getChildModel = transform.FindChild(givenOutlineModelPath);
+                var getChildModel = transform.Find(givenOutlineModelPath);
                 givenOutlineModel = (getChildModel ? getChildModel.gameObject : null);
             }
 

--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -117,7 +117,7 @@ namespace VRTK
 
         protected virtual IEnumerator CreateDraggablePanel(Canvas canvas, Vector2 canvasSize)
         {
-            if (canvas && !canvas.transform.FindChild(CANVAS_DRAGGABLE_PANEL))
+            if (canvas && !canvas.transform.Find(CANVAS_DRAGGABLE_PANEL))
             {
                 yield return null;
 
@@ -138,7 +138,7 @@ namespace VRTK
         protected virtual void CreateActivator(Canvas canvas, Vector2 canvasSize)
         {
             //if autoActivateWithinDistance is greater than 0 then create the front collider sub object
-            if (autoActivateWithinDistance > 0f && canvas && !canvas.transform.FindChild(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT))
+            if (autoActivateWithinDistance > 0f && canvas && !canvas.transform.Find(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT))
             {
                 var canvasRectTransform = canvas.GetComponent<RectTransform>();
                 Vector2 pivot = canvasRectTransform.pivot;
@@ -197,13 +197,13 @@ namespace VRTK
             }
 
             StopCoroutine(draggablePanelCreation);
-            var draggablePanel = canvas.transform.FindChild(CANVAS_DRAGGABLE_PANEL);
+            var draggablePanel = canvas.transform.Find(CANVAS_DRAGGABLE_PANEL);
             if (draggablePanel)
             {
                 Destroy(draggablePanel.gameObject);
             }
 
-            var frontTrigger = canvas.transform.FindChild(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT);
+            var frontTrigger = canvas.transform.Find(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT);
             if (frontTrigger)
             {
                 Destroy(frontTrigger.gameObject);


### PR DESCRIPTION
Transform.FindChild() is no longer part of the documentation,
but still exists as part of the UnityEngine assembly.
It is depricated and is functionally identical to Transform.Find().