### PR TITLE
fix(Interactions): pass relevant VRTK_InteractX to interactable object

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/FireExtinguisher_Base.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/FireExtinguisher_Base.cs
@@ -10,13 +10,13 @@
 
         private VRTK_ControllerEvents controllerEvents;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             controllerEvents = usingObject.GetComponent<VRTK_ControllerEvents>();
         }
 
-        public override void StopUsing(GameObject previousUsingObject)
+        public override void StopUsing(VRTK_InteractUse previousUsingObject)
         {
             base.StopUsing(previousUsingObject);
             controllerEvents = null;

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Gun.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Gun.cs
@@ -8,7 +8,7 @@
         private float bulletSpeed = 1000f;
         private float bulletLife = 5f;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             FireBullet();

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Lamp.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Lamp.cs
@@ -4,13 +4,13 @@
 
     public class Lamp : VRTK_InteractableObject
     {
-        public override void Grabbed(GameObject grabbingObject)
+        public override void Grabbed(VRTK_InteractGrab grabbingObject)
         {
             base.Grabbed(grabbingObject);
             ToggleKinematics(false);
         }
 
-        public override void Ungrabbed(GameObject previousGrabbingObject)
+        public override void Ungrabbed(VRTK_InteractGrab previousGrabbingObject)
         {
             base.Ungrabbed(previousGrabbingObject);
             ToggleKinematics(true);

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/LightSaber.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/LightSaber.cs
@@ -14,7 +14,7 @@
         private Color targetColor;
         private Color[] bladePhaseColors;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             beamExtendSpeed = 5f;
@@ -23,7 +23,7 @@
             targetColor = bladePhaseColors[1];
         }
 
-        public override void StopUsing(GameObject usingObject)
+        public override void StopUsing(VRTK_InteractUse usingObject)
         {
             base.StopUsing(usingObject);
             beamExtendSpeed = -5f;

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Menu_Color_Changer.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Menu_Color_Changer.cs
@@ -6,7 +6,7 @@
     {
         public Color newMenuColor = Color.black;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             transform.parent.gameObject.GetComponent<Menu_Container_Object_Colors>().SetSelectedColor(newMenuColor);
@@ -23,7 +23,7 @@
         {
             foreach (Menu_Color_Changer menuColorChanger in FindObjectsOfType<Menu_Color_Changer>())
             {
-                menuColorChanger.StopUsing(null);
+                menuColorChanger.StopUsing();
             }
         }
     }

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Menu_Object_Spawner.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Menu_Object_Spawner.cs
@@ -19,7 +19,7 @@
             gameObject.GetComponent<MeshRenderer>().material.color = color;
         }
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
 
@@ -47,7 +47,7 @@
         {
             foreach (Menu_Object_Spawner menuObjectSpawner in FindObjectsOfType<Menu_Object_Spawner>())
             {
-                menuObjectSpawner.StopUsing(null);
+                menuObjectSpawner.StopUsing();
             }
         }
     }

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Openable_Door.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Openable_Door.cs
@@ -16,7 +16,7 @@
         private Vector3 defaultRotation;
         private Vector3 openRotation;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             SetDoorRotation(usingObject.transform.position);

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/RealGun.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/RealGun.cs
@@ -48,7 +48,7 @@
             ToggleCollision(safetySwitchRigidbody, safetySwitchCollider, state);
         }
 
-        public override void Grabbed(GameObject currentGrabbingObject)
+        public override void Grabbed(VRTK_InteractGrab currentGrabbingObject)
         {
             base.Grabbed(currentGrabbingObject);
 
@@ -58,14 +58,14 @@
             ToggleSafetySwitch(true);
 
             //Limit hands grabbing when picked up
-            if (VRTK_DeviceFinder.GetControllerHand(currentGrabbingObject) == SDK_BaseController.ControllerHand.Left)
+            if (VRTK_DeviceFinder.GetControllerHand(currentGrabbingObject.controllerEvents.gameObject) == SDK_BaseController.ControllerHand.Left)
             {
                 allowedTouchControllers = AllowedController.LeftOnly;
                 allowedUseControllers = AllowedController.LeftOnly;
                 slide.allowedGrabControllers = AllowedController.RightOnly;
                 safetySwitch.allowedGrabControllers = AllowedController.RightOnly;
             }
-            else if (VRTK_DeviceFinder.GetControllerHand(currentGrabbingObject) == SDK_BaseController.ControllerHand.Right)
+            else if (VRTK_DeviceFinder.GetControllerHand(currentGrabbingObject.controllerEvents.gameObject) == SDK_BaseController.ControllerHand.Right)
             {
                 allowedTouchControllers = AllowedController.RightOnly;
                 allowedUseControllers = AllowedController.RightOnly;
@@ -74,7 +74,7 @@
             }
         }
 
-        public override void Ungrabbed(GameObject previousGrabbingObject)
+        public override void Ungrabbed(VRTK_InteractGrab previousGrabbingObject)
         {
             base.Ungrabbed(previousGrabbingObject);
 
@@ -90,7 +90,7 @@
             controllerEvents = null;
         }
 
-        public override void StartUsing(GameObject currentUsingObject)
+        public override void StartUsing(VRTK_InteractUse currentUsingObject)
         {
             base.StartUsing(currentUsingObject);
             if (safetySwitch.safetyOff)

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/RealGun_SafetySwitch.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/RealGun_SafetySwitch.cs
@@ -9,7 +9,7 @@
         private float offAngle = 40f;
         private Vector3 fixedPosition;
 
-        public override void StartUsing(GameObject currentUsingObject)
+        public override void StartUsing(VRTK_InteractUse currentUsingObject)
         {
             base.StartUsing(currentUsingObject);
             SetSafety(!safetyOff);

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Sword.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Sword.cs
@@ -14,13 +14,13 @@
             return collisionForce;
         }
 
-        public override void Grabbed(GameObject grabbingObject)
+        public override void Grabbed(VRTK_InteractGrab grabbingObject)
         {
             base.Grabbed(grabbingObject);
-            controllerReference = VRTK_ControllerReference.GetControllerReference(grabbingObject);
+            controllerReference = VRTK_ControllerReference.GetControllerReference(grabbingObject.controllerEvents.gameObject);
         }
 
-        public override void Ungrabbed(GameObject previousGrabbingObject)
+        public override void Ungrabbed(VRTK_InteractGrab previousGrabbingObject)
         {
             base.Ungrabbed(previousGrabbingObject);
             controllerReference = null;

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/UseRotate.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/UseRotate.cs
@@ -20,13 +20,13 @@
 
         private float spinSpeed = 0f;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             spinSpeed = activeSpinSpeed;
         }
 
-        public override void StopUsing(GameObject usingObject)
+        public override void StopUsing(VRTK_InteractUse usingObject)
         {
             base.StopUsing(usingObject);
             spinSpeed = idleSpinSpeed;

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Whirlygig.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Whirlygig.cs
@@ -7,13 +7,13 @@
         float spinSpeed = 0f;
         Transform rotator;
 
-        public override void StartUsing(GameObject usingObject)
+        public override void StartUsing(VRTK_InteractUse usingObject)
         {
             base.StartUsing(usingObject);
             spinSpeed = 360f;
         }
 
-        public override void StopUsing(GameObject usingObject)
+        public override void StopUsing(VRTK_InteractUse usingObject)
         {
             base.StopUsing(usingObject);
             spinSpeed = 0f;

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -360,12 +360,10 @@ namespace VRTK
 
         protected virtual void InitPrimaryGrab(VRTK_InteractableObject currentGrabbedObject)
         {
-            GameObject grabbingObject = controllerReference.scriptAlias;
-
-            if (!currentGrabbedObject.IsValidInteractableController(grabbingObject, currentGrabbedObject.allowedGrabControllers))
+            if (!currentGrabbedObject.IsValidInteractableController(gameObject, currentGrabbedObject.allowedGrabControllers))
             {
                 grabbedObject = null;
-                if (currentGrabbedObject.IsGrabbed(grabbingObject))
+                if (currentGrabbedObject.IsGrabbed(gameObject))
                 {
                     interactTouch.ForceStopTouching();
                 }
@@ -374,7 +372,7 @@ namespace VRTK
 
             influencingGrabbedObject = false;
             currentGrabbedObject.SaveCurrentState();
-            currentGrabbedObject.Grabbed(grabbingObject);
+            currentGrabbedObject.Grabbed(this);
             currentGrabbedObject.ZeroVelocity();
             currentGrabbedObject.ToggleHighlight(false);
             currentGrabbedObject.isKinematic = false;
@@ -382,18 +380,16 @@ namespace VRTK
 
         protected virtual void InitSecondaryGrab(VRTK_InteractableObject currentGrabbedObject)
         {
-            GameObject grabbingObject = controllerReference.scriptAlias;
-
-            if (!currentGrabbedObject.IsValidInteractableController(grabbingObject, currentGrabbedObject.allowedGrabControllers))
+            if (!currentGrabbedObject.IsValidInteractableController(gameObject, currentGrabbedObject.allowedGrabControllers))
             {
                 grabbedObject = null;
                 influencingGrabbedObject = false;
-                currentGrabbedObject.Ungrabbed(grabbingObject);
+                currentGrabbedObject.Ungrabbed(this);
                 return;
             }
 
             influencingGrabbedObject = true;
-            currentGrabbedObject.Grabbed(grabbingObject);
+            currentGrabbedObject.Grabbed(this);
         }
 
         protected virtual void CheckInfluencingObjectOnRelease()
@@ -410,13 +406,12 @@ namespace VRTK
         {
             if (grabbedObject != null)
             {
-                GameObject grabbingObject = controllerReference.scriptAlias;
                 VRTK_InteractableObject grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
                 if (!influencingGrabbedObject)
                 {
                     grabbedObjectScript.grabAttachMechanicScript.StopGrab(applyGrabbingObjectVelocity);
                 }
-                grabbedObjectScript.Ungrabbed(grabbingObject);
+                grabbedObjectScript.Ungrabbed(this);
                 grabbedObjectScript.ToggleHighlight(false);
                 ToggleControllerVisibility(true);
 
@@ -492,7 +487,6 @@ namespace VRTK
 
         protected virtual bool IsValidGrabAttempt(GameObject objectToGrab)
         {
-            GameObject grabbingObject = controllerReference.scriptAlias;
             bool initialGrabAttempt = false;
             VRTK_InteractableObject objectToGrabScript = objectToGrab.GetComponent<VRTK_InteractableObject>();
             if (grabbedObject == null && interactTouch != null && IsObjectGrabbable(interactTouch.GetTouchedObject()) && objectToGrabScript && objectToGrabScript.grabAttachMechanicScript.ValidGrab(controllerAttachPoint))
@@ -500,7 +494,7 @@ namespace VRTK
                 InitGrabbedObject();
                 if (!influencingGrabbedObject)
                 {
-                    initialGrabAttempt = objectToGrabScript.grabAttachMechanicScript.StartGrab(grabbingObject, grabbedObject, controllerAttachPoint);
+                    initialGrabAttempt = objectToGrabScript.grabAttachMechanicScript.StartGrab(gameObject, grabbedObject, controllerAttachPoint);
                 }
             }
             return initialGrabAttempt;

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -259,7 +259,6 @@ namespace VRTK
             {
                 touchedObject = colliderInteractableObject;
                 var touchedObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
-                GameObject touchingObject = gameObject;
 
                 //If this controller is not allowed to touch this interactable object then clean up touch and return before initiating a touch.
                 if (!touchedObjectScript.IsValidInteractableController(gameObject, touchedObjectScript.allowedTouchControllers))
@@ -272,7 +271,7 @@ namespace VRTK
                 touchedObjectScript.ToggleHighlight(true);
                 ToggleControllerVisibility(false);
                 CheckRumbleController(touchedObjectScript);
-                touchedObjectScript.StartTouching(touchingObject);
+                touchedObjectScript.StartTouching(this);
 
                 OnControllerTouchInteractableObject(SetControllerInteractEvent(touchedObject));
             }
@@ -397,9 +396,8 @@ namespace VRTK
         {
             if (IsObjectInteractable(untouched))
             {
-                GameObject touchingObject = gameObject;
                 var untouchedObjectScript = untouched.GetComponent<VRTK_InteractableObject>();
-                untouchedObjectScript.StopTouching(touchingObject);
+                untouchedObjectScript.StopTouching(this);
                 if (!untouchedObjectScript.IsTouched())
                 {
                     untouchedObjectScript.ToggleHighlight(false);

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -304,13 +304,13 @@ namespace VRTK
                 usingObject = touchedObject;
                 var usingObjectScript = usingObject.GetComponent<VRTK_InteractableObject>();
 
-                if (!usingObjectScript.IsValidInteractableController(controllerReference.scriptAlias, usingObjectScript.allowedUseControllers))
+                if (!usingObjectScript.IsValidInteractableController(gameObject, usingObjectScript.allowedUseControllers))
                 {
                     usingObject = null;
                     return;
                 }
 
-                usingObjectScript.StartUsing(controllerReference.scriptAlias);
+                usingObjectScript.StartUsing(this);
                 ToggleControllerVisibility(false);
                 AttemptHaptics();
                 OnControllerUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
@@ -324,7 +324,7 @@ namespace VRTK
                 var usingObjectCheck = usingObject.GetComponent<VRTK_InteractableObject>();
                 if (usingObjectCheck != null && completeStop)
                 {
-                    usingObjectCheck.StopUsing(controllerReference.scriptAlias);
+                    usingObjectCheck.StopUsing(this);
                 }
                 ToggleControllerVisibility(true);
                 OnControllerUnuseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using Highlighters;
@@ -185,7 +186,7 @@ namespace VRTK
         protected List<GameObject> touchingObjects = new List<GameObject>();
         protected List<GameObject> grabbingObjects = new List<GameObject>();
         protected List<GameObject> hoveredSnapObjects = new List<GameObject>();
-        protected GameObject usingObject = null;
+        protected VRTK_InteractUse usingObject = null;
         protected Transform trackPoint;
         protected bool customTrackPoint = false;
         protected Transform primaryControllerAttachPoint;
@@ -321,9 +322,9 @@ namespace VRTK
         /// <returns>Returns `true` if the object is currently being used.</returns>
         public virtual bool IsUsing(GameObject usedBy = null)
         {
-            if (usingObject && usedBy != null)
+            if (usingObject != null && usedBy != null)
             {
-                return (usingObject == usedBy);
+                return (usingObject.gameObject == usedBy);
             }
             return (usingObject != null);
         }
@@ -331,94 +332,166 @@ namespace VRTK
         /// <summary>
         /// The StartTouching method is called automatically when the object is touched initially. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
-        /// <param name="currentTouchingObject">The game object that is currently touching this object.</param>
+        /// <param name="currentTouchingObject">The object that is currently touching this object.</param>
+        [Obsolete("`VRTK_InteractableObject.StartTouching(GameObject currentTouchingObject)` has been replaced with `VRTK_InteractableObject.StartTouching(VRTK_InteractTouch currentTouchingObject)`. This method will be removed in a future version of VRTK.")]
         public virtual void StartTouching(GameObject currentTouchingObject)
         {
-            IgnoreColliders(currentTouchingObject);
-            if (!touchingObjects.Contains(currentTouchingObject))
+            StartTouching(currentTouchingObject.GetComponent<VRTK_InteractTouch>());
+        }
+
+        /// <summary>
+        /// The StartTouching method is called automatically when the object is touched initially. It is also a virtual method to allow for overriding in inherited classes.
+        /// </summary>
+        /// <param name="currentTouchingObject">The object that is currently touching this object.</param>
+        public virtual void StartTouching(VRTK_InteractTouch currentTouchingObject = null)
+        {
+            if (currentTouchingObject != null)
             {
-                ToggleEnableState(true);
-                touchingObjects.Add(currentTouchingObject);
-                OnInteractableObjectTouched(SetInteractableObjectEvent(currentTouchingObject));
+                IgnoreColliders(currentTouchingObject.gameObject);
+                if (!touchingObjects.Contains(currentTouchingObject.gameObject))
+                {
+                    ToggleEnableState(true);
+                    touchingObjects.Add(currentTouchingObject.gameObject);
+                    OnInteractableObjectTouched(SetInteractableObjectEvent(currentTouchingObject.gameObject));
+                }
             }
         }
 
         /// <summary>
         /// The StopTouching method is called automatically when the object has stopped being touched. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
-        /// <param name="previousTouchingObject">The game object that was previously touching this object.</param>
+        /// <param name="previousTouchingObject">The object that was previously touching this object.</param>
+        [Obsolete("`VRTK_InteractableObject.StopTouching(GameObject previousTouchingObject)` has been replaced with `VRTK_InteractableObject.StopTouching(VRTK_InteractTouch previousTouchingObject)`. This method will be removed in a future version of VRTK.")]
         public virtual void StopTouching(GameObject previousTouchingObject)
         {
-            if (touchingObjects.Contains(previousTouchingObject))
+            StopTouching(previousTouchingObject.GetComponent<VRTK_InteractTouch>());
+        }
+
+        /// <summary>
+        /// The StopTouching method is called automatically when the object has stopped being touched. It is also a virtual method to allow for overriding in inherited classes.
+        /// </summary>
+        /// <param name="previousTouchingObject">The object that was previously touching this object.</param>
+        public virtual void StopTouching(VRTK_InteractTouch previousTouchingObject = null)
+        {
+            if (previousTouchingObject != null && touchingObjects.Contains(previousTouchingObject.gameObject))
             {
-                ResetUseState(previousTouchingObject);
-                OnInteractableObjectUntouched(SetInteractableObjectEvent(previousTouchingObject));
-                touchingObjects.Remove(previousTouchingObject);
+                ResetUseState(previousTouchingObject.gameObject);
+                OnInteractableObjectUntouched(SetInteractableObjectEvent(previousTouchingObject.gameObject));
+                touchingObjects.Remove(previousTouchingObject.gameObject);
             }
         }
 
         /// <summary>
         /// The Grabbed method is called automatically when the object is grabbed initially. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
-        /// <param name="currentGrabbingObject">The game object that is currently grabbing this object.</param>
+        /// <param name="currentGrabbingObject">The object that is currently grabbing this object.</param>
+        [Obsolete("`VRTK_InteractableObject.Grabbed(GameObject currentGrabbingObject)` has been replaced with `VRTK_InteractableObject.Grabbed(VRTK_InteractGrab currentGrabbingObject)`. This method will be removed in a future version of VRTK.")]
         public virtual void Grabbed(GameObject currentGrabbingObject)
         {
-            ToggleEnableState(true);
-            if (!IsGrabbed() || IsSwappable())
+            Grabbed(currentGrabbingObject.GetComponent<VRTK_InteractGrab>());
+        }
+
+        /// <summary>
+        /// The Grabbed method is called automatically when the object is grabbed initially. It is also a virtual method to allow for overriding in inherited classes.
+        /// </summary>
+        /// <param name="currentGrabbingObject">The object that is currently grabbing this object.</param>
+        public virtual void Grabbed(VRTK_InteractGrab currentGrabbingObject = null)
+        {
+            if (currentGrabbingObject != null)
             {
-                PrimaryControllerGrab(currentGrabbingObject);
+                ToggleEnableState(true);
+                if (!IsGrabbed() || IsSwappable())
+                {
+                    PrimaryControllerGrab(currentGrabbingObject.gameObject);
+                }
+                else
+                {
+                    SecondaryControllerGrab(currentGrabbingObject.gameObject);
+                }
+                OnInteractableObjectGrabbed(SetInteractableObjectEvent(currentGrabbingObject.gameObject));
             }
-            else
-            {
-                SecondaryControllerGrab(currentGrabbingObject);
-            }
-            OnInteractableObjectGrabbed(SetInteractableObjectEvent(currentGrabbingObject));
         }
 
         /// <summary>
         /// The Ungrabbed method is called automatically when the object has stopped being grabbed. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
-        /// <param name="previousGrabbingObject">The game object that was previously grabbing this object.</param>
+        /// <param name="previousGrabbingObject">The object that was previously grabbing this object.</param>
+        [Obsolete("`VRTK_InteractableObject.Ungrabbed(GameObject previousGrabbingObject)` has been replaced with `VRTK_InteractableObject.Ungrabbed(VRTK_InteractGrab previousGrabbingObject)`. This method will be removed in a future version of VRTK.")]
         public virtual void Ungrabbed(GameObject previousGrabbingObject)
+        {
+            Ungrabbed(previousGrabbingObject.GetComponent<VRTK_InteractGrab>());
+        }
+
+        /// <summary>
+        /// The Ungrabbed method is called automatically when the object has stopped being grabbed. It is also a virtual method to allow for overriding in inherited classes.
+        /// </summary>
+        /// <param name="previousGrabbingObject">The object that was previously grabbing this object.</param>
+        public virtual void Ungrabbed(VRTK_InteractGrab previousGrabbingObject = null)
         {
             GameObject secondaryGrabbingObject = GetSecondaryGrabbingObject();
             if (!secondaryGrabbingObject || secondaryGrabbingObject != previousGrabbingObject)
             {
                 SecondaryControllerUngrab(secondaryGrabbingObject);
-                PrimaryControllerUngrab(previousGrabbingObject, secondaryGrabbingObject);
+                PrimaryControllerUngrab(previousGrabbingObject.gameObject, secondaryGrabbingObject);
             }
             else
             {
-                SecondaryControllerUngrab(previousGrabbingObject);
+                SecondaryControllerUngrab(previousGrabbingObject.gameObject);
             }
-            OnInteractableObjectUngrabbed(SetInteractableObjectEvent(previousGrabbingObject));
+            OnInteractableObjectUngrabbed(SetInteractableObjectEvent(previousGrabbingObject.gameObject));
         }
 
         /// <summary>
         /// The StartUsing method is called automatically when the object is used initially. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
-        /// <param name="currentUsingObject">The game object that is currently using this object.</param>
+        /// <param name="currentUsingObject">The object that is currently using this object.</param>
+        [Obsolete("`VRTK_InteractableObject.StartUsing(GameObject currentUsingObject)` has been replaced with `VRTK_InteractableObject.StartUsing(VRTK_InteractUse currentUsingObject)`. This method will be removed in a future version of VRTK.")]
         public virtual void StartUsing(GameObject currentUsingObject)
         {
-            ToggleEnableState(true);
-            if (IsUsing() && !IsUsing(currentUsingObject))
+            StartUsing(currentUsingObject.GetComponent<VRTK_InteractUse>());
+        }
+
+        /// <summary>
+        /// The StartUsing method is called automatically when the object is used initially. It is also a virtual method to allow for overriding in inherited classes.
+        /// </summary>
+        /// <param name="currentUsingObject">The object that is currently using this object.</param>
+        public virtual void StartUsing(VRTK_InteractUse currentUsingObject = null)
+        {
+            if (currentUsingObject != null)
             {
-                ResetUsingObject();
+                ToggleEnableState(true);
+                if (IsUsing() && !IsUsing(currentUsingObject.gameObject))
+                {
+                    ResetUsingObject();
+                }
+                OnInteractableObjectUsed(SetInteractableObjectEvent(currentUsingObject.gameObject));
+                usingObject = currentUsingObject;
             }
-            OnInteractableObjectUsed(SetInteractableObjectEvent(currentUsingObject));
-            usingObject = currentUsingObject;
         }
 
         /// <summary>
         /// The StopUsing method is called automatically when the object has stopped being used. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
-        /// <param name="previousUsingObject">The game object that was previously using this object.</param>
+        /// <param name="previousUsingObject">The object that was previously using this object.</param>
+        [Obsolete("`VRTK_InteractableObject.StopUsing(GameObject previousUsingObject)` has been replaced with `VRTK_InteractableObject.StopUsing(VRTK_InteractUse previousUsingObject)`. This method will be removed in a future version of VRTK.")]
         public virtual void StopUsing(GameObject previousUsingObject)
         {
-            OnInteractableObjectUnused(SetInteractableObjectEvent(previousUsingObject));
-            ResetUsingObject();
-            usingState = 0;
-            usingObject = null;
+            StopUsing(previousUsingObject.GetComponent<VRTK_InteractUse>());
+        }
+
+        /// <summary>
+        /// The StopUsing method is called automatically when the object has stopped being used. It is also a virtual method to allow for overriding in inherited classes.
+        /// </summary>
+        /// <param name="previousUsingObject">The object that was previously using this object.</param>
+        public virtual void StopUsing(VRTK_InteractUse previousUsingObject = null)
+        {
+            if (previousUsingObject != null)
+            {
+                OnInteractableObjectUnused(SetInteractableObjectEvent(previousUsingObject.gameObject));
+                ResetUsingObject();
+                usingState = 0;
+                usingObject = null;
+            }
         }
 
         /// <summary>
@@ -529,10 +602,19 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The GetUsingObject method is used to return the game object that is currently using this object.
+        /// The GetUsingObject method is used to return the GameObject that is currently using this object.
         /// </summary>
-        /// <returns>The game object of what is using the current object.</returns>
+        /// <returns>The GameObject of what is using the current object.</returns>
         public virtual GameObject GetUsingObject()
+        {
+            return usingObject.gameObject;
+        }
+
+        /// <summary>
+        /// The GetUsingScript method is used to return the InteractUse script that is currently using this object.
+        /// </summary>
+        /// <returns>The InteractUse script of the object that is using the current object.</returns>
+        public virtual VRTK_InteractUse GetUsingScript()
         {
             return usingObject;
         }
@@ -1118,7 +1200,7 @@ namespace VRTK
 
         protected virtual void StopUsingInteractions()
         {
-            if (usingObject != null && (usingObject.activeInHierarchy || forceDisabled))
+            if (usingObject != null && (usingObject.gameObject.activeInHierarchy || forceDisabled))
             {
                 usingObject.GetComponent<VRTK_InteractTouch>().ForceStopTouching();
                 usingObject.GetComponent<VRTK_InteractUse>().ForceStopUsing();

--- a/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
@@ -78,7 +78,7 @@ namespace VRTK
         /// </summary>
         public virtual void RewindPosition()
         {
-            if (lastGoodStandingPosition != null && headset != null)
+            if (headset != null)
             {
                 Vector3 resetVector = lastGoodHeadsetPosition - headset.position;
                 Vector3 moveOffset = resetVector.normalized * pushbackDistance;

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3150,10 +3150,10 @@ The IsUsing method is used to determine if the object is currently being used.
 
 #### StartTouching/1
 
-  > `public virtual void StartTouching(GameObject currentTouchingObject)`
+  > `public virtual void StartTouching(VRTK_InteractTouch currentTouchingObject = null)`
 
   * Parameters
-   * `GameObject currentTouchingObject` - The game object that is currently touching this object.
+   * `VRTK_InteractTouch currentTouchingObject` - The object that is currently touching this object.
   * Returns
    * _none_
 
@@ -3161,10 +3161,10 @@ The StartTouching method is called automatically when the object is touched init
 
 #### StopTouching/1
 
-  > `public virtual void StopTouching(GameObject previousTouchingObject)`
+  > `public virtual void StopTouching(VRTK_InteractTouch previousTouchingObject = null)`
 
   * Parameters
-   * `GameObject previousTouchingObject` - The game object that was previously touching this object.
+   * `VRTK_InteractTouch previousTouchingObject` - The object that was previously touching this object.
   * Returns
    * _none_
 
@@ -3172,10 +3172,10 @@ The StopTouching method is called automatically when the object has stopped bein
 
 #### Grabbed/1
 
-  > `public virtual void Grabbed(GameObject currentGrabbingObject)`
+  > `public virtual void Grabbed(VRTK_InteractGrab currentGrabbingObject = null)`
 
   * Parameters
-   * `GameObject currentGrabbingObject` - The game object that is currently grabbing this object.
+   * `VRTK_InteractGrab currentGrabbingObject` - The object that is currently grabbing this object.
   * Returns
    * _none_
 
@@ -3183,10 +3183,10 @@ The Grabbed method is called automatically when the object is grabbed initially.
 
 #### Ungrabbed/1
 
-  > `public virtual void Ungrabbed(GameObject previousGrabbingObject)`
+  > `public virtual void Ungrabbed(VRTK_InteractGrab previousGrabbingObject = null)`
 
   * Parameters
-   * `GameObject previousGrabbingObject` - The game object that was previously grabbing this object.
+   * `VRTK_InteractGrab previousGrabbingObject` - The object that was previously grabbing this object.
   * Returns
    * _none_
 
@@ -3194,10 +3194,10 @@ The Ungrabbed method is called automatically when the object has stopped being g
 
 #### StartUsing/1
 
-  > `public virtual void StartUsing(GameObject currentUsingObject)`
+  > `public virtual void StartUsing(VRTK_InteractUse currentUsingObject = null)`
 
   * Parameters
-   * `GameObject currentUsingObject` - The game object that is currently using this object.
+   * `VRTK_InteractUse currentUsingObject` - The object that is currently using this object.
   * Returns
    * _none_
 
@@ -3205,10 +3205,10 @@ The StartUsing method is called automatically when the object is used initially.
 
 #### StopUsing/1
 
-  > `public virtual void StopUsing(GameObject previousUsingObject)`
+  > `public virtual void StopUsing(VRTK_InteractUse previousUsingObject = null)`
 
   * Parameters
-   * `GameObject previousUsingObject` - The game object that was previously using this object.
+   * `VRTK_InteractUse previousUsingObject` - The object that was previously using this object.
   * Returns
    * _none_
 
@@ -3309,9 +3309,20 @@ The GetSecondaryGrabbingObject method is used to return the game object that is 
   * Parameters
    * _none_
   * Returns
-   * `GameObject` - The game object of what is using the current object.
+   * `GameObject` - The GameObject of what is using the current object.
 
-The GetUsingObject method is used to return the game object that is currently using this object.
+The GetUsingObject method is used to return the GameObject that is currently using this object.
+
+#### GetUsingScript/0
+
+  > `public virtual VRTK_InteractUse GetUsingScript()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `VRTK_InteractUse` - The InteractUse script of the object that is using the current object.
+
+The GetUsingScript method is used to return the InteractUse script that is currently using this object.
 
 #### IsValidInteractableController/2
 


### PR DESCRIPTION
The Interactable Object script would previously accept a GameObject
when the Touching/Grabbing/Using methods were called. However, this
was ambiguous as to what the object should represent. The object
that is performing the action should be the one with the relevant
VRTK_InteractX script on like VRTK_InteractTouch, VRTK_InteractGrab
and VRTK_InteractUse.

Because of this, it makes more sense to actually pass the reference
to the script as the GameObject can be obtained from the script
with less overhead than the script being obtained from the GameObject
via the `GetComponent` method call.

The existing methods that accept a GameObject still exist but have
been deprecated in favour of the new methods that take the specific
InteractX script.