### PR TITLE
fix(Utilities): new vive keyword for headset discovery in device finder

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -379,6 +379,7 @@ namespace VRTK
                     returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftCV1);
                     break;
                 case "Vive MV":
+                case "Vive MV.":
                     returnValue = (summary ? Headsets.Vive : Headsets.ViveMV);
                     break;
                 case "Vive DVT":


### PR DESCRIPTION
The DeviceFinder script has a method for determining which headset is
being used. However, there seemed to be an issue where newer HTC Vives
would report their name as `Vive MV.` with a dot at the end rather than
the standard `Vive MV` which was reported by the original HTC Vive
consumer edition.

This fix just checks both values and assumes the headset is `ViveMV`
to prevent users with newer Vive headsets receiving a warning.