### PR TITLE
fix(SDK): SteamVR defines

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
@@ -38,7 +38,7 @@ namespace VRTK
                 return false;
             }
 
-            return systemMethodParameters[0].ParameterType == Type.GetType("Valve.VR.EVREventType");
+            return systemMethodParameters[0].ParameterType == VRTK_SharedMethods.GetTypeUnknownAssembly("Valve.VR.EVREventType");
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -180,6 +180,24 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetTypeUnknownAssembly method is used to find a Type without knowing the exact assembly it is in.
+        /// </summary>
+        /// <param name="typeName">The name of the type to get.</param>
+        /// <returns>The Type, or null if none is found.</returns>
+        public static Type GetTypeUnknownAssembly(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type != null) return type;
+            foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                type = a.GetType(typeName);
+                if (type != null)
+                    return type;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// The IsEditTime method determines if the state of Unity is in the Unity Editor and the scene is not in play mode.
         /// </summary>
         /// <returns>Returns true if Unity is in the Unity Editor and not in play mode.</returns>


### PR DESCRIPTION
Type.GetType requires the use of an assembly name. This fix adds an improved version.