### PR TITLE
fix(SDKSetupSwitcher): recognize SDKSetup camera

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetupSwitcher.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetupSwitcher.cs
@@ -112,7 +112,7 @@ namespace VRTK
                     return;
             }
 
-            fallbackCamera.gameObject.SetActive(Camera.main == null || Camera.main == fallbackCamera);
+            fallbackCamera.gameObject.SetActive(VRTK_DeviceFinder.HeadsetCamera() == null);
             eventSystem.gameObject.SetActive(EventSystem.current == null || EventSystem.current == eventSystem);
         }
 


### PR DESCRIPTION
The SDK Setup Switcher sometimes didn't recognize the current camera
of the loaded SDK Setup. The fix is to actually ask the SDK Setup
for the camera (via the Device Finder) instead of relying on
`Camera.main` being set.