### PR TITLE
fix(SDKManager): honour script enable states - fixes #1216

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -184,6 +184,7 @@ namespace VRTK
         /// </summary>
         public ReadOnlyCollection<Behaviour> behavioursToToggleOnLoadedSetupChange { get; private set; }
         private List<Behaviour> _behavioursToToggleOnLoadedSetupChange = new List<Behaviour>();
+        private Dictionary<Behaviour, bool> _behavioursInitialState = new Dictionary<Behaviour, bool>();
 
         /// <summary>
         /// The event invoked whenever the loaded SDK Setup changes.
@@ -365,6 +366,7 @@ namespace VRTK
             if (!_behavioursToToggleOnLoadedSetupChange.Contains(behaviour))
             {
                 _behavioursToToggleOnLoadedSetupChange.Add(behaviour);
+                _behavioursInitialState.Add(behaviour, behaviour.enabled);
             }
 
             if (loadedSetup == null && behaviour.enabled)
@@ -671,7 +673,7 @@ namespace VRTK
 
             foreach (Behaviour behaviour in listCopy)
             {
-                behaviour.enabled = state;
+                behaviour.enabled = (state && _behavioursInitialState.ContainsKey(behaviour) ? _behavioursInitialState[behaviour] : state);
             }
         }
 


### PR DESCRIPTION
The VRTK scripts that register with the SDK Manager were always
being set to enabled even if the script was set to disabled in the
editor.

This fix stores the state of the registered script and then sets it
back to that original state when the SDK Manager runs through the
behaviours registered with it. This means the enabled state of the
scripts are now remembered and set appropriately.