### PR TITLE
feat(Structure): add events for all current actions - fixes #1206

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerRigidbodyActivator.cs
@@ -4,6 +4,22 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="interactingObject">The object that touching the activator.</param>
+    public struct ControllerRigidbodyActivatorEventArgs
+    {
+        public VRTK_InteractTouch touchingObject;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="ControllerRigidbodyActivatorEventArgs"/></param>
+    public delegate void ControllerRigidbodyActivatorEventHandler(object sender, ControllerRigidbodyActivatorEventArgs e);
+
+    /// <summary>
     /// This adds a simple trigger collider volume that when a controller enters will enable the rigidbody on the controller.
     /// </summary>
     /// <remarks>
@@ -20,6 +36,31 @@ namespace VRTK
         [Tooltip("If this is checked then the collider will have it's rigidbody toggled on and off during a collision.")]
         public bool isEnabled = true;
 
+        /// <summary>
+        /// Emitted when the controller rigidbody is turned on.
+        /// </summary>
+        public event ControllerRigidbodyActivatorEventHandler ControllerRigidbodyOn;
+        /// <summary>
+        /// Emitted when the controller rigidbody is turned off.
+        /// </summary>
+        public event ControllerRigidbodyActivatorEventHandler ControllerRigidbodyOff;
+
+        public virtual void OnControllerRigidbodyOn(ControllerRigidbodyActivatorEventArgs e)
+        {
+            if (ControllerRigidbodyOn != null)
+            {
+                ControllerRigidbodyOn(this, e);
+            }
+        }
+
+        public virtual void OnControllerRigidbodyOff(ControllerRigidbodyActivatorEventArgs e)
+        {
+            if (ControllerRigidbodyOff != null)
+            {
+                ControllerRigidbodyOff(this, e);
+            }
+        }
+
         protected virtual void OnTriggerEnter(Collider collider)
         {
             ToggleRigidbody(collider, true);
@@ -30,12 +71,27 @@ namespace VRTK
             ToggleRigidbody(collider, false);
         }
 
-        private void ToggleRigidbody(Collider collider, bool state)
+        protected virtual void ToggleRigidbody(Collider collider, bool state)
         {
-            var touch = collider.GetComponentInParent<VRTK_InteractTouch>();
-            if (touch && (isEnabled || !state))
+            VRTK_InteractTouch touch = collider.GetComponentInParent<VRTK_InteractTouch>();
+            if (touch != null && (isEnabled || !state))
             {
                 touch.ToggleControllerRigidBody(state, state);
+                EmitEvent(state, touch);
+            }
+        }
+
+        protected virtual void EmitEvent(bool state, VRTK_InteractTouch touch)
+        {
+            ControllerRigidbodyActivatorEventArgs e;
+            e.touchingObject = touch;
+            if (state)
+            {
+                OnControllerRigidbodyOn(e);
+            }
+            else
+            {
+                OnControllerRigidbodyOff(e);
             }
         }
     }

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -4,6 +4,22 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="element">The tooltip element being affected.</param>
+    public struct ControllerTooltipsEventArgs
+    {
+        public VRTK_ControllerTooltips.TooltipButtons element;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="ControllerTooltipsEventArgs"/></param>
+    public delegate void ControllerTooltipsEventHandler(object sender, ControllerTooltipsEventArgs e);
+
+    /// <summary>
     /// This adds a collection of Object Tooltips to the Controller that give information on what the main controller buttons may do. To add the prefab, it just needs to be added as a child of the relevant alias controller GameObject.
     /// </summary>
     /// <remarks>
@@ -81,11 +97,36 @@ namespace VRTK
         [Tooltip("The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.")]
         public float retryInitCounter = 0.1f;
 
+        /// <summary>
+        /// Emitted when the controller tooltip is turned on.
+        /// </summary>
+        public event ControllerTooltipsEventHandler ControllerTooltipOn;
+        /// <summary>
+        /// Emitted when the controller tooltip is turned off.
+        /// </summary>
+        public event ControllerTooltipsEventHandler ControllerTooltipOff;
+
         protected TooltipButtons[] availableButtons;
         protected VRTK_ObjectTooltip[] buttonTooltips;
         protected bool[] tooltipStates;
 
         protected int retryInitCurrentTries = 0;
+
+        public virtual void OnControllerTooltipOn(ControllerTooltipsEventArgs e)
+        {
+            if (ControllerTooltipOn != null)
+            {
+                ControllerTooltipOn(this, e);
+            }
+        }
+
+        public virtual void OnControllerTooltipOff(ControllerTooltipsEventArgs e)
+        {
+            if (ControllerTooltipOff != null)
+            {
+                ControllerTooltipOff(this, e);
+            }
+        }
 
         /// <summary>
         /// The Reset method reinitalises the tooltips on all of the controller elements.
@@ -150,6 +191,7 @@ namespace VRTK
                     buttonTooltips[(int)element].gameObject.SetActive(state);
                 }
             }
+            EmitEvent(state, element);
         }
 
         protected virtual void Awake()
@@ -185,6 +227,20 @@ namespace VRTK
         protected virtual void OnDestroy()
         {
             VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+        }
+
+        protected virtual void EmitEvent(bool state, TooltipButtons element)
+        {
+            ControllerTooltipsEventArgs e;
+            e.element = element;
+            if (state)
+            {
+                OnControllerTooltipOn(e);
+            }
+            else
+            {
+                OnControllerTooltipOff(e);
+            }
         }
 
         protected virtual void InitButtonsArray()

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
@@ -5,6 +5,12 @@ namespace VRTK
     using System.Collections;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    public delegate void DestinationPointEventHandler(object sender);
+
+    /// <summary>
     /// The Destination Point allows for a specific scene marker that can be teleported to.
     /// </summary>
     /// <remarks>
@@ -49,6 +55,27 @@ namespace VRTK
 
         public static VRTK_DestinationPoint currentDestinationPoint;
 
+        /// <summary>
+        /// Emitted when the destination point is enabled.
+        /// </summary>
+        public event DestinationPointEventHandler DestinationPointEnabled;
+        /// <summary>
+        /// Emitted when the destination point is disabled.
+        /// </summary>
+        public event DestinationPointEventHandler DestinationPointDisabled;
+        /// <summary>
+        /// Emitted when the destination point is locked.
+        /// </summary>
+        public event DestinationPointEventHandler DestinationPointLocked;
+        /// <summary>
+        /// Emitted when the destination point is unlocked.
+        /// </summary>
+        public event DestinationPointEventHandler DestinationPointUnlocked;
+        /// <summary>
+        /// Emitted when the destination point is reset.
+        /// </summary>
+        public event DestinationPointEventHandler DestinationPointReset;
+
         protected Collider pointCollider;
         protected bool createdCollider;
         protected Rigidbody pointRigidbody;
@@ -60,6 +87,46 @@ namespace VRTK
         protected bool currentTeleportState;
         protected Transform playArea;
         protected Transform headset;
+
+        public virtual void OnDestinationPointEnabled()
+        {
+            if (DestinationPointEnabled != null)
+            {
+                DestinationPointEnabled(this);
+            }
+        }
+
+        public virtual void OnDestinationPointDisabled()
+        {
+            if (DestinationPointDisabled != null)
+            {
+                DestinationPointDisabled(this);
+            }
+        }
+
+        public virtual void OnDestinationPointLocked()
+        {
+            if (DestinationPointLocked != null)
+            {
+                DestinationPointLocked(this);
+            }
+        }
+
+        public virtual void OnDestinationPointUnlocked()
+        {
+            if (DestinationPointUnlocked != null)
+            {
+                DestinationPointUnlocked(this);
+            }
+        }
+
+        public virtual void OnDestinationPointReset()
+        {
+            if (DestinationPointReset != null)
+            {
+                DestinationPointReset(this);
+            }
+        }
 
         /// <summary>
         /// The ResetDestinationPoint resets the destination point back to the default state.
@@ -273,6 +340,7 @@ namespace VRTK
             ToggleObject(lockedCursorObject, false);
             ToggleObject(defaultCursorObject, false);
             ToggleObject(hoverCursorObject, true);
+            OnDestinationPointEnabled();
         }
 
         protected virtual void DisablePoint()
@@ -281,6 +349,7 @@ namespace VRTK
             ToggleObject(lockedCursorObject, false);
             ToggleObject(defaultCursorObject, false);
             ToggleObject(hoverCursorObject, false);
+            OnDestinationPointDisabled();
         }
 
         protected virtual void ResetPoint()
@@ -292,13 +361,16 @@ namespace VRTK
                 pointCollider.enabled = true;
                 ToggleObject(defaultCursorObject, true);
                 ToggleObject(lockedCursorObject, false);
+                OnDestinationPointUnlocked();
             }
             else
             {
                 pointCollider.enabled = false;
                 ToggleObject(lockedCursorObject, true);
                 ToggleObject(defaultCursorObject, false);
+                OnDestinationPointLocked();
             }
+            OnDestinationPointReset();
         }
 
         protected virtual void ToggleObject(GameObject givenObject, bool state)

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ObjectTooltip.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ObjectTooltip.cs
@@ -5,6 +5,22 @@ namespace VRTK
     using UnityEngine.UI;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="newText">The optional new text that is given to the tooltip.</param>
+    public struct ObjectTooltipEventArgs
+    {
+        public string newText;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="ObjectTooltipEventArgs"/></param>
+    public delegate void ObjectTooltipEventHandler(object sender, ObjectTooltipEventArgs e);
+
+    /// <summary>
     /// This adds a UI element into the World Space that can be used to provide additional information about an object by providing a piece of text with a line drawn to a destination point.
     /// </summary>
     /// <remarks>
@@ -36,8 +52,33 @@ namespace VRTK
         [Tooltip("If this is checked then the tooltip will be rotated so it always face the headset.")]
         public bool alwaysFaceHeadset = false;
 
+        /// <summary>
+        /// Emitted when the object tooltip is reset.
+        /// </summary>
+        public event ObjectTooltipEventHandler ObjectTooltipReset;
+        /// <summary>
+        /// Emitted when the object tooltip text is updated.
+        /// </summary>
+        public event ObjectTooltipEventHandler ObjectTooltipTextUpdated;
+
         protected LineRenderer line;
         protected Transform headset;
+
+        public virtual void OnObjectTooltipReset(ObjectTooltipEventArgs e)
+        {
+            if (ObjectTooltipReset != null)
+            {
+                ObjectTooltipReset(this, e);
+            }
+        }
+
+        public virtual void OnObjectTooltipTextUpdated(ObjectTooltipEventArgs e)
+        {
+            if (ObjectTooltipTextUpdated != null)
+            {
+                ObjectTooltipTextUpdated(this, e);
+            }
+        }
 
         /// <summary>
         /// The ResetTooltip method resets the tooltip back to its initial state.
@@ -52,6 +93,7 @@ namespace VRTK
             {
                 drawLineTo = transform.parent;
             }
+            OnObjectTooltipReset(SetEventPayload());
         }
 
         /// <summary>
@@ -61,6 +103,7 @@ namespace VRTK
         public virtual void UpdateText(string newText)
         {
             displayText = newText;
+            OnObjectTooltipTextUpdated(SetEventPayload(newText));
             ResetTooltip();
         }
 
@@ -87,6 +130,13 @@ namespace VRTK
             {
                 transform.LookAt(headset);
             }
+        }
+
+        protected virtual ObjectTooltipEventArgs SetEventPayload(string newText = "")
+        {
+            ObjectTooltipEventArgs e;
+            e.newText = newText;
+            return e;
         }
 
         protected virtual void SetContainer()

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
@@ -4,6 +4,12 @@ namespace VRTK
     using UnityEngine;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    public delegate void PointerDirectionIndicatorEventHandler(object sender);
+
+    /// <summary>
     /// The Pointer Direction Indicator is used to determine a given world rotation that can be used by a Destiantion Marker.
     /// </summary>
     /// <remarks>
@@ -16,9 +22,22 @@ namespace VRTK
         [Tooltip("If this is checked then the reported rotation will include the offset of the headset rotation in relation to the play area.")]
         public bool includeHeadsetOffset = true;
 
+        /// <summary>
+        /// Emitted when the object tooltip is reset.
+        /// </summary>
+        public event PointerDirectionIndicatorEventHandler PointerDirectionIndicatorPositionSet;
+
         protected VRTK_ControllerEvents controllerEvents;
         protected Transform playArea;
         protected Transform headset;
+
+        public virtual void OnPointerDirectionIndicatorPositionSet()
+        {
+            if (PointerDirectionIndicatorPositionSet != null)
+            {
+                PointerDirectionIndicatorPositionSet(this);
+            }
+        }
 
         /// <summary>
         /// The Initialize method is used to set up the direction indicator.
@@ -40,6 +59,7 @@ namespace VRTK
         {
             transform.position = position;
             gameObject.SetActive(active);
+            OnPointerDirectionIndicatorPositionSet();
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -59,9 +59,17 @@ namespace VRTK
         public event ControllerInteractionEventHandler GrabButtonReleased;
 
         /// <summary>
+        /// Emitted when a grab of a valid object is started.
+        /// </summary>
+        public event ObjectInteractEventHandler ControllerStartGrabInteractableObject;
+        /// <summary>
         /// Emitted when a valid object is grabbed.
         /// </summary>
         public event ObjectInteractEventHandler ControllerGrabInteractableObject;
+        /// <summary>
+        /// Emitted when a ungrab of a valid object is started.
+        /// </summary>
+        public event ObjectInteractEventHandler ControllerStartUngrabInteractableObject;
         /// <summary>
         /// Emitted when a valid object is released from being grabbed.
         /// </summary>
@@ -85,11 +93,27 @@ namespace VRTK
             }
         }
 
+        public virtual void OnControllerStartGrabInteractableObject(ObjectInteractEventArgs e)
+        {
+            if (ControllerStartGrabInteractableObject != null)
+            {
+                ControllerStartGrabInteractableObject(this, e);
+            }
+        }
+
         public virtual void OnControllerGrabInteractableObject(ObjectInteractEventArgs e)
         {
             if (ControllerGrabInteractableObject != null)
             {
                 ControllerGrabInteractableObject(this, e);
+            }
+        }
+
+        public virtual void OnControllerStartUngrabInteractableObject(ObjectInteractEventArgs e)
+        {
+            if (ControllerStartUngrabInteractableObject != null)
+            {
+                ControllerStartUngrabInteractableObject(this, e);
             }
         }
 
@@ -351,6 +375,7 @@ namespace VRTK
             grabbedObject = interactTouch.GetTouchedObject();
             if (grabbedObject != null)
             {
+                OnControllerStartGrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
                 VRTK_InteractableObject grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
                 ChooseGrabSequence(grabbedObjectScript);
                 ToggleControllerVisibility(false);
@@ -410,6 +435,7 @@ namespace VRTK
         {
             if (grabbedObject != null)
             {
+                OnControllerStartUngrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
                 GameObject grabbingObject = controllerReference.scriptAlias;
                 VRTK_InteractableObject grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
                 if (!influencingGrabbedObject)

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -5,6 +5,22 @@ namespace VRTK
     using System;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="controllerReference">The reference to the controller to perform haptics on.</param>
+    public struct InteractHapticsEventArgs
+    {
+        public VRTK_ControllerReference controllerReference;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="InteractHapticsEventArgs"/></param>
+    public delegate void InteractHapticsEventHandler(object sender, InteractHapticsEventArgs e);
+
+    /// <summary>
     /// The Interact Haptics script is attached on the same GameObject as an Interactable Object script and provides controller haptics on touch, grab and use of the object.
     /// </summary>
     [AddComponentMenu("VRTK/Scripts/Interactions/VRTK_InteractHaptics")]
@@ -46,7 +62,44 @@ namespace VRTK
         [Tooltip("Denotes interval betweens rumble in the controller on use.")]
         public float intervalOnUse = minInterval;
 
+        /// <summary>
+        /// Emitted when the haptics are from a touch.
+        /// </summary>
+        public event InteractHapticsEventHandler InteractHapticsTouched;
+        /// <summary>
+        /// Emitted when the haptics are from a grab.
+        /// </summary>
+        public event InteractHapticsEventHandler InteractHapticsGrabbed;
+        /// <summary>
+        /// Emitted when the haptics are from a use.
+        /// </summary>
+        public event InteractHapticsEventHandler InteractHapticsUsed;
+
         protected const float minInterval = 0.05f;
+
+        public virtual void OnInteractHapticsTouched(InteractHapticsEventArgs e)
+        {
+            if (InteractHapticsTouched != null)
+            {
+                InteractHapticsTouched(this, e);
+            }
+        }
+
+        public virtual void OnInteractHapticsGrabbed(InteractHapticsEventArgs e)
+        {
+            if (InteractHapticsGrabbed != null)
+            {
+                InteractHapticsGrabbed(this, e);
+            }
+        }
+
+        public virtual void OnInteractHapticsUsed(InteractHapticsEventArgs e)
+        {
+            if (InteractHapticsUsed != null)
+            {
+                InteractHapticsUsed(this, e);
+            }
+        }
 
         /// <summary>
         /// The HapticsOnTouch method triggers the haptic feedback on the given controller for the settings associated with touch.
@@ -72,6 +125,7 @@ namespace VRTK
             {
                 TriggerHapticPulse(controllerReference, strengthOnTouch, durationOnTouch, intervalOnTouch);
             }
+            OnInteractHapticsTouched(SetEventPayload(controllerReference));
         }
 
         /// <summary>
@@ -98,6 +152,7 @@ namespace VRTK
             {
                 TriggerHapticPulse(controllerReference, strengthOnGrab, durationOnGrab, intervalOnGrab);
             }
+            OnInteractHapticsGrabbed(SetEventPayload(controllerReference));
         }
 
         /// <summary>
@@ -124,6 +179,7 @@ namespace VRTK
             {
                 TriggerHapticPulse(controllerReference, strengthOnUse, durationOnUse, intervalOnUse);
             }
+            OnInteractHapticsUsed(SetEventPayload(controllerReference));
         }
 
         protected virtual void OnEnable()
@@ -137,6 +193,13 @@ namespace VRTK
         protected virtual void TriggerHapticPulse(VRTK_ControllerReference controllerReference, float strength, float duration, float interval)
         {
             VRTK_ControllerHaptics.TriggerHapticPulse(controllerReference, strength, duration, (interval >= minInterval ? interval : minInterval));
+        }
+
+        protected virtual InteractHapticsEventArgs SetEventPayload(VRTK_ControllerReference givenControllerReference)
+        {
+            InteractHapticsEventArgs e;
+            e.controllerReference = givenControllerReference;
+            return e;
         }
     }
 }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -47,9 +47,17 @@ namespace VRTK
         public event ControllerInteractionEventHandler UseButtonReleased;
 
         /// <summary>
+        /// Emitted when a use of a valid object is started.
+        /// </summary>
+        public event ObjectInteractEventHandler ControllerStartUseInteractableObject;
+        /// <summary>
         /// Emitted when a valid object starts being used.
         /// </summary>
         public event ObjectInteractEventHandler ControllerUseInteractableObject;
+        /// <summary>
+        /// Emitted when a unuse of a valid object is started.
+        /// </summary>
+        public event ObjectInteractEventHandler ControllerStartUnuseInteractableObject;
         /// <summary>
         /// Emitted when a valid object stops being used.
         /// </summary>
@@ -68,11 +76,27 @@ namespace VRTK
 
         protected GameObject usingObject = null;
 
+        public virtual void OnControllerStartUseInteractableObject(ObjectInteractEventArgs e)
+        {
+            if (ControllerStartUseInteractableObject != null)
+            {
+                ControllerStartUseInteractableObject(this, e);
+            }
+        }
+
         public virtual void OnControllerUseInteractableObject(ObjectInteractEventArgs e)
         {
             if (ControllerUseInteractableObject != null)
             {
                 ControllerUseInteractableObject(this, e);
+            }
+        }
+
+        public virtual void OnControllerStartUnuseInteractableObject(ObjectInteractEventArgs e)
+        {
+            if (ControllerStartUnuseInteractableObject != null)
+            {
+                ControllerStartUnuseInteractableObject(this, e);
             }
         }
 
@@ -242,7 +266,7 @@ namespace VRTK
         {
             if (obj != null)
             {
-                var objScript = obj.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject objScript = obj.GetComponent<VRTK_InteractableObject>();
                 return (objScript != null && objScript.holdButtonToUse);
             }
             return false;
@@ -252,7 +276,7 @@ namespace VRTK
         {
             if (obj != null)
             {
-                var objScript = obj.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject objScript = obj.GetComponent<VRTK_InteractableObject>();
                 if (objScript != null)
                 {
                     return objScript.usingState;
@@ -265,7 +289,7 @@ namespace VRTK
         {
             if (obj != null)
             {
-                var objScript = obj.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject objScript = obj.GetComponent<VRTK_InteractableObject>();
                 if (objScript != null)
                 {
                     objScript.usingState = value;
@@ -277,7 +301,7 @@ namespace VRTK
         {
             if (usingObject != null)
             {
-                var doHaptics = usingObject.GetComponentInParent<VRTK_InteractHaptics>();
+                VRTK_InteractHaptics doHaptics = usingObject.GetComponentInParent<VRTK_InteractHaptics>();
                 if (doHaptics != null)
                 {
                     doHaptics.HapticsOnUse(controllerReference);
@@ -302,7 +326,8 @@ namespace VRTK
             if ((usingObject == null || usingObject != touchedObject) && IsObjectUsable(touchedObject))
             {
                 usingObject = touchedObject;
-                var usingObjectScript = usingObject.GetComponent<VRTK_InteractableObject>();
+                OnControllerStartUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
+                VRTK_InteractableObject usingObjectScript = usingObject.GetComponent<VRTK_InteractableObject>();
 
                 if (!usingObjectScript.IsValidInteractableController(controllerReference.scriptAlias, usingObjectScript.allowedUseControllers))
                 {
@@ -321,7 +346,8 @@ namespace VRTK
         {
             if (usingObject != null)
             {
-                var usingObjectCheck = usingObject.GetComponent<VRTK_InteractableObject>();
+                OnControllerStartUnuseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
+                VRTK_InteractableObject usingObjectCheck = usingObject.GetComponent<VRTK_InteractableObject>();
                 if (usingObjectCheck != null && completeStop)
                 {
                     usingObjectCheck.StopUsing(controllerReference.scriptAlias);
@@ -357,7 +383,7 @@ namespace VRTK
 
             if (touchedObject != null && interactTouch.IsObjectInteractable(touchedObject))
             {
-                var interactableObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject interactableObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
 
                 if (interactableObjectScript.useOnlyIfGrabbed && !interactableObjectScript.IsGrabbed())
                 {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAutoGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAutoGrab.cs
@@ -5,6 +5,12 @@ namespace VRTK
     using System.Collections;
 
     /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    public delegate void ObjectAutoGrabEventHandler(object sender);
+
+    /// <summary>
     /// It is possible to automatically grab an Interactable Object to a specific controller by applying the Object Auto Grab script to the controller that the object should be grabbed by default.
     /// </summary>
     /// <example>
@@ -29,7 +35,20 @@ namespace VRTK
         [Tooltip("The Interact Grab to listen for grab actions on. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.")]
         public VRTK_InteractGrab interactGrab;
 
+        /// <summary>
+        /// Emitted when the object auto grab has completed successfully.
+        /// </summary>
+        public event ObjectAutoGrabEventHandler ObjectAutoGrabCompleted;
+
         protected VRTK_InteractableObject previousClonedObject = null;
+
+        public virtual void OnObjectAutoGrabCompleted()
+        {
+            if (ObjectAutoGrabCompleted != null)
+            {
+                ObjectAutoGrabCompleted(this);
+            }
+        }
 
         /// <summary>
         /// The ClearPreviousClone method resets the previous cloned object to null to ensure when the script is re-enabled that a new cloned object is created, rather than the original clone being grabbed again.
@@ -112,6 +131,7 @@ namespace VRTK
                     interactTouch.ForceStopTouching();
                     interactTouch.ForceTouch(grabbableObject.gameObject);
                     interactGrab.AttemptGrab();
+                    OnObjectAutoGrabCompleted();
                 }
             }
             objectToGrab.disableWhenIdle = grabbableObjectDisableState;

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_BodyPhysics_UnityEvents.cs
@@ -19,6 +19,12 @@
         public BodyPhysicsEvent OnStartColliding = new BodyPhysicsEvent();
         public BodyPhysicsEvent OnStopColliding = new BodyPhysicsEvent();
 
+        public BodyPhysicsEvent OnStartLeaning = new BodyPhysicsEvent();
+        public BodyPhysicsEvent OnStopLeaning = new BodyPhysicsEvent();
+
+        public BodyPhysicsEvent OnStartTouchingGround = new BodyPhysicsEvent();
+        public BodyPhysicsEvent OnStopTouchingGround = new BodyPhysicsEvent();
+
         protected override void AddListeners(VRTK_BodyPhysics component)
         {
             component.StartFalling += StartFalling;
@@ -29,6 +35,12 @@
 
             component.StartColliding += StartColliding;
             component.StopColliding += StopColliding;
+
+            component.StartLeaning += StartLeaning;
+            component.StopLeaning += StopLeaning;
+
+            component.StartTouchingGround += StartTouchingGround;
+            component.StopTouchingGround += StopTouchingGround;
         }
 
         protected override void RemoveListeners(VRTK_BodyPhysics component)
@@ -41,6 +53,12 @@
 
             component.StartColliding -= StartColliding;
             component.StopColliding -= StopColliding;
+
+            component.StartLeaning -= StartLeaning;
+            component.StopLeaning -= StopLeaning;
+
+            component.StartTouchingGround -= StartTouchingGround;
+            component.StopTouchingGround -= StopTouchingGround;
         }
 
         private void StartFalling(object o, BodyPhysicsEventArgs e)
@@ -71,6 +89,26 @@
         private void StopColliding(object o, BodyPhysicsEventArgs e)
         {
             OnStopColliding.Invoke(o, e);
+        }
+
+        private void StartLeaning(object o, BodyPhysicsEventArgs e)
+        {
+            OnStartLeaning.Invoke(o, e);
+        }
+
+        private void StopLeaning(object o, BodyPhysicsEventArgs e)
+        {
+            OnStopLeaning.Invoke(o, e);
+        }
+
+        private void StartTouchingGround(object o, BodyPhysicsEventArgs e)
+        {
+            OnStartTouchingGround.Invoke(o, e);
+        }
+
+        private void StopTouchingGround(object o, BodyPhysicsEventArgs e)
+        {
+            OnStopTouchingGround.Invoke(o, e);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerRigidbodyActivator_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerRigidbodyActivator_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_ControllerRigidbodyActivator_UnityEvents")]
+    public sealed class VRTK_ControllerRigidbodyActivator_UnityEvents : VRTK_UnityEvents<VRTK_ControllerRigidbodyActivator>
+    {
+        [Serializable]
+        public sealed class ControllerRigidbodyActivatorEvent : UnityEvent<object, ControllerRigidbodyActivatorEventArgs> { }
+
+        public ControllerRigidbodyActivatorEvent OnControllerRigidbodyOn = new ControllerRigidbodyActivatorEvent();
+        public ControllerRigidbodyActivatorEvent OnControllerRigidbodyOff = new ControllerRigidbodyActivatorEvent();
+
+        protected override void AddListeners(VRTK_ControllerRigidbodyActivator component)
+        {
+            component.ControllerRigidbodyOn += ControllerRigidbodyOn;
+            component.ControllerRigidbodyOff += ControllerRigidbodyOff;
+        }
+
+        protected override void RemoveListeners(VRTK_ControllerRigidbodyActivator component)
+        {
+            component.ControllerRigidbodyOn -= ControllerRigidbodyOn;
+            component.ControllerRigidbodyOff -= ControllerRigidbodyOff;
+        }
+
+        private void ControllerRigidbodyOn(object o, ControllerRigidbodyActivatorEventArgs e)
+        {
+            OnControllerRigidbodyOn.Invoke(o, e);
+        }
+
+        private void ControllerRigidbodyOff(object o, ControllerRigidbodyActivatorEventArgs e)
+        {
+            OnControllerRigidbodyOff.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerRigidbodyActivator_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerRigidbodyActivator_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8a37a5ae8f47c2a42ab4fbb6564d92e7
+timeCreated: 1496823082
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerTooltips_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerTooltips_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_ControllerTooltips_UnityEvents")]
+    public sealed class VRTK_ControllerTooltips_UnityEvents : VRTK_UnityEvents<VRTK_ControllerTooltips>
+    {
+        [Serializable]
+        public sealed class ControllerTooltipsEvent : UnityEvent<object, ControllerTooltipsEventArgs> { }
+
+        public ControllerTooltipsEvent OnControllerTooltipOn = new ControllerTooltipsEvent();
+        public ControllerTooltipsEvent OnControllerTooltipOff = new ControllerTooltipsEvent();
+
+        protected override void AddListeners(VRTK_ControllerTooltips component)
+        {
+            component.ControllerTooltipOn += ControllerTooltipOn;
+            component.ControllerTooltipOff += ControllerTooltipOff;
+        }
+
+        protected override void RemoveListeners(VRTK_ControllerTooltips component)
+        {
+            component.ControllerTooltipOn -= ControllerTooltipOn;
+            component.ControllerTooltipOff -= ControllerTooltipOff;
+        }
+
+        private void ControllerTooltipOn(object o, ControllerTooltipsEventArgs e)
+        {
+            OnControllerTooltipOn.Invoke(o, e);
+        }
+
+        private void ControllerTooltipOff(object o, ControllerTooltipsEventArgs e)
+        {
+            OnControllerTooltipOff.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerTooltips_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerTooltips_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 56e535b433968e04cb050e96f20d9fea
+timeCreated: 1496824040
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationPoint_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationPoint_UnityEvents.cs
@@ -1,0 +1,62 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_DestinationPoint_UnityEvents")]
+    public sealed class VRTK_DestinationPoint_UnityEvents : VRTK_UnityEvents<VRTK_DestinationPoint>
+    {
+        [Serializable]
+        public sealed class DestinationPointEvent : UnityEvent<object> { }
+
+        public DestinationPointEvent OnDestinationPointEnabled = new DestinationPointEvent();
+        public DestinationPointEvent OnDestinationPointDisabled = new DestinationPointEvent();
+        public DestinationPointEvent OnDestinationPointLocked = new DestinationPointEvent();
+        public DestinationPointEvent OnDestinationPointUnlocked = new DestinationPointEvent();
+        public DestinationPointEvent OnDestinationPointReset = new DestinationPointEvent();
+
+        protected override void AddListeners(VRTK_DestinationPoint component)
+        {
+            component.DestinationPointEnabled += DestinationPointEnabled;
+            component.DestinationPointDisabled += DestinationPointDisabled;
+            component.DestinationPointLocked += DestinationPointLocked;
+            component.DestinationPointUnlocked += DestinationPointUnlocked;
+            component.DestinationPointReset += DestinationPointReset;
+        }
+
+        protected override void RemoveListeners(VRTK_DestinationPoint component)
+        {
+            component.DestinationPointEnabled -= DestinationPointEnabled;
+            component.DestinationPointDisabled -= DestinationPointDisabled;
+            component.DestinationPointLocked -= DestinationPointLocked;
+            component.DestinationPointUnlocked -= DestinationPointUnlocked;
+            component.DestinationPointReset -= DestinationPointReset;
+        }
+
+        private void DestinationPointEnabled(object o)
+        {
+            OnDestinationPointEnabled.Invoke(o);
+        }
+
+        private void DestinationPointDisabled(object o)
+        {
+            OnDestinationPointDisabled.Invoke(o);
+        }
+
+        private void DestinationPointLocked(object o)
+        {
+            OnDestinationPointLocked.Invoke(o);
+        }
+
+        private void DestinationPointUnlocked(object o)
+        {
+            OnDestinationPointUnlocked.Invoke(o);
+        }
+
+        private void DestinationPointReset(object o)
+        {
+            OnDestinationPointReset.Invoke(o);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationPoint_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_DestinationPoint_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9d034a1a4a56c594c96328ad52b9afc5
+timeCreated: 1496825975
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractControllerAppearance_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractControllerAppearance_UnityEvents.cs
@@ -1,0 +1,86 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_InteractControllerAppearance_UnityEvents")]
+    public sealed class VRTK_InteractControllerAppearance_UnityEvents : VRTK_UnityEvents<VRTK_InteractControllerAppearance>
+    {
+        [Serializable]
+        public sealed class InteractControllerAppearanceEvent : UnityEvent<object, InteractControllerAppearanceEventArgs> { }
+
+        public InteractControllerAppearanceEvent OnControllerHidden = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnControllerVisible = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnHiddenOnTouch = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnVisibleOnTouch = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnHiddenOnGrab = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnVisibleOnGrab = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnHiddenOnUse = new InteractControllerAppearanceEvent();
+        public InteractControllerAppearanceEvent OnVisibleOnUse = new InteractControllerAppearanceEvent();
+
+        protected override void AddListeners(VRTK_InteractControllerAppearance component)
+        {
+            component.ControllerHidden += ControllerHidden;
+            component.ControllerVisible += ControllerVisible;
+            component.HiddenOnTouch += HiddenOnTouch;
+            component.VisibleOnTouch += VisibleOnTouch;
+            component.HiddenOnGrab += HiddenOnGrab;
+            component.VisibleOnGrab += VisibleOnGrab;
+            component.HiddenOnUse += HiddenOnUse;
+            component.VisibleOnUse += VisibleOnUse;
+        }
+
+        protected override void RemoveListeners(VRTK_InteractControllerAppearance component)
+        {
+            component.ControllerHidden -= ControllerHidden;
+            component.ControllerVisible -= ControllerVisible;
+            component.HiddenOnTouch -= HiddenOnTouch;
+            component.VisibleOnTouch -= VisibleOnTouch;
+            component.HiddenOnGrab -= HiddenOnGrab;
+            component.VisibleOnGrab -= VisibleOnGrab;
+            component.HiddenOnUse -= HiddenOnUse;
+            component.VisibleOnUse -= VisibleOnUse;
+        }
+
+        private void ControllerHidden(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnControllerHidden.Invoke(o, e);
+        }
+
+        private void ControllerVisible(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnControllerVisible.Invoke(o, e);
+        }
+
+        private void HiddenOnTouch(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnHiddenOnTouch.Invoke(o, e);
+        }
+
+        private void VisibleOnTouch(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnVisibleOnTouch.Invoke(o, e);
+        }
+
+        private void HiddenOnGrab(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnHiddenOnGrab.Invoke(o, e);
+        }
+
+        private void VisibleOnGrab(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnVisibleOnGrab.Invoke(o, e);
+        }
+
+        private void HiddenOnUse(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnHiddenOnUse.Invoke(o, e);
+        }
+
+        private void VisibleOnUse(object o, InteractControllerAppearanceEventArgs e)
+        {
+            OnVisibleOnUse.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractControllerAppearance_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractControllerAppearance_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d0defca788d588e4e9a134d50b5204f8
+timeCreated: 1496850881
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
@@ -10,14 +10,18 @@
         [Serializable]
         public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
 
+        public ObjectInteractEvent OnControllerStartGrabInteractableObject = new ObjectInteractEvent();
         public ObjectInteractEvent OnControllerGrabInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerStartUngrabInteractableObject = new ObjectInteractEvent();
         public ObjectInteractEvent OnControllerUngrabInteractableObject = new ObjectInteractEvent();
         public VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent OnGrabButtonPressed = new VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent();
         public VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent OnGrabButtonReleased = new VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent();
 
         protected override void AddListeners(VRTK_InteractGrab component)
         {
+            component.ControllerStartGrabInteractableObject += ControllerStartGrabInteractableObject;
             component.ControllerGrabInteractableObject += ControllerGrabInteractableObject;
+            component.ControllerStartUngrabInteractableObject += ControllerStartUngrabInteractableObject;
             component.ControllerUngrabInteractableObject += ControllerUngrabInteractableObject;
             component.GrabButtonPressed += GrabButtonPressed;
             component.GrabButtonReleased += GrabButtonReleased;
@@ -25,15 +29,27 @@
 
         protected override void RemoveListeners(VRTK_InteractGrab component)
         {
+            component.ControllerStartGrabInteractableObject -= ControllerStartGrabInteractableObject;
             component.ControllerGrabInteractableObject -= ControllerGrabInteractableObject;
+            component.ControllerStartUngrabInteractableObject -= ControllerStartUngrabInteractableObject;
             component.ControllerUngrabInteractableObject -= ControllerUngrabInteractableObject;
             component.GrabButtonPressed -= GrabButtonPressed;
             component.GrabButtonReleased -= GrabButtonReleased;
         }
 
+        private void ControllerStartGrabInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerStartGrabInteractableObject.Invoke(o, e);
+        }
+
         private void ControllerGrabInteractableObject(object o, ObjectInteractEventArgs e)
         {
             OnControllerGrabInteractableObject.Invoke(o, e);
+        }
+
+        private void ControllerStartUngrabInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerStartUngrabInteractableObject.Invoke(o, e);
         }
 
         private void ControllerUngrabInteractableObject(object o, ObjectInteractEventArgs e)

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractHaptics_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractHaptics_UnityEvents.cs
@@ -1,0 +1,46 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_InteractHaptics_UnityEvents")]
+    public sealed class VRTK_InteractHaptics_UnityEvents : VRTK_UnityEvents<VRTK_InteractHaptics>
+    {
+        [Serializable]
+        public sealed class InteractHapticsEvent : UnityEvent<object, InteractHapticsEventArgs> { }
+
+        public InteractHapticsEvent OnInteractHapticsTouched = new InteractHapticsEvent();
+        public InteractHapticsEvent OnInteractHapticsGrabbed = new InteractHapticsEvent();
+        public InteractHapticsEvent OnInteractHapticsUsed = new InteractHapticsEvent();
+
+        protected override void AddListeners(VRTK_InteractHaptics component)
+        {
+            component.InteractHapticsTouched += InteractHapticsTouched;
+            component.InteractHapticsGrabbed += InteractHapticsGrabbed;
+            component.InteractHapticsUsed += InteractHapticsUsed;
+        }
+
+        protected override void RemoveListeners(VRTK_InteractHaptics component)
+        {
+            component.InteractHapticsTouched -= InteractHapticsTouched;
+            component.InteractHapticsGrabbed -= InteractHapticsGrabbed;
+            component.InteractHapticsUsed -= InteractHapticsUsed;
+        }
+
+        private void InteractHapticsTouched(object o, InteractHapticsEventArgs e)
+        {
+            OnInteractHapticsTouched.Invoke(o, e);
+        }
+
+        private void InteractHapticsGrabbed(object o, InteractHapticsEventArgs e)
+        {
+            OnInteractHapticsGrabbed.Invoke(o, e);
+        }
+
+        private void InteractHapticsUsed(object o, InteractHapticsEventArgs e)
+        {
+            OnInteractHapticsUsed.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractHaptics_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractHaptics_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4ff171c043701b54d864a68baf7c7b39
+timeCreated: 1496852192
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
@@ -10,19 +10,36 @@
         [Serializable]
         public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
 
+        public ObjectInteractEvent OnControllerStartTouchInteractableObject = new ObjectInteractEvent();
         public ObjectInteractEvent OnControllerTouchInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerStartUntouchInteractableObject = new ObjectInteractEvent();
         public ObjectInteractEvent OnControllerUntouchInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerRigidbodyActivated = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerRigidbodyDeactivated = new ObjectInteractEvent();
 
         protected override void AddListeners(VRTK_InteractTouch component)
         {
+            component.ControllerStartTouchInteractableObject += ControllerStartTouchInteractableObject;
             component.ControllerTouchInteractableObject += ControllerTouchInteractableObject;
+            component.ControllerStartUntouchInteractableObject += ControllerStartUntouchInteractableObject;
             component.ControllerUntouchInteractableObject += ControllerUntouchInteractableObject;
+            component.ControllerRigidbodyActivated += ControllerRigidbodyActivated;
+            component.ControllerRigidbodyDeactivated += ControllerRigidbodyDeactivated;
         }
 
         protected override void RemoveListeners(VRTK_InteractTouch component)
         {
+            component.ControllerStartTouchInteractableObject -= ControllerStartTouchInteractableObject;
             component.ControllerTouchInteractableObject -= ControllerTouchInteractableObject;
+            component.ControllerStartUntouchInteractableObject -= ControllerStartUntouchInteractableObject;
             component.ControllerUntouchInteractableObject -= ControllerUntouchInteractableObject;
+            component.ControllerRigidbodyActivated -= ControllerRigidbodyActivated;
+            component.ControllerRigidbodyDeactivated -= ControllerRigidbodyDeactivated;
+        }
+
+        private void ControllerStartTouchInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerStartTouchInteractableObject.Invoke(o, e);
         }
 
         private void ControllerTouchInteractableObject(object o, ObjectInteractEventArgs e)
@@ -30,9 +47,24 @@
             OnControllerTouchInteractableObject.Invoke(o, e);
         }
 
+        private void ControllerStartUntouchInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerStartUntouchInteractableObject.Invoke(o, e);
+        }
+
         private void ControllerUntouchInteractableObject(object o, ObjectInteractEventArgs e)
         {
             OnControllerUntouchInteractableObject.Invoke(o, e);
+        }
+
+        private void ControllerRigidbodyActivated(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerRigidbodyActivated.Invoke(o, e);
+        }
+
+        private void ControllerRigidbodyDeactivated(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerRigidbodyDeactivated.Invoke(o, e);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_InteractUse_UnityEvents.cs
@@ -10,14 +10,18 @@
         [Serializable]
         public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
 
+        public ObjectInteractEvent OnControllerStartUseInteractableObject = new ObjectInteractEvent();
         public ObjectInteractEvent OnControllerUseInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerStartUnuseInteractableObject = new ObjectInteractEvent();
         public ObjectInteractEvent OnControllerUnuseInteractableObject = new ObjectInteractEvent();
         public VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent OnUseButtonPressed = new VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent();
         public VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent OnUseButtonReleased = new VRTK_ControllerEvents_UnityEvents.ControllerInteractionEvent();
 
         protected override void AddListeners(VRTK_InteractUse component)
         {
+            component.ControllerStartUseInteractableObject += ControllerStartUseInteractableObject;
             component.ControllerUseInteractableObject += ControllerUseInteractableObject;
+            component.ControllerStartUnuseInteractableObject += ControllerStartUnuseInteractableObject;
             component.ControllerUnuseInteractableObject += ControllerUnuseInteractableObject;
             component.UseButtonPressed += UseButtonPressed;
             component.UseButtonReleased += UseButtonReleased;
@@ -25,15 +29,27 @@
 
         protected override void RemoveListeners(VRTK_InteractUse component)
         {
+            component.ControllerStartUseInteractableObject -= ControllerStartUseInteractableObject;
             component.ControllerUseInteractableObject -= ControllerUseInteractableObject;
+            component.ControllerStartUnuseInteractableObject -= ControllerStartUnuseInteractableObject;
             component.ControllerUnuseInteractableObject -= ControllerUnuseInteractableObject;
             component.UseButtonPressed -= UseButtonPressed;
             component.UseButtonReleased -= UseButtonReleased;
         }
 
+        private void ControllerStartUseInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerStartUseInteractableObject.Invoke(o, e);
+        }
+
         private void ControllerUseInteractableObject(object o, ObjectInteractEventArgs e)
         {
             OnControllerUseInteractableObject.Invoke(o, e);
+        }
+
+        private void ControllerStartUnuseInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerStartUnuseInteractableObject.Invoke(o, e);
         }
 
         private void ControllerUnuseInteractableObject(object o, ObjectInteractEventArgs e)

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectAutoGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectAutoGrab_UnityEvents.cs
@@ -1,0 +1,30 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_ObjectAutoGrab_UnityEvents")]
+    public sealed class VRTK_ObjectAutoGrab_UnityEvents : VRTK_UnityEvents<VRTK_ObjectAutoGrab>
+    {
+        [Serializable]
+        public sealed class ObjectAutoGrabEvent : UnityEvent<object> { }
+
+        public ObjectAutoGrabEvent OnObjectAutoGrabCompleted = new ObjectAutoGrabEvent();
+
+        protected override void AddListeners(VRTK_ObjectAutoGrab component)
+        {
+            component.ObjectAutoGrabCompleted += ObjectAutoGrabCompleted;
+        }
+
+        protected override void RemoveListeners(VRTK_ObjectAutoGrab component)
+        {
+            component.ObjectAutoGrabCompleted -= ObjectAutoGrabCompleted;
+        }
+
+        private void ObjectAutoGrabCompleted(object o)
+        {
+            OnObjectAutoGrabCompleted.Invoke(o);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectAutoGrab_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectAutoGrab_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 00db76965dfde574da231945fe5e5da2
+timeCreated: 1496916397
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectTooltip_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectTooltip_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_ObjectTooltip_UnityEvents")]
+    public sealed class VRTK_ObjectTooltip_UnityEvents : VRTK_UnityEvents<VRTK_ObjectTooltip>
+    {
+        [Serializable]
+        public sealed class ObjectTooltipEvent : UnityEvent<object, ObjectTooltipEventArgs> { }
+
+        public ObjectTooltipEvent OnObjectTooltipReset = new ObjectTooltipEvent();
+        public ObjectTooltipEvent OnObjectTooltipTextUpdated = new ObjectTooltipEvent();
+
+        protected override void AddListeners(VRTK_ObjectTooltip component)
+        {
+            component.ObjectTooltipReset += ObjectTooltipReset;
+            component.ObjectTooltipTextUpdated += ObjectTooltipTextUpdated;
+        }
+
+        protected override void RemoveListeners(VRTK_ObjectTooltip component)
+        {
+            component.ObjectTooltipReset -= ObjectTooltipReset;
+            component.ObjectTooltipTextUpdated -= ObjectTooltipTextUpdated;
+        }
+
+        private void ObjectTooltipReset(object o, ObjectTooltipEventArgs e)
+        {
+            OnObjectTooltipReset.Invoke(o, e);
+        }
+
+        private void ObjectTooltipTextUpdated(object o, ObjectTooltipEventArgs e)
+        {
+            OnObjectTooltipTextUpdated.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectTooltip_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ObjectTooltip_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f9949283f41c47d469a4a4fdd479643c
+timeCreated: 1496824737
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayAreaCursor_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayAreaCursor_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_PlayAreaCursor_UnityEvents")]
+    public sealed class VRTK_PlayAreaCursor_UnityEvents : VRTK_UnityEvents<VRTK_PlayAreaCursor>
+    {
+        [Serializable]
+        public sealed class PlayAreaCursorEvent : UnityEvent<object, PlayAreaCursorEventArgs> { }
+
+        public PlayAreaCursorEvent OnPlayAreaCursorStartCollision = new PlayAreaCursorEvent();
+        public PlayAreaCursorEvent OnPlayAreaCursorEndCollision = new PlayAreaCursorEvent();
+
+        protected override void AddListeners(VRTK_PlayAreaCursor component)
+        {
+            component.PlayAreaCursorStartCollision += PlayAreaCursorStartCollision;
+            component.PlayAreaCursorEndCollision += PlayAreaCursorEndCollision;
+        }
+
+        protected override void RemoveListeners(VRTK_PlayAreaCursor component)
+        {
+            component.PlayAreaCursorStartCollision -= PlayAreaCursorStartCollision;
+            component.PlayAreaCursorEndCollision -= PlayAreaCursorEndCollision;
+        }
+
+        private void PlayAreaCursorStartCollision(object o, PlayAreaCursorEventArgs e)
+        {
+            OnPlayAreaCursorStartCollision.Invoke(o, e);
+        }
+
+        private void PlayAreaCursorEndCollision(object o, PlayAreaCursorEventArgs e)
+        {
+            OnPlayAreaCursorEndCollision.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayAreaCursor_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PlayAreaCursor_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2b8b2bf4dcd017b4aa75a435f2e9f303
+timeCreated: 1496844107
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PointerDirectionIndicator_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PointerDirectionIndicator_UnityEvents.cs
@@ -1,0 +1,30 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_PointerDirectionIndicator_UnityEvents")]
+    public sealed class VRTK_PointerDirectionIndicator_UnityEvents : VRTK_UnityEvents<VRTK_PointerDirectionIndicator>
+    {
+        [Serializable]
+        public sealed class PointerDirectionIndicatorEvent : UnityEvent<object> { }
+
+        public PointerDirectionIndicatorEvent OnPointerDirectionIndicatorPositionSet = new PointerDirectionIndicatorEvent();
+
+        protected override void AddListeners(VRTK_PointerDirectionIndicator component)
+        {
+            component.PointerDirectionIndicatorPositionSet += PointerDirectionIndicatorPositionSet;
+        }
+
+        protected override void RemoveListeners(VRTK_PointerDirectionIndicator component)
+        {
+            component.PointerDirectionIndicatorPositionSet -= PointerDirectionIndicatorPositionSet;
+        }
+
+        private void PointerDirectionIndicatorPositionSet(object o)
+        {
+            OnPointerDirectionIndicatorPositionSet.Invoke(o);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PointerDirectionIndicator_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PointerDirectionIndicator_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6b1a318d5f3204c4aaea5ecb316eaf4c
+timeCreated: 1496827025
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PositionRewind_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PositionRewind_UnityEvents.cs
@@ -1,0 +1,30 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_PositionRewind_UnityEvents")]
+    public sealed class VRTK_PositionRewind_UnityEvents : VRTK_UnityEvents<VRTK_PositionRewind>
+    {
+        [Serializable]
+        public sealed class PositionRewindEvent : UnityEvent<object, PositionRewindEventArgs> { }
+
+        public PositionRewindEvent OnPositionRewindToSafe = new PositionRewindEvent();
+
+        protected override void AddListeners(VRTK_PositionRewind component)
+        {
+            component.PositionRewindToSafe += PositionRewindToSafe;
+        }
+
+        protected override void RemoveListeners(VRTK_PositionRewind component)
+        {
+            component.PositionRewindToSafe -= PositionRewindToSafe;
+        }
+
+        private void PositionRewindToSafe(object o, PositionRewindEventArgs e)
+        {
+            OnPositionRewindToSafe.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PositionRewind_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_PositionRewind_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c9cb0ab9969bf124cac8d97db7c60990
+timeCreated: 1496843412
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIDraggableItem_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIDraggableItem_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_UIDraggableItem_UnityEvents")]
+    public sealed class VRTK_UIDraggableItem_UnityEvents : VRTK_UnityEvents<VRTK_UIDraggableItem>
+    {
+        [Serializable]
+        public sealed class UIDraggableItemEvent : UnityEvent<object, UIDraggableItemEventArgs> { }
+
+        public UIDraggableItemEvent OnDraggableItemDropped = new UIDraggableItemEvent();
+        public UIDraggableItemEvent OnDraggableItemReset = new UIDraggableItemEvent();
+
+        protected override void AddListeners(VRTK_UIDraggableItem component)
+        {
+            component.DraggableItemDropped += DraggableItemDropped;
+            component.DraggableItemReset += DraggableItemReset;
+        }
+
+        protected override void RemoveListeners(VRTK_UIDraggableItem component)
+        {
+            component.DraggableItemDropped -= DraggableItemDropped;
+            component.DraggableItemReset -= DraggableItemReset;
+        }
+
+        private void DraggableItemDropped(object o, UIDraggableItemEventArgs e)
+        {
+            OnDraggableItemDropped.Invoke(o, e);
+        }
+
+        private void DraggableItemReset(object o, UIDraggableItemEventArgs e)
+        {
+            OnDraggableItemReset.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIDraggableItem_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_UIDraggableItem_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 089d53583326b2147b0319c455bef773
+timeCreated: 1496829222
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -154,6 +154,21 @@ There are a number of parameters that can be set on the Prefab which are provide
  * **Line Color:** The colour to use for the line drawn between the tooltip and the destination transform.
  * **Always Face Headset:** If this is checked then the tooltip will be rotated so it always face the headset.
 
+### Class Events
+
+ * `ObjectTooltipReset` - Emitted when the object tooltip is reset.
+ * `ObjectTooltipTextUpdated` - Emitted when the object tooltip text is updated.
+
+### Unity Events
+
+Adding the `VRTK_ObjectTooltip_UnityEvents` component to `VRTK_ObjectTooltip` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `string newText` - The optional new text that is given to the tooltip.
+
 ### Class Methods
 
 #### ResetTooltip/0
@@ -219,6 +234,21 @@ There are a number of parameters that can be set on the Prefab which are provide
  * **Retry Init Max Tries:** The total number of initialisation attempts to make when waiting for the button transforms to initialise.
  * **Retry Init Counter:** The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.
 
+### Class Events
+
+ * `ControllerTooltipOn` - Emitted when the controller tooltip is turned on.
+ * `ControllerTooltipOff` - Emitted when the controller tooltip is turned off.
+
+### Unity Events
+
+Adding the `VRTK_ControllerTooltips_UnityEvents` component to `VRTK_ControllerTooltips` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `VRTK_ControllerTooltips.TooltipButtons element` - The tooltip element being affected.
+
 ### Class Methods
 
 #### ResetTooltip/0
@@ -279,6 +309,21 @@ It's also possible to replace the sphere trigger collider with an alternative tr
 ### Inspector Parameters
 
  * **Is Enabled:** If this is checked then the collider will have it's rigidbody toggled on and off during a collision.
+
+### Class Events
+
+ * `ControllerRigidbodyOn` - Emitted when the controller rigidbody is turned on.
+ * `ControllerRigidbodyOff` - Emitted when the controller rigidbody is turned off.
+
+### Unity Events
+
+Adding the `VRTK_ControllerRigidbodyActivator_UnityEvents` component to `VRTK_ControllerRigidbodyActivator` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * ` interactingObject` - The object that touching the activator.
 
 ---
 
@@ -654,6 +699,20 @@ The destination points can also have a locked state if the `Enable Teleport` fla
   * `RotateWithNoHeadsetOffset` - The destination point's rotation will be emitted without taking into consideration the current headset rotation.
   * `RotateWithHeadsetOffset` - The destination point's rotation will be emitted and will take into consideration the current headset rotation.
 
+### Class Events
+
+ * `DestinationPointEnabled` - Emitted when the destination point is enabled.
+ * `DestinationPointDisabled` - Emitted when the destination point is disabled.
+ * `DestinationPointLocked` - Emitted when the destination point is locked.
+ * `DestinationPointUnlocked` - Emitted when the destination point is unlocked.
+ * `DestinationPointReset` - Emitted when the destination point is reset.
+
+### Unity Events
+
+Adding the `VRTK_DestinationPoint_UnityEvents` component to `VRTK_DestinationPoint` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
 ### Class Methods
 
 #### ResetDestinationPoint/0
@@ -686,6 +745,16 @@ This can be useful for rotating the play area upon teleporting to face the user 
 ### Inspector Parameters
 
  * **Include Headset Offset:** If this is checked then the reported rotation will include the offset of the headset rotation in relation to the play area.
+
+### Class Events
+
+ * `PointerDirectionIndicatorPositionSet` - Emitted when the object tooltip is reset.
+
+### Unity Events
+
+Adding the `VRTK_PointerDirectionIndicator_UnityEvents` component to `VRTK_PointerDirectionIndicator` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
 
 ### Class Methods
 
@@ -1232,6 +1301,21 @@ The Play Area Cursor is used in conjunction with a Pointer script and displays a
  * **Valid Location Object:** A custom GameObject to use for the play area cursor representation for when the location is valid.
  * **Invalid Location Object:** A custom GameObject to use for the play area cursor representation for when the location is invalid.
 
+### Class Events
+
+ * `PlayAreaCursorStartCollision` - Emitted when the play area collides with another object.
+ * `PlayAreaCursorEndCollision` - Emitted when the play area stops colliding with another object.
+
+### Unity Events
+
+Adding the `VRTK_PlayAreaCursor_UnityEvents` component to `VRTK_PlayAreaCursor` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * ` collidedWith` - The collider that is/was being collided with.
+
 ### Class Methods
 
 #### HasCollided/0
@@ -1256,12 +1340,13 @@ The HasCollided method returns the state of whether the play area cursor has cur
 
 The SetHeadsetPositionCompensation method determines whether the offset position of the headset from the centre of the play area should be taken into consideration when setting the destination marker. If `true` then it will take the offset position into consideration.
 
-#### SetPlayAreaCursorCollision/1
+#### SetPlayAreaCursorCollision/2
 
-  > `public virtual void SetPlayAreaCursorCollision(bool state)`
+  > `public virtual void SetPlayAreaCursorCollision(bool state, Collider collider = null)`
 
   * Parameters
    * `bool state` - The state of whether to check for play area collisions.
+   * `Collider collider` - The state of whether to check for play area collisions.
   * Returns
    * _none_
 
@@ -2676,6 +2761,28 @@ The Interact Controller Appearance script is attached on the same GameObject as 
  * **Hide Controller On Use:** Hides the controller model when a valid use occurs.
  * **Hide Delay On Use:** The amount of seconds to wait before hiding the controller on use.
 
+### Class Events
+
+ * `ControllerHidden` - Emitted when the interacting object is hidden.
+ * `ControllerVisible` - Emitted when the interacting object is shown.
+ * `HiddenOnTouch` - Emitted when the interacting object is hidden on touch.
+ * `VisibleOnTouch` - Emitted when the interacting object is shown on untouch.
+ * `HiddenOnGrab` - Emitted when the interacting object is hidden on grab.
+ * `VisibleOnGrab` - Emitted when the interacting object is shown on ungrab.
+ * `HiddenOnUse` - Emitted when the interacting object is hidden on use.
+ * `VisibleOnUse` - Emitted when the interacting object is shown on unuse.
+
+### Unity Events
+
+Adding the `VRTK_InteractControllerAppearance_UnityEvents` component to `VRTK_InteractControllerAppearance` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `GameObject interactingObject` - The object that is interacting.
+ * `GameObject ignoredObject` - The object that is being ignored.
+
 ### Class Methods
 
 #### ToggleControllerOnTouch/3
@@ -2739,8 +2846,12 @@ A custom collider can be provided by the Custom Rigidbody Object parameter.
 
 ### Class Events
 
+ * `ControllerStartTouchInteractableObject` - Emitted when the touch of a valid object has started.
  * `ControllerTouchInteractableObject` - Emitted when a valid object is touched.
+ * `ControllerStartUntouchInteractableObject` - Emitted when the untouch of a valid object has started.
  * `ControllerUntouchInteractableObject` - Emitted when a valid object is no longer being touched.
+ * `ControllerRigidbodyActivated` - Emitted when the controller rigidbody is activated.
+ * `ControllerRigidbodyDeactivated` - Emitted when the controller rigidbody is deactivated.
 
 ### Unity Events
 
@@ -2882,7 +2993,9 @@ The interactable objects require a collider to activate the trigger and a rigidb
 
  * `GrabButtonPressed` - Emitted when the grab button is pressed.
  * `GrabButtonReleased` - Emitted when the grab button is released.
+ * `ControllerStartGrabInteractableObject` - Emitted when a grab of a valid object is started.
  * `ControllerGrabInteractableObject` - Emitted when a valid object is grabbed.
+ * `ControllerStartUngrabInteractableObject` - Emitted when a ungrab of a valid object is started.
  * `ControllerUngrabInteractableObject` - Emitted when a valid object is released from being grabbed.
 
 ### Unity Events
@@ -2972,7 +3085,9 @@ If a valid interactable object is usable then pressing the set `Use` button on t
 
  * `UseButtonPressed` - Emitted when the use toggle alias button is pressed.
  * `UseButtonReleased` - Emitted when the use toggle alias button is released.
+ * `ControllerStartUseInteractableObject` - Emitted when a use of a valid object is started.
  * `ControllerUseInteractableObject` - Emitted when a valid object starts being used.
+ * `ControllerStartUnuseInteractableObject` - Emitted when a unuse of a valid object is started.
  * `ControllerUnuseInteractableObject` - Emitted when a valid object stops being used.
 
 ### Unity Events
@@ -3585,6 +3700,22 @@ The Interact Haptics script is attached on the same GameObject as an Interactabl
  * **Duration On Use:** Denotes how long the rumble in the controller will last on use.
  * **Interval On Use:** Denotes interval betweens rumble in the controller on use.
 
+### Class Events
+
+ * `InteractHapticsTouched` - Emitted when the haptics are from a touch.
+ * `InteractHapticsGrabbed` - Emitted when the haptics are from a grab.
+ * `InteractHapticsUsed` - Emitted when the haptics are from a use.
+
+### Unity Events
+
+Adding the `VRTK_InteractHaptics_UnityEvents` component to `VRTK_InteractHaptics` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `VRTK_ControllerReference controllerReference` - The reference to the controller to perform haptics on.
+
 ### Class Methods
 
 #### HapticsOnTouch/1
@@ -3636,6 +3767,16 @@ It is possible to automatically grab an Interactable Object to a specific contro
  * **Always Clone On Enable:** If `Clone Grabbed Object` is checked and this is checked, then whenever this script is disabled and re-enabled, it will always create a new clone of the object to grab. If this is false then the original cloned object will attempt to be grabbed again. If the original cloned object no longer exists then a new clone will be created.
  * **Interact Touch:** The Interact Touch to listen for touches on. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
  * **Interact Grab:** The Interact Grab to listen for grab actions on. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
+
+### Class Events
+
+ * `ObjectAutoGrabCompleted` - Emitted when the object auto grab has completed successfully.
+
+### Unity Events
+
+Adding the `VRTK_ObjectAutoGrab_UnityEvents` component to `VRTK_ObjectAutoGrab` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
 
 ### Class Methods
 
@@ -5019,9 +5160,13 @@ To allow for peeking over a ledge and not falling, a fall restiction can happen 
  * `StartFalling` - Emitted when a fall begins.
  * `StopFalling` - Emitted when a fall ends.
  * `StartMoving` - Emitted when movement in the play area begins.
- * `StopMoving` - Emitted when movement in the play area ends
- * `StartColliding` - Emitted when the body collider starts colliding with another game object
- * `StopColliding` - Emitted when the body collider stops colliding with another game object
+ * `StopMoving` - Emitted when movement in the play area ends.
+ * `StartColliding` - Emitted when the body collider starts colliding with another game object.
+ * `StopColliding` - Emitted when the body collider stops colliding with another game object.
+ * `StartLeaning` - Emitted when the body collider starts leaning over another game object.
+ * `StopLeaning` - Emitted when the body collider stops leaning over another game object.
+ * `StartTouchingGround` - Emitted when the body collider starts touching the ground.
+ * `StopTouchingGround` - Emitted when the body collider stops touching the ground.
 
 ### Unity Events
 
@@ -5245,6 +5390,21 @@ The Position Rewind script is used to reset the user back to a good known standi
   * `HeadsetOnly` - Listen for collisions on the headset collider only.
   * `BodyOnly` - Listen for collisions on the body physics collider only.
   * `HeadsetAndBody` - Listen for collisions on both the headset collider and body physics collider.
+
+### Class Events
+
+ * `PositionRewindToSafe` - Emitted when the draggable item is successfully dropped.
+
+### Unity Events
+
+Adding the `VRTK_PositionRewind_UnityEvents` component to `VRTK_PositionRewind` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `Vector3 collidedPosition` - The position of the play area when it collded.
+ * `Vector3 resetPosition` - The position of the play area when it has been rewinded to a safe position.
 
 ### Class Methods
 
@@ -5480,6 +5640,21 @@ If a UI Draggable item is set to `Restrict To Drop Zone = true` then the UI Drag
 ### Class Variables
 
  * `public GameObject validDropZone` - The current valid drop zone the dragged element is hovering over.
+
+### Class Events
+
+ * `DraggableItemDropped` - Emitted when the draggable item is successfully dropped.
+ * `DraggableItemReset` - Emitted when the draggable item is reset.
+
+### Unity Events
+
+Adding the `VRTK_UIDraggableItem_UnityEvents` component to `VRTK_UIDraggableItem` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `GameObject target` - The target the item is dragged onto.
 
 ### Example
 


### PR DESCRIPTION
A number of the scripts perform actions that set state but the only
way of knowing the action has happened or the state has changed was
to have a reference to the script and access relevant variables or
methods.

This change sees that any VRTK script that performs an action will
now also emit a C# delegate event (and a corresponding Unity event
via the Unity Event helpers). This means that any action that occurs
can be utilised simply through registering for the event.