### PR TITLE
feat(Presence): provide collision sweep detection for body physics - fixes #1259

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
@@ -152,5 +152,17 @@ namespace VRTK
 
             return axisDirection;
         }
+
+        protected virtual bool CanMove(VRTK_BodyPhysics givenBodyPhysics, Vector3 currentPosition, Vector3 proposedPosition)
+        {
+            if (givenBodyPhysics == null)
+            {
+                return true;
+            }
+
+            Vector3 proposedDirection = (proposedPosition - currentPosition).normalized;
+            float distance = Vector3.Distance(currentPosition, proposedPosition);
+            return !givenBodyPhysics.SweepCollision(proposedDirection, distance);
+        }
     }
 }

--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SlideObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SlideObjectControlAction.cs
@@ -17,6 +17,8 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Locomotion/Object Control Actions/VRTK_SlideObjectControlAction")]
     public class VRTK_SlideObjectControlAction : VRTK_BaseObjectControlAction
     {
+        [Header("Slide Settings")]
+
         [Tooltip("The maximum speed the controlled object can be moved in based on the position of the axis.")]
         public float maximumSpeed = 3f;
         [Tooltip("The rate of speed deceleration when the axis is no longer being changed.")]
@@ -26,7 +28,12 @@ namespace VRTK
         [Tooltip("The speed multiplier to be applied when the modifier button is pressed.")]
         public float speedMultiplier = 1.5f;
 
-        private float currentSpeed = 0f;
+        [Header("Custom Settings")]
+
+        [Tooltip("An optional Body Physics script to check for potential collisions in the moving direction. If any potential collision is found then the move will not take place. This can help reduce collision tunnelling.")]
+        public VRTK_BodyPhysics bodyPhysics;
+
+        protected float currentSpeed = 0f;
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
@@ -80,8 +87,13 @@ namespace VRTK
             {
                 float storeYPosition = controlledGameObject.transform.position.y;
                 Vector3 updatedPosition = axisDirection * currentSpeed * Time.deltaTime;
-                controlledGameObject.transform.position += updatedPosition;
-                controlledGameObject.transform.position = new Vector3(controlledGameObject.transform.position.x, storeYPosition, controlledGameObject.transform.position.z);
+                Vector3 finalPosition = controlledGameObject.transform.position + updatedPosition;
+                finalPosition = new Vector3(finalPosition.x, storeYPosition, finalPosition.z);
+
+                if (CanMove(bodyPhysics, controlledGameObject.transform.position, finalPosition))
+                {
+                    controlledGameObject.transform.position = finalPosition;
+                }
             }
         }
     }

--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SnapRotateObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SnapRotateObjectControlAction.cs
@@ -29,7 +29,7 @@ namespace VRTK
         [Tooltip("The threshold the listened axis needs to exceed before the action occurs. This can be used to limit the snap rotate to a single axis direction (e.g. pull down to flip rotate). The threshold is ignored if it is 0.")]
         public float axisThreshold = 0f;
 
-        private float snapDelayTimer = 0f;
+        protected float snapDelayTimer = 0f;
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {

--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_WarpObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_WarpObjectControlAction.cs
@@ -17,6 +17,8 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Locomotion/Object Control Actions/VRTK_WarpObjectControlAction")]
     public class VRTK_WarpObjectControlAction : VRTK_BaseObjectControlAction
     {
+        [Header("Warp Settings")]
+
         [Tooltip("The distance to warp in the facing direction.")]
         public float warpDistance = 1f;
         [Tooltip("The multiplier to be applied to the warp when the modifier button is pressed.")]
@@ -28,8 +30,13 @@ namespace VRTK
         [Tooltip("The speed for the headset to fade out and back in. Having a blink between warps can reduce nausia.")]
         public float blinkTransitionSpeed = 0.6f;
 
-        private float warpDelayTimer = 0f;
-        private Transform headset;
+        [Header("Custom Settings")]
+
+        [Tooltip("An optional Body Physics script to check for potential collisions in the moving direction. If any potential collision is found then the move will not take place. This can help reduce collision tunnelling.")]
+        public VRTK_BodyPhysics bodyPhysics;
+
+        protected float warpDelayTimer = 0f;
+        protected Transform headset;
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
@@ -73,9 +80,11 @@ namespace VRTK
                 Vector3 finalPosition = targetPosition - objectPosition + controlledGameObject.transform.position;
 
                 warpDelayTimer = Time.timeSinceLevelLoad + warpDelay;
-                controlledGameObject.transform.position = finalPosition;
-
-                Blink(blinkTransitionSpeed);
+                if (CanMove(bodyPhysics, controlledGameObject.transform.position, finalPosition))
+                {
+                    controlledGameObject.transform.position = finalPosition;
+                    Blink(blinkTransitionSpeed);
+                }
             }
         }
     }

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -354,6 +354,22 @@ namespace VRTK
             ignoreCollisionsOnGameObjects.Clear();
         }
 
+        /// <summary>
+        /// The SweepCollision method tests to see if a collision will occur with the body collider in a given direction and distance.
+        /// </summary>
+        /// <param name="direction">The direction to test for the potential collision.</param>
+        /// <param name="maxDistance">The maximum distance to check for a potential collision.</param>
+        /// <returns>Returns true if a collision will occur on the given direction over the given maxium distance. Returns false if there is no collision about to happen.</returns>
+        public virtual bool SweepCollision(Vector3 direction, float maxDistance)
+        {
+            Vector3 point1 = (bodyCollider.transform.position + bodyCollider.center) + (Vector3.up * ((bodyCollider.height * 0.5f) - bodyCollider.radius));
+            Vector3 point2 = (bodyCollider.transform.position + bodyCollider.center) - (Vector3.up * ((bodyCollider.height * 0.5f) - bodyCollider.radius));
+            RaycastHit collisionHit;
+#pragma warning disable 0618
+            return VRTK_CustomRaycast.CapsuleCast(customRaycast, point1, point2, bodyCollider.radius, direction, maxDistance, out collisionHit, layersToIgnore, QueryTriggerInteraction.Ignore);
+#pragma warning restore 0618
+        }
+
         protected virtual void Awake()
         {
             VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);

--- a/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_CustomRaycast.cs
@@ -64,6 +64,31 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The CapsuleCast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="point1">The center of the sphere at the start of the capsule.</param>
+        /// <param name="point2">The center of the sphere at the end of the capsule.</param>
+        /// <param name="radius">The radius of the capsule.</param>
+        /// <param name="direction">The direction into which to sweep the capsule.</param>
+        /// <param name="maxDistance">The max length of the sweep.</param>
+        /// <param name="hitData">The linecast hit data.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the linecast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns true if the linecast successfully collides with a valid object.</returns>
+        public static bool CapsuleCast(VRTK_CustomRaycast customCast, Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomCapsuleCast(point1, point2, radius, direction, maxDistance, out hitData);
+            }
+            else
+            {
+                return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
         /// The CustomRaycast method is used to generate a raycast based on the options defined in the CustomRaycast object.
         /// </summary>
         /// <param name="ray">The Ray to cast with.</param>
@@ -85,6 +110,21 @@ namespace VRTK
         public virtual bool CustomLinecast(Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData)
         {
             return Physics.Linecast(startPosition, endPosition, out hitData, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomCapsuleCast method is used to generate a capsulecast based on the options defined in the CustomRaycast object.
+        /// </summary>
+        /// <param name="point1">The center of the sphere at the start of the capsule.</param>
+        /// <param name="point2">The center of the sphere at the end of the capsule.</param>
+        /// <param name="radius">The radius of the capsule.</param>
+        /// <param name="direction">The direction into which to sweep the capsule.</param>
+        /// <param name="maxDistance">The max length of the sweep.</param>
+        /// <param name="hitData">The capsulecast hit data.</param>
+        /// <returns>Returns true if the capsule successfully collides with a valid object.</returns>
+        public virtual bool CustomCapsuleCast(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, out RaycastHit hitData)
+        {
+            return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~layersToIgnore, triggerInteraction);
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1944,7 +1944,7 @@ If the controlled object is the play area and `VRTK_BodyPhysics` is also availab
 
 Move In Place allows the user to move the play area by calculating the y-movement of the user's headset and/or controllers. The user is propelled forward the more they are moving. This simulates moving in game by moving in real life.
 
-> This locomotion method is based on Immersive Movement, originally created by Highsight.
+> This locomotion method is based on Immersive Movement, originally created by Highsight. Thanks to KJack (author of Arm Swinger) for additional work.
 
 ### Inspector Parameters
 
@@ -1959,6 +1959,7 @@ Move In Place allows the user to move the play area by calculating the y-movemen
  * **Falling Deceleration:** The speed in which the play area slows down to a complete stop when the user is falling.
  * **Smart Decouple Threshold:** The degree threshold that all tracked objects (controllers, headset) must be within to change direction when using the Smart Decoupling Direction Method.
  * **Sensitivity:** The maximum amount of movement required to register in the virtual world.  Decreasing this will increase acceleration, and vice versa.
+ * **Body Physics:** An optional Body Physics script to check for potential collisions in the moving direction. If any potential collision is found then the move will not take place. This can help reduce collision tunnelling.
 
 ### Class Variables
 
@@ -2123,6 +2124,7 @@ The effect is a smooth sliding motion in forward and sideways directions to simu
  * **Deceleration:** The rate of speed deceleration when the axis is no longer being changed.
  * **Falling Deceleration:** The rate of speed deceleration when the axis is no longer being changed and the object is falling.
  * **Speed Multiplier:** The speed multiplier to be applied when the modifier button is pressed.
+ * **Body Physics:** An optional Body Physics script to check for potential collisions in the moving direction. If any potential collision is found then the move will not take place. This can help reduce collision tunnelling.
 
 ### Example
 
@@ -2195,6 +2197,7 @@ The effect is a immediate snap to a new position in the given direction.
  * **Warp Delay:** The amount of time required to pass before another warp can be carried out.
  * **Floor Height Tolerance:** The height different in floor allowed to be a valid warp.
  * **Blink Transition Speed:** The speed for the headset to fade out and back in. Having a blink between warps can reduce nausia.
+ * **Body Physics:** An optional Body Physics script to check for potential collisions in the moving direction. If any potential collision is found then the move will not take place. This can help reduce collision tunnelling.
 
 ### Example
 
@@ -5215,6 +5218,18 @@ The GetCurrentCollidingObject method returns the object that the body physics co
 
 The ResetIgnoredCollisions method is used to clear any stored ignored colliders in case the `Ignore Collisions On` array parameter is changed at runtime. This needs to be called manually if changes are made at runtime.
 
+#### SweepCollision/2
+
+  > `public virtual bool SweepCollision(Vector3 direction, float maxDistance)`
+
+  * Parameters
+   * `Vector3 direction` - The direction to test for the potential collision.
+   * `float maxDistance` - The maximum distance to check for a potential collision.
+  * Returns
+   * `bool` - Returns true if a collision will occur on the given direction over the given maxium distance. Returns false if there is no collision about to happen.
+
+The SweepCollision method tests to see if a collision will occur with the body collider in a given direction and distance.
+
 ### Example
 
 `VRTK/Examples/017_CameraRig_TouchpadWalking` has a collection of walls and slopes that can be traversed by the user with the touchpad but the user cannot pass through the objects as they are collidable and the rigidbody physics won't allow the intersection to occur.
@@ -6775,6 +6790,25 @@ The Raycast method is used to generate a raycast either from the given CustomRay
 
 The Linecast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
 
+#### CapsuleCast/9
+
+  > `public static bool CapsuleCast(VRTK_CustomRaycast customCast, Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)`
+
+  * Parameters
+   * `VRTK_CustomRaycast customCast` - The optional object with customised cast parameters.
+   * `Vector3 point1` - The center of the sphere at the start of the capsule.
+   * `Vector3 point2` - The center of the sphere at the end of the capsule.
+   * `float radius` - The radius of the capsule.
+   * `Vector3 direction` - The direction into which to sweep the capsule.
+   * `float maxDistance` - The max length of the sweep.
+   * `out RaycastHit hitData` - The linecast hit data.
+   * `LayerMask ignoreLayers` - A layermask of layers to ignore from the linecast.
+   * `QueryTriggerInteraction affectTriggers` - Determines the trigger interaction level of the cast.
+  * Returns
+   * `bool` - Returns true if the linecast successfully collides with a valid object.
+
+The CapsuleCast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
+
 #### CustomRaycast/3
 
   > `public virtual bool CustomRaycast(Ray ray, out RaycastHit hitData, float length = Mathf.Infinity)`
@@ -6800,6 +6834,22 @@ The CustomRaycast method is used to generate a raycast based on the options defi
    * `bool` - Returns true if the line successfully collides with a valid object.
 
 The CustomLinecast method is used to generate a linecast based on the options defined in the CustomRaycast object.
+
+#### CustomCapsuleCast/6
+
+  > `public virtual bool CustomCapsuleCast(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, out RaycastHit hitData)`
+
+  * Parameters
+   * `Vector3 point1` - The center of the sphere at the start of the capsule.
+   * `Vector3 point2` - The center of the sphere at the end of the capsule.
+   * `float radius` - The radius of the capsule.
+   * `Vector3 direction` - The direction into which to sweep the capsule.
+   * `float maxDistance` - The max length of the sweep.
+   * `out RaycastHit hitData` - The capsulecast hit data.
+  * Returns
+   * `bool` - Returns true if the capsule successfully collides with a valid object.
+
+The CustomCapsuleCast method is used to generate a capsulecast based on the options defined in the CustomRaycast object.
 
 ---
 


### PR DESCRIPTION
The Body Physics script now has a new method `SweepCollision` that
can be used to determine if the body physics body collider will
collide with an object if it continues to move in a given direction
for a given distance.

This new method is now used in some of the Locomotion methods that
move the play area via `transform.position` and can now check
if they are provided with a Body Physics script if when they move
forward, will the new position cause collision tunnelling and if
it does then the movement can be denied meaning tunnelling is not
possible.