### PR TITLE
Fixes SteamVR compatibility with Unity 2017.1

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -24,7 +24,7 @@ namespace VRTK
         /// </summary>
         public override void InitBoundaries()
         {
-#if !UNITY_2017_1_OR_NEWER && UNITY_5_6_OR_NEWER
+#if UNITY_5_6
             Transform headsetCamera = VRTK_DeviceFinder.HeadsetCamera();
             if (headsetCamera != null && headsetCamera.GetComponent<SteamVR_UpdatePoses>() == null)
             {

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -24,7 +24,7 @@ namespace VRTK
         /// </summary>
         public override void InitBoundaries()
         {
-#if UNITY_5_6_OR_NEWER
+#if !UNITY_2017_1_OR_NEWER && UNITY_5_6_OR_NEWER
             Transform headsetCamera = VRTK_DeviceFinder.HeadsetCamera();
             if (headsetCamera != null && headsetCamera.GetComponent<SteamVR_UpdatePoses>() == null)
             {


### PR DESCRIPTION
Fixes issues with VRTK in Unity 2017.1 where SteamVR camera remains black.

Tested in latest beta 9