### PR TITLE
fix(UIPointerEvents_ListenerExample): Ensure pointers not toggled if active

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerUIPointerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerUIPointerEvents_ListenerExample.cs
@@ -30,7 +30,7 @@
         private void VRTK_ControllerUIPointerEvents_ListenerExample_UIPointerElementEnter(object sender, UIPointerEventArgs e)
         {
             VRTK_Logger.Info("UI Pointer entered " + e.currentTarget.name + " on Controller index [" + VRTK_ControllerReference.GetRealIndex(e.controllerReference) + "] and the state was " + e.isActive + " ### World Position: " + e.raycastResult.worldPosition);
-            if (togglePointerOnHit && GetComponent<VRTK_Pointer>())
+            if (togglePointerOnHit && GetComponent<VRTK_Pointer>() && !GetComponent<VRTK_Pointer>().IsPointerActive())
             {
                 GetComponent<VRTK_Pointer>().Toggle(true);
             }


### PR DESCRIPTION
Calling VRTK_Pointer.Toggle(true) when the pointer is already active seems to cause it to toggle false, then true under some situations causing the pointer to flicker on and off rapidly.