### PR TITLE
fix(Locomotion): prevent current destination point being set to null - fixes #1307

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
@@ -152,7 +152,6 @@ namespace VRTK
             initaliseListeners = StartCoroutine(ManageDestinationMarkersAtEndOfFrame());
             ResetPoint();
             currentTeleportState = enableTeleport;
-            currentDestinationPoint = null;
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
             headset = VRTK_DeviceFinder.HeadsetTransform();
             destinationLocation = (destinationLocation != null ? destinationLocation : transform);
@@ -307,6 +306,11 @@ namespace VRTK
             {
                 ResetPoint();
             }
+            else if (currentDestinationPoint != null && e.raycastHit.transform != currentDestinationPoint.transform)
+            {
+                currentDestinationPoint = null;
+                ResetPoint();
+            }
         }
 
         protected virtual IEnumerator DoDestinationMarkerSetAtEndOfFrame(DestinationMarkerEventArgs e)
@@ -384,7 +388,11 @@ namespace VRTK
 
         protected virtual void ResetPoint()
         {
-            currentDestinationPoint = null;
+            if (snapToPoint && currentDestinationPoint == this)
+            {
+                return;
+            }
+
             ToggleObject(hoverCursorObject, false);
             if (enableTeleport)
             {


### PR DESCRIPTION
There was an issue with the DestinationPoint script where the
`currentDestinationPoint` which is a static variable was being reset
to null whenever the destination point was set or the pointer exited
the destination point area.

This was not apparent when the pointer activation button and selection
button was the same button because of the speed in which the events
would be triggered.

However, if the activation and selection buttons were different then
the `currentDestinationPoint` would be set to null and this would
reactivate the actual current destination point even though it should
be disabled.

The fix is to ensure the `currentDestinationPoint` is never set to
null and is used for a simple check when resetting the Destination
Point.