### PR TITLE
fix(Slide Locomotion): decrease y axis' role in SlideObjectControlAction

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SlideObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SlideObjectControlAction.cs
@@ -79,6 +79,8 @@ namespace VRTK
             if (directionDevice && directionDevice.gameObject.activeInHierarchy && controlledGameObject.activeInHierarchy)
             {
                 float storeYPosition = controlledGameObject.transform.position.y;
+                axisDirection.y *= 0.1f;
+                axisDirection.Normalize();
                 Vector3 updatedPosition = axisDirection * currentSpeed * Time.deltaTime;
                 controlledGameObject.transform.position += updatedPosition;
                 controlledGameObject.transform.position = new Vector3(controlledGameObject.transform.position.x, storeYPosition, controlledGameObject.transform.position.z);


### PR DESCRIPTION
Scaling down the Y axis (but not to 0) makes it so that you will experience less "slowdown" while angling the controllers up or down when using the slide locomotion, but I propose avoid just forcing it to zero as that can cause a jerky jolt if you spin the controller vertically.