### PR TITLE
fix(Interactions): prevent null reference exceptions - fixes #1274

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -259,7 +259,8 @@ namespace VRTK
 
         protected virtual bool IsObjectUsable(GameObject obj)
         {
-            return (interactTouch.IsObjectInteractable(obj) && obj.GetComponent<VRTK_InteractableObject>().isUsable);
+            VRTK_InteractableObject objScript = (obj != null ? obj.GetComponent<VRTK_InteractableObject>() : null);
+            return (obj != null && interactTouch != null && interactTouch.IsObjectInteractable(obj) && objScript != null && objScript.isUsable);
         }
 
         protected virtual bool IsObjectHoldOnUse(GameObject obj)
@@ -323,28 +324,31 @@ namespace VRTK
 
         protected virtual void UseInteractedObject(GameObject touchedObject)
         {
-            if ((usingObject == null || usingObject != touchedObject) && IsObjectUsable(touchedObject))
+            if ((usingObject == null || usingObject != touchedObject) && IsObjectUsable(touchedObject) && interactTouch != null)
             {
                 usingObject = touchedObject;
                 OnControllerStartUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
-                VRTK_InteractableObject usingObjectScript = usingObject.GetComponent<VRTK_InteractableObject>();
+                VRTK_InteractableObject usingObjectScript = (usingObject != null ? usingObject.GetComponent<VRTK_InteractableObject>() : null);
 
-                if (!usingObjectScript.IsValidInteractableController(controllerReference.scriptAlias, usingObjectScript.allowedUseControllers))
+                if (usingObjectScript != null)
                 {
-                    usingObject = null;
-                    return;
-                }
+                    if (!usingObjectScript.IsValidInteractableController(controllerReference.scriptAlias, usingObjectScript.allowedUseControllers))
+                    {
+                        usingObject = null;
+                        return;
+                    }
 
-                usingObjectScript.StartUsing(controllerReference.scriptAlias);
-                ToggleControllerVisibility(false);
-                AttemptHaptics();
-                OnControllerUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
+                    usingObjectScript.StartUsing(controllerReference.scriptAlias);
+                    ToggleControllerVisibility(false);
+                    AttemptHaptics();
+                    OnControllerUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
+                }
             }
         }
 
         protected virtual void UnuseInteractedObject(bool completeStop)
         {
-            if (usingObject != null)
+            if (usingObject != null && interactTouch != null)
             {
                 OnControllerStartUnuseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
                 VRTK_InteractableObject usingObjectCheck = usingObject.GetComponent<VRTK_InteractableObject>();
@@ -375,17 +379,17 @@ namespace VRTK
 
         protected virtual void AttemptUseObject()
         {
-            GameObject touchedObject = interactTouch.GetTouchedObject();
+            GameObject touchedObject = (interactTouch != null ? interactTouch.GetTouchedObject() : null);
             if (touchedObject == null)
             {
                 touchedObject = GetFromGrab();
             }
 
-            if (touchedObject != null && interactTouch.IsObjectInteractable(touchedObject))
+            if (touchedObject != null && interactTouch != null && interactTouch.IsObjectInteractable(touchedObject))
             {
                 VRTK_InteractableObject interactableObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
 
-                if (interactableObjectScript.useOnlyIfGrabbed && !interactableObjectScript.IsGrabbed())
+                if (interactableObjectScript != null && interactableObjectScript.useOnlyIfGrabbed && !interactableObjectScript.IsGrabbed())
                 {
                     return;
                 }


### PR DESCRIPTION
The Interact Touch/Grab/Use script had a number of areas where it
was possible to create a null reference exception because a script
would be called but could be null.

The fix is to do null checks before any methods or variables are
called on these dependent scripts.