### PR TITLE
fix(Locomotion): replace `timeSinceLevelLoad` to prevent stuck timer - fixes #1300

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SnapRotateObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SnapRotateObjectControlAction.cs
@@ -33,7 +33,7 @@ namespace VRTK
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
-            if (snapDelayTimer < Time.timeSinceLevelLoad && ValidThreshold(axis))
+            if (snapDelayTimer < Time.time && ValidThreshold(axis))
             {
                 float angle = Rotate(axis, modifierActive);
                 if (angle != 0f)
@@ -51,7 +51,7 @@ namespace VRTK
 
         protected virtual float Rotate(float axis, bool modifierActive)
         {
-            snapDelayTimer = Time.timeSinceLevelLoad + snapDelay;
+            snapDelayTimer = Time.time + snapDelay;
             int directionMultiplier = GetAxisDirection(axis);
             return (anglePerSnap * (modifierActive ? angleMultiplier : 1)) * directionMultiplier;
         }

--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_WarpObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_WarpObjectControlAction.cs
@@ -40,7 +40,7 @@ namespace VRTK
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
-            if (warpDelayTimer < Time.timeSinceLevelLoad && axis != 0f)
+            if (warpDelayTimer < Time.time && axis != 0f)
             {
                 Warp(controlledGameObject, directionDevice, axisDirection, axis, modifierActive);
             }
@@ -79,7 +79,7 @@ namespace VRTK
                 targetPosition.y = warpRaycastHit.point.y + (colliderHeight / 2f);
                 Vector3 finalPosition = targetPosition - objectPosition + controlledGameObject.transform.position;
 
-                warpDelayTimer = Time.timeSinceLevelLoad + warpDelay;
+                warpDelayTimer = Time.time + warpDelay;
                 if (CanMove(bodyPhysics, controlledGameObject.transform.position, finalPosition))
                 {
                     controlledGameObject.transform.position = finalPosition;


### PR DESCRIPTION
The SnapRotate and WarpObject control actions both used
`Time.timeSinceLevelLoad` to manage the action delay, however this
would cause an issue when switching scene as the time would no longer
be correct when calculating the delay.

The fix is simply to use `Time.time` to determine when the delay has
subsided.