### PR TITLE
feat(DesktopCamera): render desktop-only camera while in VR

### DIFF
--- a/Assets/VRTK/Prefabs/DesktopCamera.prefab
+++ b/Assets/VRTK/Prefabs/DesktopCamera.prefab
@@ -1,0 +1,404 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1042811817518116}
+  m_IsPrefabParent: 1
+--- !u!1 &1042811817518116
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4934652213904522}
+  - component: {fileID: 114633414738637088}
+  - component: {fileID: 114999985697777428}
+  m_Layer: 0
+  m_Name: DesktopCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1191981426926616
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224730995454723592}
+  - component: {fileID: 222022361979082978}
+  - component: {fileID: 114875260969753814}
+  - component: {fileID: 114804801066480696}
+  m_Layer: 0
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1339917933382392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4233084601455098}
+  - component: {fileID: 20925059199990588}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1740920664178068
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224448664911673038}
+  - component: {fileID: 223647970445981788}
+  - component: {fileID: 114438113607979530}
+  - component: {fileID: 114812799459679886}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1833957408490314
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224596492490445500}
+  - component: {fileID: 222925746554489996}
+  - component: {fileID: 114045748572757610}
+  m_Layer: 0
+  m_Name: RawImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4233084601455098
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1339917933382392}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4934652213904522}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4934652213904522
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1042811817518116}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4233084601455098}
+  - {fileID: 224448664911673038}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &20925059199990588
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1339917933382392}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.05
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 0
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!114 &114045748572757610
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1833957408490314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 10305, guid: 0000000000000000f000000000000000, type: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!114 &114438113607979530
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1740920664178068}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &114633414738637088
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1042811817518116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80051f0bcd2e4f6c99dcca21d8991fe4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  desktopCamera: {fileID: 0}
+  followScript: {fileID: 0}
+  headsetImage: {fileID: 114045748572757610}
+  headsetRenderTexture: {fileID: 0}
+--- !u!114 &114804801066480696
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1191981426926616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 5
+    m_Right: 5
+    m_Top: 5
+    m_Bottom: 5
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+--- !u!114 &114812799459679886
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1740920664178068}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 10
+    m_Bottom: 10
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+--- !u!114 &114875260969753814
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1191981426926616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114999985697777428
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1042811817518116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe5040c2eaa9ff147b80ded004191c67, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameObjectToFollow: {fileID: 0}
+  gameObjectToChange: {fileID: 0}
+  followsPosition: 1
+  smoothsPosition: 1
+  maxAllowedPerFrameDistanceDifference: 0.003
+  followsRotation: 1
+  smoothsRotation: 1
+  maxAllowedPerFrameAngleDifference: 1.5
+  followsScale: 0
+  smoothsScale: 0
+  maxAllowedPerFrameSizeDifference: 0.003
+  _moment: 2
+--- !u!222 &222022361979082978
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1191981426926616}
+--- !u!222 &222925746554489996
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1833957408490314}
+--- !u!223 &223647970445981788
+Canvas:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1740920664178068}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &224448664911673038
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1740920664178068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 224730995454723592}
+  m_Father: {fileID: 4934652213904522}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!224 &224596492490445500
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1833957408490314}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224730995454723592}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 170}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224730995454723592
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1191981426926616}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224596492490445500}
+  m_Father: {fileID: 224448664911673038}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/VRTK/Prefabs/DesktopCamera.prefab.meta
+++ b/Assets/VRTK/Prefabs/DesktopCamera.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cff3fcd971e904049aab5e4ec16486cf
+timeCreated: 1498292593
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DesktopCamera.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DesktopCamera.cs
@@ -1,0 +1,154 @@
+﻿// Desktop Camera|Prefabs|0015
+namespace VRTK
+{
+    using UnityEngine;
+    using UnityEngine.UI;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Allows rendering a separate camera that is shown on the desktop only, without changing what's seen in VR headsets.
+    /// </summary>
+    /// <remarks>
+    /// To use the prefab, it simply needs to be placed into the scene.
+    /// </remarks>
+    [AddComponentMenu("VRTK/Scripts/Prefabs/VRTK_DesktopCamera")]
+    public class VRTK_DesktopCamera : MonoBehaviour
+    {
+        [Header("Desktop Camera")]
+
+        [Tooltip("The camera to use for the desktop view. If left blank the camera on the game object this script is attached to or any of its children will be used.")]
+        public Camera desktopCamera;
+        [Tooltip("The follow script to use for following the headset. If left blank the follow script on the game object this script is attached to or any of its children will be used.")]
+        public VRTK_ObjectFollow followScript;
+
+        [Header("Headset Image")]
+
+        [Tooltip("The optional image to render the headset's view into. Can be left blank.")]
+        public RawImage headsetImage;
+        [Tooltip("The optional render texture to render the headset's view into. Can be left blank. If this is blank and `headsetImage` is set a default render texture will be created.")]
+        public RenderTexture headsetRenderTexture;
+
+        protected Camera headsetCameraCopy;
+        protected VRTK_TransformFollow headsetCameraTransformFollow;
+        protected VRTK_SDKManager sdkManager;
+
+        protected virtual void OnEnable()
+        {
+            desktopCamera = desktopCamera == null ? GetComponentInChildren<Camera>() : desktopCamera;
+            followScript = followScript == null ? GetComponentInChildren<VRTK_ObjectFollow>() : followScript;
+
+            if (desktopCamera == null)
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, "VRTK_DesktopCamera", "Camera", "desktopCamera", "the same", " or any child of it"));
+                return;
+            }
+
+            if (followScript == null)
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, "VRTK_DesktopCamera", "VRTK_ObjectFollow", "followScript", "the same", " or any child of it"));
+                return;
+            }
+
+            headsetCameraTransformFollow = gameObject.AddComponent<VRTK_TransformFollow>();
+            headsetCameraTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnLateUpdate;
+
+            sdkManager = VRTK_SDKManager.instance;
+            if (sdkManager != null)
+            {
+                sdkManager.LoadedSetupChanged += LoadedSetupChanged;
+                if (sdkManager.loadedSetup != null)
+                {
+                    ConfigureForCurrentSDKSetup();
+                }
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (sdkManager != null)
+            {
+                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
+            }
+
+            Destroy(headsetCameraTransformFollow);
+            if (headsetCameraCopy != null)
+            {
+                Destroy(headsetCameraCopy.gameObject);
+            }
+        }
+
+        protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
+        {
+            ConfigureForCurrentSDKSetup();
+        }
+
+        protected virtual void ConfigureForCurrentSDKSetup()
+        {
+            if (headsetCameraCopy != null)
+            {
+                Destroy(headsetCameraCopy.gameObject);
+            }
+
+            headsetCameraTransformFollow.enabled = false;
+            followScript.enabled = false;
+
+            if (sdkManager.loadedSetup == null)
+            {
+                return;
+            }
+
+            Camera headsetCamera = VRTK_DeviceFinder.HeadsetCamera().GetComponent<Camera>();
+
+            desktopCamera.depth = headsetCamera.depth + 1;
+            desktopCamera.stereoTargetEye = StereoTargetEyeMask.None;
+
+            followScript.gameObjectToFollow = headsetCamera.gameObject;
+            followScript.gameObjectToChange = desktopCamera.gameObject;
+            followScript.Follow();
+            followScript.enabled = true;
+
+            if (headsetImage == null)
+            {
+                return;
+            }
+
+            if (headsetRenderTexture == null)
+            {
+                headsetRenderTexture = new RenderTexture(
+                    (int)headsetImage.rectTransform.rect.width,
+                    (int)headsetImage.rectTransform.rect.height,
+                    24,
+                    RenderTextureFormat.ARGB32)
+                {
+                    name = VRTK_SharedMethods.GenerateVRTKObjectName(true, "Headset RenderTexture")
+                };
+            }
+
+            headsetCameraCopy = Instantiate(headsetCamera, transform);
+            headsetCameraCopy.name = VRTK_SharedMethods.GenerateVRTKObjectName(true, "Headset Camera Copy");
+            headsetCameraCopy.targetTexture = headsetRenderTexture;
+
+            foreach (Transform child in headsetCameraCopy.transform)
+            {
+                Destroy(child.gameObject);
+            }
+
+            IEnumerable<Component> componentsToDestroy = headsetCameraCopy
+                .GetComponents<Component>()
+                .Where(component => component != headsetCameraCopy && !(component is Transform));
+            foreach (Component component in componentsToDestroy)
+            {
+                Destroy(component);
+            }
+
+            headsetCameraTransformFollow.gameObjectToFollow = headsetCamera.gameObject;
+            headsetCameraTransformFollow.gameObjectToChange = headsetCameraCopy.gameObject;
+            headsetCameraTransformFollow.Follow();
+            headsetCameraTransformFollow.enabled = true;
+
+            headsetImage.texture = headsetRenderTexture;
+            headsetImage.SetNativeSize();
+        }
+    }
+}

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DesktopCamera.cs.meta
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DesktopCamera.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 80051f0bcd2e4f6c99dcca21d8991fe4
+timeCreated: 1498225674


### PR DESCRIPTION
There's a need to show something different on the desktop window
than what's shown in the VR headset. The potential use cases range
from offering nicer spectator views to showing completely different
views for asymmetrical games.
In combination with VRTK's existing ObjectFollow scripts this allows
for trailer recordings in which the VR headset's movement is
smoothed.

Having a separated desktop-only camera allows for:
- additional overlays or effects
- render other layers in addition/only
- changing the FOV
- ...

This change adds the new `VRTK_DesktopCamera` script and a
corresponding prefab that shows how to use the optional support for
rendering the headset's view in addition to the desktop-only view.