### PR TITLE
feat(Presence): option to ignore trigger colliders for head collisions

### DIFF
--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -10,9 +10,11 @@ namespace VRTK
     /// Event Payload
     /// </summary>
     /// <param name="target">The target the event is dealing with.</param>
+    /// <param name="collider">An optional collider that the body physics is colliding with.</param>
     public struct BodyPhysicsEventArgs
     {
         public GameObject target;
+        public Collider collider;
     }
 
     /// <summary>
@@ -399,7 +401,7 @@ namespace VRTK
             {
                 CheckStepUpCollision(collision);
                 currentCollidingObject = collision.gameObject;
-                OnStartColliding(SetBodyPhysicsEvent(currentCollidingObject));
+                OnStartColliding(SetBodyPhysicsEvent(currentCollidingObject, collision.collider));
             }
         }
 
@@ -408,7 +410,7 @@ namespace VRTK
             if (CheckValidCollision(collider.gameObject))
             {
                 currentCollidingObject = collider.gameObject;
-                OnStartColliding(SetBodyPhysicsEvent(currentCollidingObject));
+                OnStartColliding(SetBodyPhysicsEvent(currentCollidingObject, collider));
             }
 
         }
@@ -417,7 +419,7 @@ namespace VRTK
         {
             if (CheckExistingCollision(collision.gameObject))
             {
-                OnStopColliding(SetBodyPhysicsEvent(currentCollidingObject));
+                OnStopColliding(SetBodyPhysicsEvent(currentCollidingObject, collision.collider));
                 currentCollidingObject = null;
             }
         }
@@ -426,7 +428,7 @@ namespace VRTK
         {
             if (CheckExistingCollision(collider.gameObject))
             {
-                OnStopColliding(SetBodyPhysicsEvent(currentCollidingObject));
+                OnStopColliding(SetBodyPhysicsEvent(currentCollidingObject, collider));
                 currentCollidingObject = null;
             }
         }
@@ -565,10 +567,11 @@ namespace VRTK
             }
         }
 
-        protected virtual BodyPhysicsEventArgs SetBodyPhysicsEvent(GameObject target)
+        protected virtual BodyPhysicsEventArgs SetBodyPhysicsEvent(GameObject target, Collider collider)
         {
             BodyPhysicsEventArgs e;
             e.target = target;
+            e.collider = collider;
             return e;
         }
 
@@ -754,11 +757,11 @@ namespace VRTK
         {
             if (movementState)
             {
-                OnStartMoving(SetBodyPhysicsEvent(null));
+                OnStartMoving(SetBodyPhysicsEvent(null, null));
             }
             else
             {
-                OnStopMoving(SetBodyPhysicsEvent(null));
+                OnStopMoving(SetBodyPhysicsEvent(null, null));
             }
         }
 
@@ -1164,7 +1167,7 @@ namespace VRTK
             isLeaning = false;
             onGround = false;
             fallMinTime = Time.time + (Time.fixedDeltaTime * 3.0f); // Wait at least 3 fixed update frames before declaring falling finished 
-            OnStartFalling(SetBodyPhysicsEvent(targetFloor));
+            OnStartFalling(SetBodyPhysicsEvent(targetFloor, null));
         }
 
         protected virtual void StopFall()
@@ -1177,7 +1180,7 @@ namespace VRTK
 
             if (wasFalling)
             {
-                OnStopFalling(SetBodyPhysicsEvent(null));
+                OnStopFalling(SetBodyPhysicsEvent(null, null));
             }
         }
 

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetCollision.cs
@@ -33,6 +33,8 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Presence/VRTK_HeadsetCollision")]
     public class VRTK_HeadsetCollision : MonoBehaviour
     {
+        [Tooltip("If this is checked then the headset collision will ignore colliders set to `Is Trigger = true`.")]
+        public bool ignoreTriggerColliders = false;
         [Tooltip("The radius of the auto generated sphere collider for detecting collisions on the headset.")]
         public float colliderRadius = 0.1f;
         [Tooltip("A specified VRTK_PolicyList to use to determine whether any objects will be acted upon by the Headset Collision.")]
@@ -233,6 +235,11 @@ namespace VRTK
 
         protected virtual void OnTriggerStay(Collider collider)
         {
+            if (parent.ignoreTriggerColliders && collider != null && collider.isTrigger)
+            {
+                return;
+            }
+
             if (enabled && !VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && ValidTarget(collider.transform))
             {
                 parent.headsetColliding = true;
@@ -243,6 +250,11 @@ namespace VRTK
 
         protected virtual void OnTriggerExit(Collider collider)
         {
+            if (parent.ignoreTriggerColliders && collider != null && collider.isTrigger)
+            {
+                return;
+            }
+
             EndCollision(collider);
         }
 

--- a/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_PositionRewind.cs
@@ -29,6 +29,8 @@ namespace VRTK
 
         [Tooltip("The colliders to determine if a collision has occured for the rewind to be actioned.")]
         public CollisionDetectors collisionDetector = CollisionDetectors.HeadsetOnly;
+        [Tooltip("If this is checked then the collision detector will ignore colliders set to `Is Trigger = true`.")]
+        public bool ignoreTriggerColliders = false;
         [Tooltip("The amount of time from original headset collision until the rewind to the last good known position takes place.")]
         public float rewindDelay = 0.5f;
         [Tooltip("The additional distance to push the play area back upon rewind to prevent being right next to the wall again.")]
@@ -167,8 +169,13 @@ namespace VRTK
             }
         }
 
-        protected virtual void StartCollision(GameObject target)
+        protected virtual void StartCollision(GameObject target, Collider collider)
         {
+            if (ignoreTriggerColliders && collider.isTrigger)
+            {
+                return;
+            }
+
             if (!VRTK_PolicyList.Check(target, targetListPolicy))
             {
                 isColliding = true;
@@ -180,8 +187,13 @@ namespace VRTK
             }
         }
 
-        protected virtual void EndCollision()
+        protected virtual void EndCollision(Collider collider)
         {
+            if (ignoreTriggerColliders && collider != null && collider.isTrigger)
+            {
+                return;
+            }
+
             isColliding = false;
             hasCollided = false;
             isRewinding = false;
@@ -248,22 +260,22 @@ namespace VRTK
 
         private void StartColliding(object sender, BodyPhysicsEventArgs e)
         {
-            StartCollision(e.target);
+            StartCollision(e.target, e.collider);
         }
 
         private void StopColliding(object sender, BodyPhysicsEventArgs e)
         {
-            EndCollision();
+            EndCollision(e.collider);
         }
 
         protected virtual void HeadsetCollisionDetect(object sender, HeadsetCollisionEventArgs e)
         {
-            StartCollision(e.collider.gameObject);
+            StartCollision(e.collider.gameObject, e.collider);
         }
 
         protected virtual void HeadsetCollisionEnded(object sender, HeadsetCollisionEventArgs e)
         {
-            EndCollision();
+            EndCollision(e.collider);
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4710,6 +4710,7 @@ The Headset Collision script will automatically create a script on the headset t
 
 ### Inspector Parameters
 
+ * **Ignore Trigger Colliders:** If this is checked then the headset collision will ignore colliders set to `Is Trigger = true`.
  * **Collider Radius:** The radius of the auto generated sphere collider for detecting collisions on the headset.
  * **Target List Policy:** A specified VRTK_PolicyList to use to determine whether any objects will be acted upon by the Headset Collision.
 
@@ -5031,6 +5032,7 @@ Adding the `VRTK_BodyPhysics_UnityEvents` component to `VRTK_BodyPhysics` object
 ### Event Payload
 
  * `GameObject target` - The target the event is dealing with.
+ * `Collider collider` - An optional collider that the body physics is colliding with.
 
 ### Class Methods
 
@@ -5228,6 +5230,7 @@ The Position Rewind script is used to reset the user back to a good known standi
 ### Inspector Parameters
 
  * **Collision Detector:** The colliders to determine if a collision has occured for the rewind to be actioned.
+ * **Ignore Trigger Colliders:** If this is checked then the collision detector will ignore colliders set to `Is Trigger = true`.
  * **Rewind Delay:** The amount of time from original headset collision until the rewind to the last good known position takes place.
  * **Pushback Distance:** The additional distance to push the play area back upon rewind to prevent being right next to the wall again.
  * **Crouch Threshold:** The threshold to determine how low the headset has to be before it is considered the user is crouching. The last good position will only be recorded in a non-crouching position.


### PR DESCRIPTION
The Headset Collision script now has a new parameter to allow it to
ignore colliding with Trigger colliders.

This option is also now in the Position Rewind to allow the rewind
to be ignored when colliding with a trigger collider (but the headset
collision could still fade the headset on trigger collision if that was
required).