### PR TITLE
fix(ControllerTooptips): enable tips if no HeadsetAware script is found

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -401,7 +401,7 @@ namespace VRTK
                 return;
             }
 
-            if (!hideWhenNotInView)
+            if (headsetControllerAware == null || !hideWhenNotInView)
             {
                 ToggleTips(true);
             }


### PR DESCRIPTION
There was an issue if the `hideWhenNotInView` option was active but
no `headsetControllerAware` script was set then the tooltips could
never become active.

This fix just checks to see if `headsetControllerAware` is set and if
it's not then it always activates the tooltips.