### PR TITLE
fix(InteractGrab): Protect against objectToGrabScript.grabAttachMechanicScript being null - fixes #1274  

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -521,7 +521,7 @@ namespace VRTK
             GameObject grabbingObject = controllerReference.scriptAlias;
             bool initialGrabAttempt = false;
             VRTK_InteractableObject objectToGrabScript = objectToGrab.GetComponent<VRTK_InteractableObject>();
-            if (grabbedObject == null && interactTouch != null && IsObjectGrabbable(interactTouch.GetTouchedObject()) && objectToGrabScript && objectToGrabScript.grabAttachMechanicScript.ValidGrab(controllerAttachPoint))
+            if (grabbedObject == null && interactTouch != null && IsObjectGrabbable(interactTouch.GetTouchedObject()) && objectToGrabScript && objectToGrabScript.grabAttachMechanicScript && objectToGrabScript.grabAttachMechanicScript.ValidGrab(controllerAttachPoint))
             {
                 InitGrabbedObject();
                 if (!influencingGrabbedObject)


### PR DESCRIPTION
Quick and easy, NRE fix (I have no idea if the reference is supposed to be there still or not - doing this fixes my immediate issue)