### PR TITLE
fix/feat: SDK Setup load/unload on scene changes

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/SceneChanger.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/SceneChanger.cs
@@ -15,7 +15,7 @@
             DynamicGI.UpdateEnvironment();
         }
 
-        private bool ForwardPressed()
+        private bool IsForwardPressed()
         {
             if (!VRTK_ControllerReference.IsValid(controllerReference))
             {
@@ -31,7 +31,7 @@
             return false;
         }
 
-        private bool BackPressed()
+        private bool IsBackPressed()
         {
             if (!VRTK_ControllerReference.IsValid(controllerReference))
             {
@@ -57,27 +57,29 @@
         {
             GameObject rightHand = VRTK_DeviceFinder.GetControllerRightHand(true);
             controllerReference = VRTK_ControllerReference.GetControllerReference(rightHand);
-            if (ForwardPressed() || Input.GetKeyUp(KeyCode.Space))
+
+            int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+            int nextSceneIndex = currentSceneIndex;
+
+            if (IsForwardPressed() || Input.GetKeyUp(KeyCode.Space))
             {
-                int nextSceneIndex = SceneManager.GetActiveScene().buildIndex + 1;
+                nextSceneIndex++;
                 if (nextSceneIndex >= SceneManager.sceneCountInBuildSettings)
-                {
                     nextSceneIndex = 0;
-                }
-                VRTK_SDKManager.instance.UnloadSDKSetup();
-                SceneManager.LoadScene(nextSceneIndex);
+            }
+            else if (IsBackPressed() || Input.GetKeyUp(KeyCode.Backspace))
+            {
+                nextSceneIndex--;
+                if (nextSceneIndex < 0)
+                    nextSceneIndex = SceneManager.sceneCountInBuildSettings - 1;
             }
 
-            if (BackPressed() || Input.GetKeyUp(KeyCode.Backspace))
+            if (nextSceneIndex == currentSceneIndex)
             {
-                int previousSceneIndex = SceneManager.GetActiveScene().buildIndex - 1;
-                if (previousSceneIndex < 0)
-                {
-                    previousSceneIndex = SceneManager.sceneCountInBuildSettings - 1;
-                }
-                VRTK_SDKManager.instance.UnloadSDKSetup();
-                SceneManager.LoadScene(previousSceneIndex);
+                return;
             }
+
+            SceneManager.LoadScene(nextSceneIndex);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -385,6 +385,43 @@ namespace VRTK
         }
 
         /// <summary>
+        /// Tries to load a valid <see cref="VRTK_SDKSetup"/> from <see cref="setups"/>.
+        /// </summary>
+        public void TryLoadSDKSetupFromList()
+        {
+            int index = 0;
+
+            if (VRSettings.enabled)
+            {
+                // Use the SDK Setup for the current VR Device if it's working already
+                // (may be due to command line argument '-vrmode')
+                index = Array.FindIndex(
+                    setups,
+                    setup => setup.usedVRDeviceNames.Contains(VRSettings.loadedDeviceName)
+                );
+            }
+            else
+            {
+                // If '-vrmode none' was used try to load the respective SDK Setup
+                string[] commandLineArgs = Environment.GetCommandLineArgs();
+                int commandLineArgIndex = Array.IndexOf(commandLineArgs, "-vrmode", 1);
+                if (VRSettings.loadedDeviceName == "None"
+                    || (commandLineArgIndex != -1
+                        && commandLineArgIndex + 1 < commandLineArgs.Length
+                        && commandLineArgs[commandLineArgIndex + 1].ToLowerInvariant() == "none"))
+                {
+                    index = Array.FindIndex(
+                        setups,
+                        setup => setup.usedVRDeviceNames.All(vrDeviceName => vrDeviceName == "None")
+                    );
+                }
+            }
+
+            index = index == -1 ? 0 : index;
+            TryLoadSDKSetup(index, false, setups.ToArray());
+        }
+
+        /// <summary>
         /// Tries to load a valid <see cref="VRTK_SDKSetup"/> from a list.
         /// </summary>
         /// <remarks>
@@ -492,7 +529,7 @@ namespace VRTK
         /// Unloads the currently loaded <see cref="VRTK_SDKSetup"/>, if there is one.
         /// </summary>
         /// <param name="disableVR">Whether to disable VR altogether after unloading the SDK Setup.</param>
-        public void UnloadSDKSetup(bool disableVR = true)
+        public void UnloadSDKSetup(bool disableVR = false)
         {
             if (loadedSetup != null)
             {
@@ -538,35 +575,7 @@ namespace VRTK
 
             if (autoLoadSetup)
             {
-                int index = 0;
-
-                if (VRSettings.enabled)
-                {
-                    // Use the SDK Setup for the current VR Device if it's working already
-                    // (may be due to command line argument '-vrmode')
-                    index = Array.FindIndex(
-                        setups,
-                        setup => setup.usedVRDeviceNames.Contains(VRSettings.loadedDeviceName)
-                    );
-                }
-                else
-                {
-                    // If '-vrmode none' was used try to load the respective SDK Setup
-                    string[] commandLineArgs = Environment.GetCommandLineArgs();
-                    int commandLineArgIndex = Array.IndexOf(commandLineArgs, "-vrmode", 1);
-                    if (commandLineArgIndex != -1
-                        && commandLineArgIndex + 1 < commandLineArgs.Length
-                        && commandLineArgs[commandLineArgIndex + 1].ToLowerInvariant() == "none")
-                    {
-                        index = Array.FindIndex(
-                            setups,
-                            setup => setup.usedVRDeviceNames.All(vrDeviceName => vrDeviceName == "None")
-                        );
-                    }
-                }
-
-                index = index == -1 ? 0 : index;
-                TryLoadSDKSetup(index, false, setups.ToArray());
+                TryLoadSDKSetupFromList();
             }
         }
 

--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetupSwitcher.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetupSwitcher.cs
@@ -133,7 +133,7 @@ namespace VRTK
                 chooseNoneButton.SetActive(true);
 
                 chooseNoneButton.GetComponent<Button>().onClick.AddListener(
-                    () => sdkManager.UnloadSDKSetup()
+                    () => sdkManager.UnloadSDKSetup(true)
                 );
 
                 chooseButtonGameObjects.Add(chooseNoneButton);


### PR DESCRIPTION
Whenever the scene changed it was recommended to unload the
currently loaded SDK Setup via the SDK Manager. This lead to issues
with coming up with the exact time to call the unload method,
especially when using `SteamVR_LoadLevel`. That SteamVR script even
lead to crashes.

This fix stops unloading the currently used VR Device everywhere.
The result is that **there is no need to call the unload method
manually anymore**.

The SceneChanger script was simplified a bit after being updated for
this fix.

---

The SDK Manager now tries to use the same SDK Setup that was used
previously (even when it was used in another scene).