### PR TITLE
fix(Presence): calculate collider height based on global positions - fixes #1325

### DIFF
--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -1095,7 +1095,7 @@ namespace VRTK
         {
             if (bodyCollider != null && headset != null)
             {
-                float newpresenceColliderYSize = (headset ? headset.transform.localPosition.y - (headsetYOffset + CalculateStepUpYOffset()) : 0f);
+                float newpresenceColliderYSize = (headset.position.y - playArea.position.y) - (headsetYOffset + CalculateStepUpYOffset());
                 float newpresenceColliderYCenter = Mathf.Max((newpresenceColliderYSize * 0.5f) + CalculateStepUpYOffset() + playAreaHeightAdjustment, bodyCollider.radius + playAreaHeightAdjustment);
 
                 bodyCollider.height = Mathf.Max(newpresenceColliderYSize, bodyCollider.radius);


### PR DESCRIPTION
There was an issue with the Body Physics body collider being sized
incorrectly in the simulator because the calculation was relying
on local positions and the simulator has a more complex set up
with the new neck object.

This fix uses global positions and is more generic to provide a
better future proof solution.

Thanks to @virror for the fix.