### PR TITLE
fix(Presence): reduce GetComponent calls in body physics update

### DIFF
--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -202,6 +202,8 @@ namespace VRTK
         protected bool enableBodyCollisionsStartingValue;
         protected float fallMinTime;
         protected List<GameObject> ignoreCollisionsOnGameObjects = new List<GameObject>();
+        protected Transform cachedGrabbedObjectTransform = null;
+        protected VRTK_InteractableObject cachedGrabbedObject;
 
         // Draws a sphere for current standing position and a sphere for current headset position.
         // Set to `true` to view the debug spheres.
@@ -1192,8 +1194,12 @@ namespace VRTK
 
         protected virtual bool FloorIsGrabbedObject(RaycastHit collidedObj)
         {
-            VRTK_InteractableObject obj = collidedObj.transform.GetComponent<VRTK_InteractableObject>();
-            return (obj != null && obj.IsGrabbed());
+            if (cachedGrabbedObjectTransform != collidedObj.transform)
+            {
+                cachedGrabbedObjectTransform = collidedObj.transform;
+                cachedGrabbedObject = collidedObj.transform.GetComponent<VRTK_InteractableObject>();
+            }
+            return (cachedGrabbedObject != null && cachedGrabbedObject.IsGrabbed());
         }
 
         protected virtual bool FloorHeightChanged(float currentY)


### PR DESCRIPTION
The BodyPhysics script was doing a `GetComponent` call every
`FixedUpdate` when checking to see if the snap to floor was valid
by checking to see if the object being held was underneath the
headset.

The fix attempts to cache the check the first time around to reduce
any further unnecessary calls to `GetComponent` if the held object
has not changed.