### PR TITLE
feat(Pointers): expose policy list as public on destination marker

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -69,7 +69,7 @@ namespace VRTK
         /// <param name="register">Determines whether to register or unregister the listeners.</param>
         public virtual void InitDestinationSetListener(GameObject markerMaker, bool register)
         {
-            if (markerMaker)
+            if (markerMaker != null)
             {
                 VRTK_DestinationMarker[] worldMarkers = markerMaker.GetComponentsInChildren<VRTK_DestinationMarker>();
                 for (int i = 0; i < worldMarkers.Length; i++)
@@ -78,7 +78,10 @@ namespace VRTK
                     if (register)
                     {
                         worldMarker.DestinationMarkerSet += new DestinationMarkerEventHandler(DoTeleport);
-                        worldMarker.SetInvalidTarget(targetListPolicy);
+                        if (worldMarker.targetListPolicy == null)
+                        {
+                            worldMarker.targetListPolicy = targetListPolicy;
+                        }
                         worldMarker.SetNavMeshCheckDistance(navMeshLimitDistance);
                         worldMarker.SetHeadsetPositionCompensation(headsetPositionCompensation);
                     }

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -115,7 +115,7 @@ namespace VRTK
             navMeshCheckDistance = givenNavMeshCheckDistance;
             headsetPositionCompensation = givenHeadsetPositionCompensation;
 
-            if (controllingPointer != null && controllingPointer.interactWithObjects && controllingPointer.controller && !objectInteractor)
+            if (controllingPointer != null && controllingPointer.interactWithObjects && controllingPointer.controller != null && objectInteractor == null)
             {
                 controllerGrabScript = controllingPointer.controller.GetComponent<VRTK_InteractGrab>();
                 CreateObjectInteractor();
@@ -356,7 +356,7 @@ namespace VRTK
             {
                 validNavMeshLocation = true;
             }
-            return (validNavMeshLocation && destinationHit.transform && !(VRTK_PolicyList.Check(destinationHit.transform.gameObject, invalidListPolicy)));
+            return (validNavMeshLocation && destinationHit.collider != null && !(VRTK_PolicyList.Check(destinationHit.collider.gameObject, invalidListPolicy)));
         }
 
         protected virtual void ToggleElement(GameObject givenObject, bool pointerState, bool actualState, VisibilityStates givenVisibility, ref bool currentVisible)

--- a/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_BasePointer.cs
@@ -426,7 +426,7 @@ namespace VRTK
             {
                 validNavMeshLocation = true;
             }
-            return (validNavMeshLocation && target && !(VRTK_PolicyList.Check(target.gameObject, invalidListPolicy)));
+            return (validNavMeshLocation && target && !(VRTK_PolicyList.Check(target.gameObject, targetListPolicy)));
         }
 
         protected virtual void CreateObjectInteractor()

--- a/Assets/VRTK/Scripts/Pointers/VRTK_DestinationMarker.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_DestinationMarker.cs
@@ -2,6 +2,7 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System;
 
     /// <summary>
     /// Event Payload
@@ -24,7 +25,7 @@ namespace VRTK
         public Quaternion? destinationRotation;
         public bool forceDestinationPosition;
         public bool enableTeleport;
-        [System.Obsolete("`DestinationMarkerEventArgs.controllerIndex` has been replaced with `DestinationMarkerEventArgs.controllerReference`. This parameter will be removed in a future version of VRTK.")]
+        [Obsolete("`DestinationMarkerEventArgs.controllerIndex` has been replaced with `DestinationMarkerEventArgs.controllerReference`. This parameter will be removed in a future version of VRTK.")]
         public uint controllerIndex;
         public VRTK_ControllerReference controllerReference;
     }
@@ -45,8 +46,11 @@ namespace VRTK
     public abstract class VRTK_DestinationMarker : MonoBehaviour
     {
         [Header("Destination Marker Settings", order = 1)]
+
         [Tooltip("If this is checked then the teleport flag is set to true in the Destination Set event so teleport scripts will know whether to action the new destination.")]
         public bool enableTeleport = true;
+        [Tooltip("A specified VRTK_PolicyList to use to determine whether destination targets will be considered valid or invalid.")]
+        public VRTK_PolicyList targetListPolicy;
 
         /// <summary>
         /// Emitted when a collision with another collider has first occurred.
@@ -64,7 +68,6 @@ namespace VRTK
         /// </summary>
         public event DestinationMarkerEventHandler DestinationMarkerSet;
 
-        protected VRTK_PolicyList invalidListPolicy;
         protected float navMeshCheckDistance;
         protected bool headsetPositionCompensation;
         protected bool forceHoverOnRepeatedEnter = true;
@@ -113,9 +116,10 @@ namespace VRTK
         /// The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets. It accepts a VRTK_PolicyList for a custom level of policy management.
         /// </summary>
         /// <param name="list">The Tag Or Script list policy to check the set operation on.</param>
+        [Obsolete("`DestinationMarkerEventArgs.SetInvalidTarget(list)` has been replaced with the public variable `DestinationMarkerEventArgs.targetListPolicy`. This method will be removed in a future version of VRTK.")]
         public virtual void SetInvalidTarget(VRTK_PolicyList list = null)
         {
-            invalidListPolicy = list;
+            targetListPolicy = list;
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -321,7 +321,7 @@ namespace VRTK
         {
             if (EnabledPointerRenderer())
             {
-                pointerRenderer.InitalizePointer(this, invalidListPolicy, navMeshCheckDistance, headsetPositionCompensation);
+                pointerRenderer.InitalizePointer(this, targetListPolicy, navMeshCheckDistance, headsetPositionCompensation);
                 pointerRenderer.UpdateRenderer();
                 if (!IsPointerActive())
                 {
@@ -422,7 +422,7 @@ namespace VRTK
         {
             if (EnabledPointerRenderer())
             {
-                pointerRenderer.InitalizePointer(this, invalidListPolicy, navMeshCheckDistance, headsetPositionCompensation);
+                pointerRenderer.InitalizePointer(this, targetListPolicy, navMeshCheckDistance, headsetPositionCompensation);
             }
         }
 

--- a/Assets/VRTK/Scripts/Utilities/VRTK_PolicyList.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_PolicyList.cs
@@ -80,7 +80,7 @@ namespace VRTK
         /// <returns>Returns true of the given game object matches the policy list or given string logic.</returns>
         public static bool Check(GameObject obj, VRTK_PolicyList list)
         {
-            if (list)
+            if (list != null)
             {
                 return list.Find(obj);
             }
@@ -89,9 +89,9 @@ namespace VRTK
 
         protected virtual bool ScriptCheck(GameObject obj, bool returnState)
         {
-            foreach (var identifier in identifiers)
+            for(int i = 0; i < identifiers.Count; i++)
             {
-                if (obj.GetComponent(identifier))
+                if (obj.GetComponent(identifiers[i]))
                 {
                     return returnState;
                 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1056,6 +1056,7 @@ It is utilised by the `VRTK_BasePointer` for dealing with pointer events when th
 ### Inspector Parameters
 
  * **Enable Teleport:** If this is checked then the teleport flag is set to true in the Destination Set event so teleport scripts will know whether to action the new destination.
+ * **Target List Policy:** A specified VRTK_PolicyList to use to determine whether destination targets will be considered valid or invalid.
 
 ### Class Events
 
@@ -1081,17 +1082,6 @@ Adding the `VRTK_DestinationMarker_UnityEvents` component to `VRTK_DestinationMa
  * `VRTK_ControllerReference controllerReference` - The optional reference to the controller controlling the destination marker.
 
 ### Class Methods
-
-#### SetInvalidTarget/1
-
-  > `public virtual void SetInvalidTarget(VRTK_PolicyList list = null)`
-
-  * Parameters
-   * `VRTK_PolicyList list` - The Tag Or Script list policy to check the set operation on.
-  * Returns
-   * _none_
-
-The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets. It accepts a VRTK_PolicyList for a custom level of policy management.
 
 #### SetNavMeshCheckDistance/1
 


### PR DESCRIPTION
The DestinationMarker script had a hidden policy list that the
teleporter would use to determine when to set a pointer to the valid
or invalid colour. However, it wasn't possible to just change the
pointer state based on simply what the pointer was looking at.

This change exposes the hidden policy list variable on the destination
marker and makes it a public parameter that can be updated in the
Unity inspector.

If the pointer has a policy list assigned then it won't get assigned
one by the teleporter, this is useful for overriding the teleport
policy list setting.