### PR TITLE
fix(Utilities): prevent sdk change event unregistering on disable

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_FramesPerSecondViewer.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_FramesPerSecondViewer.cs
@@ -39,29 +39,24 @@ namespace VRTK
         protected float framesTime;
         protected Canvas canvas;
         protected Text text;
+        protected VRTK_SDKManager sdkManager;
 
         protected virtual void OnEnable()
         {
-            VRTK_SDKManager sdkManager = VRTK_SDKManager.instance;
+            sdkManager = VRTK_SDKManager.instance;
             if (sdkManager != null)
             {
                 sdkManager.LoadedSetupChanged += LoadedSetupChanged;
             }
+            InitCanvas();
+        }
 
-            canvas = transform.GetComponentInParent<Canvas>();
-            text = GetComponent<Text>();
-
-            if (canvas != null)
+        protected virtual void OnDisable()
+        {
+            if (sdkManager != null && !gameObject.activeSelf)
             {
-                canvas.planeDistance = 0.5f;
+                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
             }
-
-            if (text != null)
-            {
-                text.fontSize = fontSize;
-                text.transform.localPosition = position;
-            }
-            SetCanvasCamera();
         }
 
         protected virtual void Update()
@@ -93,6 +88,24 @@ namespace VRTK
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
+            SetCanvasCamera();
+        }
+
+        protected virtual void InitCanvas()
+        {
+            canvas = transform.GetComponentInParent<Canvas>();
+            text = GetComponent<Text>();
+
+            if (canvas != null)
+            {
+                canvas.planeDistance = 0.5f;
+            }
+
+            if (text != null)
+            {
+                text.fontSize = fontSize;
+                text.transform.localPosition = position;
+            }
             SetCanvasCamera();
         }
 

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKObjectAlias.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKObjectAlias.cs
@@ -36,7 +36,7 @@ namespace VRTK
 
         protected virtual void OnDisable()
         {
-            if (sdkManager != null)
+            if (sdkManager != null && !gameObject.activeSelf)
             {
                 sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
             }

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
@@ -53,7 +53,7 @@ namespace VRTK
 
         protected virtual void OnDisable()
         {
-            if (sdkManager != null)
+            if (sdkManager != null && !gameObject.activeSelf)
             {
                 sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
             }


### PR DESCRIPTION
A number of scripts that utilise the `LoadedSetupChanged` event on
the SDKManager were set up so that if they were on a GameObject that
was a child of the current SDK camera rig then when the SDK was
changed, the camera rig would become disabled and the script listening
to the setup change event would then also have the `OnDisable` method
called and unregister the listener. This would mean that the script
would no longer be listening for the switch in SDK and any
functionality required on SDK switch would no longer be available.

For instance, the SDK Object Alias script would not re-child the
relevant object because the SDK change would not be observed as the
listener had been unregistered.

This is fixed by checking in the `OnDisable` method of the script
to see if the actual GameObject the script is on is disabled and
to only unregister the event if it is, therefore ignoring any
parent GameObject enabled state.