### PR TITLE
fix(SDKManager): deprecate persist on load setting - fixes #1316

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -152,7 +152,8 @@ namespace VRTK
         }
         private static VRTK_SDKManager _instance;
 
-        [Tooltip("If this is true then the instance of the SDK Manager won't be destroyed on every scene load.")]
+        [Tooltip("**OBSOLETE. STOP USING THIS ASAP!** If this is true then the instance of the SDK Manager won't be destroyed on every scene load.")]
+        [Obsolete("`VRTK_SDKManager.persistOnLoad` has been deprecated and will be removed in a future version of VRTK. See https://github.com/thestonefox/VRTK/issues/1316 for details.")]
         public bool persistOnLoad;
 
         [Tooltip("Determines whether the scripting define symbols required by the installed SDKs are automatically added to and removed from the player settings.")]
@@ -610,7 +611,9 @@ namespace VRTK
 
         private void OnDisable()
         {
+#pragma warning disable 618
             if (_instance == this && !persistOnLoad)
+#pragma warning restore 618
             {
                 UnloadSDKSetup();
             }
@@ -623,7 +626,9 @@ namespace VRTK
                 _instance = this;
                 VRTK_SDK_Bridge.InvalidateCaches();
 
+#pragma warning disable 618
                 if (persistOnLoad && Application.isPlaying)
+#pragma warning restore 618
                 {
                     DontDestroyOnLoad(gameObject);
                 }

--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -397,7 +397,12 @@ namespace VRTK
 
         private void OnEnable()
         {
-            PopulateObjectReferences(false);
+#pragma warning disable 618
+            if (!VRTK_SDKManager.instance.persistOnLoad)
+#pragma warning restore 618
+            {
+                PopulateObjectReferences(false);
+            }
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
When using the persist on load setting on the SDK Manager it is
moved to the `DontDestroyOnLoad` scene at runtime by Unity. That
scene is inaccessible which means there's no way to find objects in
that scene. Because of the issues related to looking up objects in
the inaccessible scene the persist on load setting on the SDK
Manager is now deprecated.

It's recommended to use additive scene loading instead. To reduce
the likelihood of these issues breaking the project for users
already using the setting this fix also makes sure to only populate
the SDK Setup object references when this setting is *not* checked.