### PR TITLE
fix(SteamVR): only add SteamVR_UpdatePoses for Unity 5.6

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -24,7 +24,7 @@ namespace VRTK
         /// </summary>
         public override void InitBoundaries()
         {
-#if UNITY_5_6_OR_NEWER
+#if UNITY_5_6
             Transform headsetCamera = VRTK_DeviceFinder.HeadsetCamera();
             if (headsetCamera != null && headsetCamera.GetComponent<SteamVR_UpdatePoses>() == null)
             {


### PR DESCRIPTION
The `SteamVR_UpdatePoses` script was added on Unity 5.6 and newer, but
it's no longer needed to do that in Unity 2017.1.