### PR TITLE
fix(Pointers): ensure object interactor is set by global scale - fixes #1162

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -504,7 +504,7 @@ namespace VRTK
                 VRTK_PlayerObject.SetPlayerObject(objectInteractorAttachPoint, VRTK_PlayerObject.ObjectTypes.Pointer);
             }
 
-            ScaleObjectInteractor(Vector3.one * 0.025f);
+            ScaleObjectInteractor(Vector3.one);
             objectInteractor.SetActive(false);
         }
 
@@ -512,7 +512,7 @@ namespace VRTK
         {
             if (objectInteractor != null)
             {
-                objectInteractor.transform.localScale = scaleAmount;
+                VRTK_SharedMethods.SetGlobalScale(transform, scaleAmount);
             }
         }
 

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -220,7 +220,8 @@ namespace VRTK
                 actualContainer.transform.position = origin.position;
                 actualContainer.transform.rotation = origin.rotation;
 
-                ScaleObjectInteractor(actualCursor.transform.localScale * 1.05f);
+                float objectInteractorScaleIncrease = 1.05f;
+                ScaleObjectInteractor(actualCursor.transform.lossyScale * objectInteractorScaleIncrease);
 
                 if (destinationHit.transform)
                 {

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -445,6 +445,17 @@ namespace VRTK
             return (percent == 0f ? value : (value - (percent / 100f)));
         }
 
+        /// <summary>
+        /// The SetGlobalScale method is used to set a transform scale based on a global scale instead of a local scale.
+        /// </summary>
+        /// <param name="transform">The reference to the transform to scale.</param>
+        /// <param name="globalScale">A Vector3 of a global scale to apply to the given transform.</param>
+        public static void SetGlobalScale(this Transform transform, Vector3 globalScale)
+        {
+            transform.localScale = Vector3.one;
+            transform.localScale = new Vector3(globalScale.x / transform.lossyScale.x, globalScale.y / transform.lossyScale.y, globalScale.z / transform.lossyScale.z);
+        }
+
 #if UNITY_EDITOR
         public static BuildTargetGroup[] GetValidBuildTargetGroups()
         {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6665,6 +6665,18 @@ The Vector2ShallowCompare method compares two given Vector2 objects based on the
 
 The NumberPercent method is used to determine the percentage of a given value.
 
+#### SetGlobalScale/2
+
+  > `public static void SetGlobalScale(this Transform transform, Vector3 globalScale)`
+
+  * Parameters
+   * `this Transform transform` - The reference to the transform to scale.
+   * `Vector3 globalScale` - A Vector3 of a global scale to apply to the given transform.
+  * Returns
+   * _none_
+
+The SetGlobalScale method is used to set a transform scale based on a global scale instead of a local scale.
+
 ---
 
 ## Policy List (VRTK_PolicyList)


### PR DESCRIPTION
The pointer object interactor that becomes an extension of the
controller but tracks the scale of the actual pointer cursor.

This would cause an issue when the camera rig was scaled, the
object interactor would change size along with the camera rig
and no longer match the scale of the pointer cursor.

This fix uses the global scale of the pointer cursor to set the
global scale of the object interactor so the scales continue
to match even when the camera rig is scaled.