### PR TITLE
fix(Utilities): allow for trigger colliders to be ignored by casts - fixes #1230

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -62,7 +62,7 @@ namespace VRTK
             Ray ray = new Ray(tipPosition + rayStartPositionOffset, -playArea.up);
             RaycastHit rayCollidedWith;
 #pragma warning disable 0618
-            if (target && VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity))
+            if (target != null && VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity, QueryTriggerInteraction.Ignore))
 #pragma warning restore 0618
             {
                 newY = (tipPosition.y - rayCollidedWith.distance) + heightOffset;

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -626,7 +626,7 @@ namespace VRTK
 
             //Determine the current valid floor that the user is standing over
 #pragma warning disable 0618
-            currentValidFloorObject = (VRTK_CustomRaycast.Raycast(customRaycast, standingDownRay, out standingDownRayCollision, layersToIgnore, Mathf.Infinity) ? standingDownRayCollision.collider.gameObject : null);
+            currentValidFloorObject = (VRTK_CustomRaycast.Raycast(customRaycast, standingDownRay, out standingDownRayCollision, layersToIgnore, Mathf.Infinity, QueryTriggerInteraction.Ignore) ? standingDownRayCollision.collider.gameObject : null);
 #pragma warning restore 0618
 
             //Don't bother checking for lean if body collisions are disabled
@@ -647,7 +647,7 @@ namespace VRTK
             // Cast a ray forward just outside the body collider radius to see if anything is blocking your path
             // If nothing is blocking your path and you're currently standing over a valid floor
 #pragma warning disable 0618
-            if (!VRTK_CustomRaycast.Raycast(customRaycast, forwardRay, out forwardRayCollision, layersToIgnore, forwardLength) && currentValidFloorObject != null)
+            if (!VRTK_CustomRaycast.Raycast(customRaycast, forwardRay, out forwardRayCollision, layersToIgnore, forwardLength, QueryTriggerInteraction.Ignore) && currentValidFloorObject != null)
 #pragma warning restore 0618
             {
                 CalculateLean(standingDownRayStartPosition, forwardLength, standingDownRayCollision.distance);
@@ -668,7 +668,7 @@ namespace VRTK
 
             //Cast a ray down from the end of the forward ray position
 #pragma warning disable 0618
-            if (VRTK_CustomRaycast.Raycast(customRaycast, downRay, out downRayCollision, layersToIgnore, Mathf.Infinity))
+            if (VRTK_CustomRaycast.Raycast(customRaycast, downRay, out downRayCollision, layersToIgnore, Mathf.Infinity, QueryTriggerInteraction.Ignore))
 #pragma warning restore 0618
             {
                 //Determine the difference between the original down ray and the projected forward a bit downray
@@ -1034,7 +1034,7 @@ namespace VRTK
             Ray ray = new Ray(controllerObj.transform.position, -playArea.up);
             RaycastHit rayCollidedWith;
 #pragma warning disable 0618
-            VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity);
+            VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity, QueryTriggerInteraction.Ignore);
 #pragma warning restore 0618
             return controllerObj.transform.position.y - rayCollidedWith.distance;
         }
@@ -1078,7 +1078,7 @@ namespace VRTK
                 Ray ray = new Ray(headset.transform.position, -playArea.up);
                 RaycastHit rayCollidedWith;
 #pragma warning disable 0618
-                bool rayHit = VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity);
+                bool rayHit = VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, layersToIgnore, Mathf.Infinity, QueryTriggerInteraction.Ignore);
 #pragma warning restore 0618
                 hitFloorYDelta = playArea.position.y - rayCollidedWith.point.y;
 

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
@@ -204,7 +204,7 @@ namespace VRTK
             {
                 var destination = (customDestination ? customDestination.position : controller.transform.position);
                 RaycastHit hitInfo;
-                if (VRTK_CustomRaycast.Linecast(customRaycast, headset.position, destination, out hitInfo, new LayerMask()))
+                if (VRTK_CustomRaycast.Linecast(customRaycast, headset.position, destination, out hitInfo, new LayerMask(), QueryTriggerInteraction.Ignore))
                 {
                     obscured = true;
                 }

--- a/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
@@ -27,8 +27,9 @@ namespace VRTK
         /// <param name="hitData">The raycast hit data.</param>
         /// <param name="ignoreLayers">A layermask of layers to ignore from the raycast.</param>
         /// <param name="length">The maximum length of the raycast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
         /// <returns>Returns true if the raycast successfully collides with a valid object.</returns>
-        public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity)
+        public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
             {
@@ -36,7 +37,7 @@ namespace VRTK
             }
             else
             {
-                return Physics.Raycast(ray, out hitData, length, ~ignoreLayers);
+                return Physics.Raycast(ray, out hitData, length, ~ignoreLayers, affectTriggers);
             }
         }
 
@@ -48,8 +49,9 @@ namespace VRTK
         /// <param name="endPosition">The world position to end the linecast at.</param>
         /// <param name="hitData">The linecast hit data.</param>
         /// <param name="ignoreLayers">A layermask of layers to ignore from the linecast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
         /// <returns>Returns true if the linecast successfully collides with a valid object.</returns>
-        public static bool Linecast(VRTK_CustomRaycast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers)
+        public static bool Linecast(VRTK_CustomRaycast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
             {
@@ -57,7 +59,7 @@ namespace VRTK
             }
             else
             {
-                return Physics.Linecast(startPosition, endPosition, out hitData);
+                return Physics.Linecast(startPosition, endPosition, out hitData, ~ignoreLayers, affectTriggers);
             }
         }
 
@@ -82,7 +84,7 @@ namespace VRTK
         /// <returns>Returns true if the line successfully collides with a valid object.</returns>
         public virtual bool CustomLinecast(Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData)
         {
-            return Physics.Linecast(startPosition, endPosition, out hitData, ~layersToIgnore);
+            return Physics.Linecast(startPosition, endPosition, out hitData, ~layersToIgnore, triggerInteraction);
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6692,9 +6692,9 @@ For example, the VRTK_BodyPhysics script can be set to ignore trigger colliders 
 
 ### Class Methods
 
-#### Raycast/5
+#### Raycast/6
 
-  > `public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity)`
+  > `public static bool Raycast(VRTK_CustomRaycast customCast, Ray ray, out RaycastHit hitData, LayerMask ignoreLayers, float length = Mathf.Infinity, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)`
 
   * Parameters
    * `VRTK_CustomRaycast customCast` - The optional object with customised cast parameters.
@@ -6702,14 +6702,15 @@ For example, the VRTK_BodyPhysics script can be set to ignore trigger colliders 
    * `out RaycastHit hitData` - The raycast hit data.
    * `LayerMask ignoreLayers` - A layermask of layers to ignore from the raycast.
    * `float length` - The maximum length of the raycast.
+   * `QueryTriggerInteraction affectTriggers` - Determines the trigger interaction level of the cast.
   * Returns
    * `bool` - Returns true if the raycast successfully collides with a valid object.
 
 The Raycast method is used to generate a raycast either from the given CustomRaycast object or a default Physics.Raycast.
 
-#### Linecast/5
+#### Linecast/6
 
-  > `public static bool Linecast(VRTK_CustomRaycast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers)`
+  > `public static bool Linecast(VRTK_CustomRaycast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)`
 
   * Parameters
    * `VRTK_CustomRaycast customCast` - The optional object with customised cast parameters.
@@ -6717,6 +6718,7 @@ The Raycast method is used to generate a raycast either from the given CustomRay
    * `Vector3 endPosition` - The world position to end the linecast at.
    * `out RaycastHit hitData` - The linecast hit data.
    * `LayerMask ignoreLayers` - A layermask of layers to ignore from the linecast.
+   * `QueryTriggerInteraction affectTriggers` - Determines the trigger interaction level of the cast.
   * Returns
    * `bool` - Returns true if the linecast successfully collides with a valid object.
 


### PR DESCRIPTION
The various casts done by scripts such as Body Physics, teleporters
and the pointers were all colliding with trigger colliders by default.

The CustomRaycast script has now been updated so it can be called
and informed to ignore trigger colliders without providing an
instantiated CustomRaycast object.

Body Physics and the teleporters now ignore trigger colliders by
default, whereas the pointers still interact with trigger colliders
by default because the UI Canvas generates a trigger collider.

If the pointer is required to pass through a trigger collider then
the object should be put on the Ignore Raycasts layer.