### PR TITLE
feat(Locomotion): rename force teleport to teleport and add new method

### DIFF
--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -10,8 +10,8 @@ namespace VRTK
     [SDK_Description(typeof(SDK_SimSystem))]
     public class SDK_SimController : SDK_BaseController
     {
-        protected SDK_ControllerSim rightController = new SDK_ControllerSim();
-        protected SDK_ControllerSim leftController = new SDK_ControllerSim();
+        protected SDK_ControllerSim rightController;
+        protected SDK_ControllerSim leftController;
         protected Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
         {
             {"Trigger", KeyCode.Mouse1 },
@@ -131,9 +131,9 @@ namespace VRTK
             switch (index)
             {
                 case 1:
-                    return (sdkManager != null && !actual ? sdkManager.scriptAliasRightController : rightController.gameObject);
+                    return (sdkManager != null && !actual ? sdkManager.scriptAliasRightController : (rightController != null ? rightController.gameObject : null));
                 case 2:
-                    return (sdkManager != null && !actual ? sdkManager.scriptAliasLeftController : leftController.gameObject);
+                    return (sdkManager != null && !actual ? sdkManager.scriptAliasLeftController : (leftController != null ? leftController.gameObject : null));
                 default:
                     return null;
             }
@@ -330,9 +330,9 @@ namespace VRTK
             switch (index)
             {
                 case 1:
-                    return rightController.GetVelocity();
+                    return (rightController != null ? rightController.GetVelocity() : Vector3.zero);
                 case 2:
-                    return leftController.GetVelocity();
+                    return (leftController != null ? leftController.GetVelocity() : Vector3.zero);
                 default:
                     return Vector3.zero;
             }
@@ -349,9 +349,9 @@ namespace VRTK
             switch (index)
             {
                 case 1:
-                    return rightController.GetAngularVelocity();
+                    return (rightController != null ? rightController.GetAngularVelocity() : Vector3.zero);
                 case 2:
-                    return leftController.GetAngularVelocity();
+                    return (leftController != null ? leftController.GetAngularVelocity() : Vector3.zero);
                 default:
                     return Vector3.zero;
             }
@@ -528,14 +528,14 @@ namespace VRTK
 
             if (index == 1)
             {
-                if (!rightController.Selected)
+                if (rightController != null && !rightController.Selected)
                 {
                     return false;
                 }
             }
             else if (index == 2)
             {
-                if (!leftController.Selected)
+                if (leftController != null && !leftController.Selected)
                 {
                     return false;
                 }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_DashTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_DashTeleport.cs
@@ -95,7 +95,10 @@ namespace VRTK
 
         protected override void ProcessOrientation(object sender, DestinationMarkerEventArgs e, Vector3 newPosition, Quaternion newRotation)
         {
-            StartCoroutine(lerpToPosition(sender, e, newPosition));
+            if (ValidRigObjects())
+            {
+                StartCoroutine(lerpToPosition(sender, e, newPosition));
+            }
         }
 
         protected override void EndTeleport(object sender, DestinationMarkerEventArgs e)

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -50,7 +50,7 @@ namespace VRTK
 
         protected virtual float GetTeleportY(Transform target, Vector3 tipPosition)
         {
-            if (!snapToNearestFloor)
+            if (!snapToNearestFloor || !ValidRigObjects())
             {
                 return tipPosition.y;
             }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1841,20 +1841,20 @@ The ToggleTeleportEnabled method is used to determine whether the teleporter wil
 
 The ValidLocation method determines if the given target is a location that can be teleported to
 
-#### ForceTeleport/1
+#### Teleport/1
 
-  > `public virtual void ForceTeleport(DestinationMarkerEventArgs teleportArgs)`
+  > `public virtual void Teleport(DestinationMarkerEventArgs teleportArgs)`
 
   * Parameters
    * `DestinationMarkerEventArgs teleportArgs` - The pseudo Destination Marker event for the teleport action.
   * Returns
    * _none_
 
-The ForceTeleport/1 method forces the teleport to update position without needing to listen for a Destination Marker event.
+The Teleport/1 method calls the teleport to update position without needing to listen for a Destination Marker event.
 
-#### ForceTeleport/4
+#### Teleport/4
 
-  > `public virtual void ForceTeleport(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null, bool forceDestinationPosition = false)`
+  > `public virtual void Teleport(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null, bool forceDestinationPosition = false)`
 
   * Parameters
    * `Transform target` - The Transform of the destination object.
@@ -1864,7 +1864,19 @@ The ForceTeleport/1 method forces the teleport to update position without needin
   * Returns
    * _none_
 
-The ForceTeleport/3 method forces the teleport to update position without needing to listen for a Destination Marker event. It will build a destination marker out of the provided parameters.
+The Teleport/4 method calls the teleport to update position without needing to listen for a Destination Marker event. It will build a destination marker out of the provided parameters.
+
+#### ForceTeleport/2
+
+  > `public virtual void ForceTeleport(Vector3 destinationPosition, Quaternion? destinationRotation = null)`
+
+  * Parameters
+   * `Vector3 destinationPosition` - The world position to teleport to.
+   * `Quaternion? destinationRotation` - The world rotation to teleport to.
+  * Returns
+   * _none_
+
+The ForceTeleport method forces the position to update to a given destination and ignores any target checking or floor adjustment.
 
 ### Example
 


### PR DESCRIPTION
The `ForceTeleport` method has now been renamed to `Teleport` and a
new `ForceTeleport` method has been added that simply takes a
position and a rotation and sets the player location to those given
parameters.