### PR TITLE
fix(SDKManager): handle null Behaviour

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -706,14 +706,23 @@ namespace VRTK
 
         private void ToggleBehaviours(bool state)
         {
-            IEnumerable<Behaviour> listCopy = _behavioursToToggleOnLoadedSetupChange.ToList();
+            List<Behaviour> listCopy = _behavioursToToggleOnLoadedSetupChange.ToList();
             if (!state)
             {
-                listCopy = listCopy.Reverse();
+                listCopy.Reverse();
             }
 
-            foreach (Behaviour behaviour in listCopy)
+            for (int index = 0; index < listCopy.Count; index++)
             {
+                Behaviour behaviour = listCopy[index];
+                if (behaviour == null)
+                {
+                    VRTK_Logger.Error(string.Format("A behaviour to toggle has been destroyed. Have you forgot the corresponding call `VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this)` in the `OnDestroy` method of `{0}`?", behaviour.GetType()));
+                    _behavioursToToggleOnLoadedSetupChange.RemoveAt(state ? index : _behavioursToToggleOnLoadedSetupChange.Count - 1 - index);
+
+                    continue;
+                }
+
                 behaviour.enabled = (state && _behavioursInitialState.ContainsKey(behaviour) ? _behavioursInitialState[behaviour] : state);
             }
         }


### PR DESCRIPTION
The SDK Manager offers to remember any Behaviour to automatically
toggle it off and on based on whether an SDK Setup is loaded to
remove the need to listen to the SDK Setup Loaded event manually.
When users forget to call the remove method the SDK Manager will
throw a null reference exception which doesn't offer the user enough
info.

This fix handles that case and logs an error in addition to removing
the bad Behaviours.

---

Thanks for @trumpetx for the idea and example implementation.