### PR TITLE
fix(UIPointer): ensure toggle does not execute if on existing state

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -234,7 +234,7 @@ namespace VRTK
         /// <param name="state">If true the pointer will be enabled if possible, if false the pointer will be disabled if possible.</param>
         public virtual void Toggle(bool state)
         {
-            if (!CanActivate() || NoPointerRenderer() || CanActivateOnToggleButton(state))
+            if (!CanActivate() || NoPointerRenderer() || CanActivateOnToggleButton(state) || (state && IsPointerActive()) || (!state && !IsPointerActive()))
             {
                 return;
             }


### PR DESCRIPTION
The UIPointer `Toggle` method now exits early if the toggle state
that is passed to the method is already in that state.

e.g. If `Toggle(true)` is called but the pointer is already active
then the Toggle method will exit early.