### PR TITLE
feat(Locomotion): allow finer customisation of nav mesh limits

### DIFF
--- a/Assets/VRTK/Editor/VRTK_EditorUtilities.cs
+++ b/Assets/VRTK/Editor/VRTK_EditorUtilities.cs
@@ -3,22 +3,23 @@
     using UnityEngine;
     using UnityEditor;
     using System;
+    using System.Reflection;
 
     public static class VRTK_EditorUtilities
     {
         public static GUIContent BuildGUIContent<T>(string fieldName, string displayOverride = null)
         {
-            var displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
-            var fieldInfo = typeof(T).GetField(fieldName);
-            var tooltipAttribute = (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
+            string displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
+            FieldInfo fieldInfo = typeof(T).GetField(fieldName);
+            TooltipAttribute tooltipAttribute = (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
             return (tooltipAttribute == null ? new GUIContent(displayName) : new GUIContent(displayName, tooltipAttribute.tooltip));
         }
 
         public static void AddHeader<T>(string fieldName, string displayOverride = null)
         {
-            var displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
-            var fieldInfo = typeof(T).GetField(fieldName);
-            var headerAttribute = (HeaderAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(HeaderAttribute));
+            string displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
+            FieldInfo fieldInfo = typeof(T).GetField(fieldName);
+            HeaderAttribute headerAttribute = (HeaderAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(HeaderAttribute));
             AddHeader(headerAttribute == null ? displayName : headerAttribute.header);
         }
 

--- a/Assets/VRTK/Editor/VRTK_NavMeshDataEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_NavMeshDataEditor.cs
@@ -1,0 +1,45 @@
+﻿namespace VRTK
+{
+    using UnityEditor;
+
+    [CustomEditor(typeof(VRTK_NavMeshData), true)]
+    public class VRTK_NavMeshDataEditor : Editor
+    {
+        public new VRTK_NavMeshData target { get { return base.target as VRTK_NavMeshData; } }
+
+        private SerializedProperty distanceLimit = null;
+        private bool _showLayers;
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.PropertyField(distanceLimit);
+
+            _showLayers = EditorGUILayout.Foldout(_showLayers, VRTK_EditorUtilities.BuildGUIContent<VRTK_NavMeshData>("validAreas"));
+
+            if (_showLayers)
+            {
+                EditorGUI.indentLevel++;
+                int currentAreas = target.validAreas;
+                string[] areas = GameObjectUtility.GetNavMeshAreaNames();
+                for (int i = 0; i < areas.Length; i++)
+                {
+                    var selected = (currentAreas & (1 << i)) != 0;
+                    if (EditorGUILayout.Toggle(areas[i], selected))
+                    {
+                        target.validAreas |= (1 << i);
+                    }
+                    else
+                    {
+                        target.validAreas &= ~(1 << i);
+                    }
+                }
+                EditorGUI.indentLevel--;
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            distanceLimit = serializedObject.FindProperty("distanceLimit");
+        }
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_NavMeshDataEditor.cs.meta
+++ b/Assets/VRTK/Editor/VRTK_NavMeshDataEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 110250a74b7d0674d9536c056e94a50b
+timeCreated: 1498248589
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Examples/033_CameraRig_TeleportingInNavMesh.unity
+++ b/Assets/VRTK/Examples/033_CameraRig_TeleportingInNavMesh.unity
@@ -334,6 +334,7 @@ GameObject:
   - component: {fileID: 284858738}
   - component: {fileID: 284858740}
   - component: {fileID: 284858739}
+  - component: {fileID: 284858741}
   m_Layer: 0
   m_Name: PlayArea
   m_TagString: Untagged
@@ -370,6 +371,7 @@ MonoBehaviour:
   distanceBlinkDelay: 0
   headsetPositionCompensation: 1
   targetListPolicy: {fileID: 0}
+  navMeshData: {fileID: 284858741}
   navMeshLimitDistance: 0.1
   snapToNearestFloor: 1
   customRaycast: {fileID: 0}
@@ -388,6 +390,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enableTeleport: 1
+  targetListPolicy: {fileID: 0}
   enableBodyCollisions: 0
   ignoreGrabbedCollisions: 1
   ignoreCollisionsWith: []
@@ -411,6 +414,19 @@ MonoBehaviour:
   teleporter: {fileID: 0}
   customBodyColliderContainer: {fileID: 0}
   customFootColliderContainer: {fileID: 0}
+--- !u!114 &284858741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 284858737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ab75fce112558341a4fd08a5daa0969, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  distanceLimit: 0.1
+  validAreas: -1
 --- !u!1 &454710426
 GameObject:
   m_ObjectHideFlags: 0
@@ -553,6 +569,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playareaCursor: {fileID: 0}
+  directionIndicator: {fileID: 0}
   customRaycast: {fileID: 0}
   layersToIgnore:
     serializedVersion: 2
@@ -647,6 +664,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enableTeleport: 1
+  targetListPolicy: {fileID: 0}
   pointerRenderer: {fileID: 807325090}
   activationButton: 10
   holdButtonToActivate: 1
@@ -661,7 +679,6 @@ MonoBehaviour:
   controller: {fileID: 0}
   interactUse: {fileID: 0}
   customOrigin: {fileID: 0}
-  directionIndicator: {fileID: 0}
 --- !u!1 &927287133
 GameObject:
   m_ObjectHideFlags: 0
@@ -692,6 +709,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playareaCursor: {fileID: 0}
+  directionIndicator: {fileID: 0}
   customRaycast: {fileID: 0}
   layersToIgnore:
     serializedVersion: 2
@@ -790,6 +808,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enableTeleport: 1
+  targetListPolicy: {fileID: 0}
   pointerRenderer: {fileID: 927287134}
   activationButton: 10
   holdButtonToActivate: 1
@@ -804,7 +823,6 @@ MonoBehaviour:
   controller: {fileID: 0}
   interactUse: {fileID: 0}
   customOrigin: {fileID: 0}
-  directionIndicator: {fileID: 0}
 --- !u!1 &1011430510
 GameObject:
   m_ObjectHideFlags: 0
@@ -881,32 +899,32 @@ Prefab:
         type: 2}
       propertyPath: actualBoundaries
       value: 
-      objectReference: {fileID: 1107519348}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: actualHeadset
       value: 
-      objectReference: {fileID: 1107519351}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: actualLeftController
       value: 
-      objectReference: {fileID: 1107519350}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: actualRightController
       value: 
-      objectReference: {fileID: 1107519349}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: modelAliasLeftController
       value: 
-      objectReference: {fileID: 1107519347}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: modelAliasRightController
       value: 
-      objectReference: {fileID: 1107519346}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 41c0760bd81dd084283814f0c432b466, type: 2}
   m_IsPrefabParent: 0
@@ -945,36 +963,6 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1107519339}
   m_Script: {fileID: 11500000, guid: eeda6d41317f444b900e374895f14e95, type: 3}
---- !u!1 &1107519346 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1846200688178366, guid: 41c0760bd81dd084283814f0c432b466,
-    type: 2}
-  m_PrefabInternal: {fileID: 1107519339}
---- !u!1 &1107519347 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1297872528131846, guid: 41c0760bd81dd084283814f0c432b466,
-    type: 2}
-  m_PrefabInternal: {fileID: 1107519339}
---- !u!1 &1107519348 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1000012704122952, guid: 41c0760bd81dd084283814f0c432b466,
-    type: 2}
-  m_PrefabInternal: {fileID: 1107519339}
---- !u!1 &1107519349 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1000012404417072, guid: 41c0760bd81dd084283814f0c432b466,
-    type: 2}
-  m_PrefabInternal: {fileID: 1107519339}
---- !u!1 &1107519350 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1000012074436610, guid: 41c0760bd81dd084283814f0c432b466,
-    type: 2}
-  m_PrefabInternal: {fileID: 1107519339}
---- !u!1 &1107519351 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1000013428897076, guid: 41c0760bd81dd084283814f0c432b466,
-    type: 2}
-  m_PrefabInternal: {fileID: 1107519339}
 --- !u!1 &1284134037
 GameObject:
   m_ObjectHideFlags: 0
@@ -1315,7 +1303,7 @@ Prefab:
     - target: {fileID: 224000012326194302, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012326194302, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1325,7 +1313,7 @@ Prefab:
     - target: {fileID: 224000012326194302, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1345,7 +1333,7 @@ Prefab:
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1355,7 +1343,7 @@ Prefab:
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1375,7 +1363,7 @@ Prefab:
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -30
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1385,7 +1373,7 @@ Prefab:
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1405,7 +1393,7 @@ Prefab:
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1415,7 +1403,7 @@ Prefab:
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1435,7 +1423,7 @@ Prefab:
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1445,7 +1433,7 @@ Prefab:
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1465,7 +1453,7 @@ Prefab:
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1475,7 +1463,7 @@ Prefab:
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1495,7 +1483,7 @@ Prefab:
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -30
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1505,7 +1493,7 @@ Prefab:
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1525,7 +1513,7 @@ Prefab:
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -55
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1535,7 +1523,7 @@ Prefab:
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1555,7 +1543,7 @@ Prefab:
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -25.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1565,7 +1553,7 @@ Prefab:
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 41
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1585,7 +1573,7 @@ Prefab:
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -82
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -1595,7 +1583,7 @@ Prefab:
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 66
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3, type: 2}

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -3,6 +3,7 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Collections;
+    using System;
 #if UNITY_5_5_OR_NEWER
     using UnityEngine.AI;
 #endif
@@ -39,7 +40,11 @@ namespace VRTK
         public bool headsetPositionCompensation = true;
         [Tooltip("A specified VRTK_PolicyList to use to determine whether destination targets will be acted upon by the Teleporter.")]
         public VRTK_PolicyList targetListPolicy;
-        [Tooltip("The max distance the teleport destination can be outside the nav mesh to be considered valid. If a value of `0` is given then the nav mesh restrictions will be ignored.")]
+        [Tooltip("An optional NavMeshData object that will be utilised for limiting the teleport to within any scene NavMesh.")]
+        public VRTK_NavMeshData navMeshData;
+
+        [HideInInspector]
+        [Obsolete("`VRTK_BasicTeleport.navMeshLimitDistance` is no longer used, use `VRTK_BasicTeleport.processNavMesh` instead. This parameter will be removed in a future version of VRTK.")]
         public float navMeshLimitDistance = 0f;
 
         /// <summary>
@@ -82,7 +87,7 @@ namespace VRTK
                         {
                             worldMarker.targetListPolicy = targetListPolicy;
                         }
-                        worldMarker.SetNavMeshCheckDistance(navMeshLimitDistance);
+                        worldMarker.SetNavMeshData(navMeshData);
                         worldMarker.SetHeadsetPositionCompensation(headsetPositionCompensation);
                     }
                     else
@@ -117,12 +122,15 @@ namespace VRTK
             }
 
             bool validNavMeshLocation = false;
-            if (target != null)
+            if (navMeshData != null)
             {
-                NavMeshHit hit;
-                validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, navMeshLimitDistance, NavMesh.AllAreas);
+                if (target != null)
+                {
+                    NavMeshHit hit;
+                    validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, navMeshData.distanceLimit, navMeshData.validAreas);
+                }
             }
-            if (navMeshLimitDistance == 0f)
+            else
             {
                 validNavMeshLocation = true;
             }

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -84,7 +84,7 @@ namespace VRTK
         protected Color currentColor;
 
         protected VRTK_PolicyList invalidListPolicy;
-        protected float navMeshCheckDistance;
+        protected VRTK_NavMeshData navMeshData;
         protected bool headsetPositionCompensation;
 
         protected GameObject objectInteractor;
@@ -113,11 +113,26 @@ namespace VRTK
         /// <param name="givenInvalidListPolicy">The VRTK_PolicyList for managing valid and invalid pointer locations.</param>
         /// <param name="givenNavMeshCheckDistance">The given distance from a nav mesh that the pointer can be to be valid.</param>
         /// <param name="givenHeadsetPositionCompensation">Determines whether the play area cursor will take the headset position within the play area into account when being displayed.</param>
+        [Obsolete("`VRTK_BasePointerRenderer.InitalizePointer(givenPointer, givenInvalidListPolicy, givenNavMeshCheckDistance, givenHeadsetPositionCompensation)` has been replaced with the method `VRTK_BasePointerRenderer.InitalizePointer(givenPointer, givenInvalidListPolicy, givenNavMeshData, givenHeadsetPositionCompensation)`. This method will be removed in a future version of VRTK.")]
         public virtual void InitalizePointer(VRTK_Pointer givenPointer, VRTK_PolicyList givenInvalidListPolicy, float givenNavMeshCheckDistance, bool givenHeadsetPositionCompensation)
+        {
+            VRTK_NavMeshData givenData = gameObject.AddComponent<VRTK_NavMeshData>();
+            givenData.distanceLimit = givenNavMeshCheckDistance;
+            InitalizePointer(givenPointer, givenInvalidListPolicy, givenData, givenHeadsetPositionCompensation);
+        }
+
+        /// <summary>
+        /// The InitalizePointer method is used to set up the state of the pointer renderer.
+        /// </summary>
+        /// <param name="givenPointer">The VRTK_Pointer that is controlling the pointer renderer.</param>
+        /// <param name="givenInvalidListPolicy">The VRTK_PolicyList for managing valid and invalid pointer locations.</param>
+        /// <param name="givenNavMeshData">The NavMeshData object that contains the Nav Mesh restriction options.</param>
+        /// <param name="givenHeadsetPositionCompensation">Determines whether the play area cursor will take the headset position within the play area into account when being displayed.</param>
+        public virtual void InitalizePointer(VRTK_Pointer givenPointer, VRTK_PolicyList givenInvalidListPolicy, VRTK_NavMeshData givenNavMeshData, bool givenHeadsetPositionCompensation)
         {
             controllingPointer = givenPointer;
             invalidListPolicy = givenInvalidListPolicy;
-            navMeshCheckDistance = givenNavMeshCheckDistance;
+            navMeshData = givenNavMeshData;
             headsetPositionCompensation = givenHeadsetPositionCompensation;
 
             if (controllingPointer != null && controllingPointer.interactWithObjects && controllingPointer.controller != null && objectInteractor == null)
@@ -358,12 +373,15 @@ namespace VRTK
         protected virtual bool ValidDestination()
         {
             bool validNavMeshLocation = false;
-            if (destinationHit.transform != null)
+            if (navMeshData != null)
             {
-                NavMeshHit hit;
-                validNavMeshLocation = NavMesh.SamplePosition(destinationHit.point, out hit, navMeshCheckDistance, NavMesh.AllAreas);
+                if (destinationHit.transform != null)
+                {
+                    NavMeshHit hit;
+                    validNavMeshLocation = NavMesh.SamplePosition(destinationHit.point, out hit, navMeshData.distanceLimit, navMeshData.validAreas);
+                }
             }
-            if (navMeshCheckDistance == 0f)
+            else
             {
                 validNavMeshLocation = true;
             }

--- a/Assets/VRTK/Scripts/Pointers/VRTK_DestinationMarker.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_DestinationMarker.cs
@@ -68,7 +68,10 @@ namespace VRTK
         /// </summary>
         public event DestinationMarkerEventHandler DestinationMarkerSet;
 
-        protected float navMeshCheckDistance;
+        [Obsolete("`VRTK_DestinationMarker.navMeshCheckDistance` is no longer used. This parameter will be removed in a future version of VRTK.")]
+        protected float navMeshCheckDistance = 0f;
+
+        protected VRTK_NavMeshData navmeshData;
         protected bool headsetPositionCompensation;
         protected bool forceHoverOnRepeatedEnter = true;
         protected Collider existingCollider;
@@ -126,9 +129,21 @@ namespace VRTK
         /// The SetNavMeshCheckDistance method sets the max distance the destination marker position can be from the edge of a nav mesh to be considered a valid destination.
         /// </summary>
         /// <param name="distance">The max distance the nav mesh can be from the sample point to be valid.</param>
+        [Obsolete("`DestinationMarker.SetNavMeshCheckDistance(distance)` has been replaced with the method `DestinationMarker.SetNavMeshCheckDistance(givenData)`. This method will be removed in a future version of VRTK.")]
         public virtual void SetNavMeshCheckDistance(float distance)
         {
-            navMeshCheckDistance = distance;
+            VRTK_NavMeshData givenData = gameObject.AddComponent<VRTK_NavMeshData>();
+            givenData.distanceLimit = distance;
+            SetNavMeshData(givenData);
+        }
+
+        /// <summary>
+        /// The SetNavMeshData method is used to limit the destination marker to the scene NavMesh based on the settings in the given NavMeshData object.
+        /// </summary>
+        /// <param name="givenData">The NavMeshData object that contains the NavMesh restriction settings.</param>
+        public virtual void SetNavMeshData(VRTK_NavMeshData givenData)
+        {
+            navmeshData = givenData;
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -351,7 +351,7 @@ namespace VRTK
         {
             if (EnabledPointerRenderer())
             {
-                pointerRenderer.InitalizePointer(this, targetListPolicy, navMeshCheckDistance, headsetPositionCompensation);
+                pointerRenderer.InitalizePointer(this, targetListPolicy, navmeshData, headsetPositionCompensation);
                 pointerRenderer.UpdateRenderer();
                 if (!IsPointerActive())
                 {
@@ -434,7 +434,7 @@ namespace VRTK
         {
             if (EnabledPointerRenderer())
             {
-                pointerRenderer.InitalizePointer(this, targetListPolicy, navMeshCheckDistance, headsetPositionCompensation);
+                pointerRenderer.InitalizePointer(this, targetListPolicy, navmeshData, headsetPositionCompensation);
             }
         }
 

--- a/Assets/VRTK/Scripts/Utilities/VRTK_NavMeshData.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_NavMeshData.cs
@@ -1,0 +1,12 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public class VRTK_NavMeshData : MonoBehaviour
+    {
+        [Tooltip("The max distance given point can be outside the nav mesh to be considered valid.")]
+        public float distanceLimit = 0.1f;
+        [Tooltip("The parts of the navmesh that are considered valid")]
+        public int validAreas = -1;
+    }
+}

--- a/Assets/VRTK/Scripts/Utilities/VRTK_NavMeshData.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_NavMeshData.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6ab75fce112558341a4fd08a5daa0969
+timeCreated: 1498248396
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1099,16 +1099,16 @@ Adding the `VRTK_DestinationMarker_UnityEvents` component to `VRTK_DestinationMa
 
 ### Class Methods
 
-#### SetNavMeshCheckDistance/1
+#### SetNavMeshData/1
 
-  > `public virtual void SetNavMeshCheckDistance(float distance)`
+  > `public virtual void SetNavMeshData(VRTK_NavMeshData givenData)`
 
   * Parameters
-   * `float distance` - The max distance the nav mesh can be from the sample point to be valid.
+   * `VRTK_NavMeshData givenData` - The NavMeshData object that contains the NavMesh restriction settings.
   * Returns
    * _none_
 
-The SetNavMeshCheckDistance method sets the max distance the destination marker position can be from the edge of a nav mesh to be considered a valid destination.
+The SetNavMeshData method is used to limit the destination marker to the scene NavMesh based on the settings in the given NavMeshData object.
 
 #### SetHeadsetPositionCompensation/1
 
@@ -1502,12 +1502,12 @@ The GetPointerObjects returns an array of the auto generated GameObjects associa
 
 #### InitalizePointer/4
 
-  > `public virtual void InitalizePointer(VRTK_Pointer givenPointer, VRTK_PolicyList givenInvalidListPolicy, float givenNavMeshCheckDistance, bool givenHeadsetPositionCompensation)`
+  > `public virtual void InitalizePointer(VRTK_Pointer givenPointer, VRTK_PolicyList givenInvalidListPolicy, VRTK_NavMeshData givenNavMeshData, bool givenHeadsetPositionCompensation)`
 
   * Parameters
    * `VRTK_Pointer givenPointer` - The VRTK_Pointer that is controlling the pointer renderer.
    * `VRTK_PolicyList givenInvalidListPolicy` - The VRTK_PolicyList for managing valid and invalid pointer locations.
-   * `float givenNavMeshCheckDistance` - The given distance from a nav mesh that the pointer can be to be valid.
+   * `VRTK_NavMeshData givenNavMeshData` - The NavMeshData object that contains the Nav Mesh restriction options.
    * `bool givenHeadsetPositionCompensation` - Determines whether the play area cursor will take the headset position within the play area into account when being displayed.
   * Returns
    * _none_
@@ -1780,7 +1780,7 @@ The y position is never altered so the basic teleporter cannot be used to move u
  * **Distance Blink Delay:** A range between 0 and 32 that determines how long the blink transition will stay blacked out depending on the distance being teleported. A value of 0 will not delay the teleport blink effect over any distance, a value of 32 will delay the teleport blink fade in even when the distance teleported is very close to the original position. This can be used to simulate time taking longer to pass the further a user teleports. A value of 16 provides a decent basis to simulate this to the user.
  * **Headset Position Compensation:** If this is checked then the teleported location will be the position of the headset within the play area. If it is unchecked then the teleported location will always be the centre of the play area even if the headset position is not in the centre of the play area.
  * **Target List Policy:** A specified VRTK_PolicyList to use to determine whether destination targets will be acted upon by the Teleporter.
- * **Nav Mesh Limit Distance:** The max distance the teleport destination can be outside the nav mesh to be considered valid. If a value of `0` is given then the nav mesh restrictions will be ignored.
+ * **Nav Mesh Data:** An optional NavMeshData object that will be utilised for limiting the teleport to within any scene NavMesh.
 
 ### Class Events
 


### PR DESCRIPTION
The Teleporter scripts now can take a new NavMeshData object which
provides a finer level of customisation over nav mesh limits when
teleporting.

This new NavMeshData object supersedes the previous
`navMeshDistanceLimit` setting which has now been deprecated.

The NavMeshData object contains the ability to set the nav mesh
distance limit but also to allow picking valid Nav Mesh Layers
when determining a valid location.