### PR TITLE
fix(SDK): support SteamVR plugin 1.2.2

### DIFF
--- a/Assets/VRTK/SDK/Oculus/SDK_OculusDefines.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusDefines.cs
@@ -57,26 +57,7 @@ namespace VRTK
                 return null;
             }
 
-            var version = (Version)versionField.GetValue(null);
-            return version;
-        }
-
-        private static Version GetOculusRuntimeVersion()
-        {
-            Type pluginClass = VRTK_SharedMethods.GetTypeUnknownAssembly("OVRPlugin");
-            if (pluginClass == null)
-            {
-                return null;
-            }
-
-            PropertyInfo versionProperty = pluginClass.GetProperty("version", BindingFlags.Public | BindingFlags.Static);
-            if (versionProperty == null)
-            {
-                return null;
-            }
-
-            var version = (Version)versionProperty.GetGetMethod().Invoke(null, null);
-            return version;
+            return (Version)versionField.GetValue(null);
         }
     }
 }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -24,7 +24,7 @@ namespace VRTK
         /// </summary>
         public override void InitBoundaries()
         {
-#if UNITY_5_6
+#if UNITY_5_6 && !VRTK_DEFINE_STEAMVR_PLUGIN_1_2_2_OR_NEWER
             Transform headsetCamera = VRTK_DeviceFinder.HeadsetCamera();
             if (headsetCamera != null && headsetCamera.GetComponent<SteamVR_UpdatePoses>() == null)
             {
@@ -135,6 +135,9 @@ namespace VRTK
 
         protected virtual Vector3[] ProcessVertices(Vector3[] vertices)
         {
+#if VRTK_DEFINE_STEAMVR_PLUGIN_1_2_2_OR_NEWER
+            return vertices;
+#else
             //If there aren't enough vertices or the play area is calibrated then just return
             if (vertices.Length < 8 || IsPlayAreaSizeCalibrated())
             {
@@ -149,6 +152,7 @@ namespace VRTK
                 modifiedVertices[i] = vertices[verticeIndexes[i]];
             }
             return modifiedVertices;
+#endif
         }
 #endif
     }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -3,10 +3,12 @@ namespace VRTK
 {
 #if VRTK_DEFINE_SDK_STEAMVR
     using UnityEngine;
-    using System;
     using System.Collections.Generic;
-    using System.Reflection;
     using Valve.VR;
+#if !VRTK_DEFINE_STEAMVR_PLUGIN_1_2_2_OR_NEWER
+    using System;
+    using System.Reflection;
+#endif
 #endif
 
     /// <summary>
@@ -27,6 +29,7 @@ namespace VRTK
         protected Dictionary<uint, SteamVR_TrackedObject> cachedTrackedObjectsByIndex = new Dictionary<uint, SteamVR_TrackedObject>();
         protected ushort maxHapticVibration = 3999;
 
+#if !VRTK_DEFINE_STEAMVR_PLUGIN_1_2_2_OR_NEWER
         /// <summary>
         /// This method is called just after unloading the <see cref="VRTK_SDKSetup"/> that's using this SDK.
         /// </summary>
@@ -49,6 +52,7 @@ namespace VRTK
             Array.Clear(connected, 0, connected.Length);
             connectedField.SetValue(controllerManager, connected);
         }
+#endif
 
         /// <summary>
         /// The ProcessUpdate method enables an SDK to run logic for every Unity Update

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
@@ -17,67 +17,58 @@ namespace VRTK
         private const string BuildTargetGroupName = "Standalone";
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_2_OR_NEWER", BuildTargetGroupName)]
+        private static bool IsPluginVersion122OrNewer()
+        {
+            Version version = GetVersion();
+            return version != null && version >= new Version(1, 2, 2);
+        }
+
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_1_OR_NEWER", BuildTargetGroupName)]
         private static bool IsPluginVersion121OrNewer()
         {
-            Type eventClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Events");
-            if (eventClass == null)
-            {
-                return false;
-            }
-
-            MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
-            if (systemMethod == null)
-            {
-                return false;
-            }
-
-            ParameterInfo[] systemMethodParameters = systemMethod.GetParameters();
-            if (systemMethodParameters.Length != 1)
-            {
-                return false;
-            }
-
-            return systemMethodParameters[0].ParameterType == VRTK_SharedMethods.GetTypeUnknownAssembly("Valve.VR.EVREventType");
+            Version version = GetVersion();
+            return version != null && version >= new Version(1, 2, 1);
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_0", BuildTargetGroupName)]
         private static bool IsPluginVersion120()
         {
-            Type eventClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Events");
-            if (eventClass == null)
-            {
-                return false;
-            }
-
-            MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
-            if (systemMethod == null)
-            {
-                return false;
-            }
-
-            ParameterInfo[] systemMethodParameters = systemMethod.GetParameters();
-            if (systemMethodParameters.Length != 1)
-            {
-                return false;
-            }
-
-            return systemMethodParameters[0].ParameterType == typeof(string);
+            Version version = GetVersion();
+            return version != null && version == new Version(1, 2, 0);
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_1_1_OR_OLDER", BuildTargetGroupName)]
         private static bool IsPluginVersion111OrOlder()
         {
-            Type utilsClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Utils");
-            if (utilsClass == null)
+            Version version = GetVersion();
+            return version != null && version <= new Version(1, 1, 1);
+        }
+
+        private static Version GetVersion()
+        {
+            Type pluginClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Update");
+            if (pluginClass == null)
             {
-                return false;
+                return null;
             }
 
-            Type eventClass = utilsClass.GetNestedType("Event");
-            return eventClass != null && eventClass.GetMethod("Listen", BindingFlags.Public | BindingFlags.Static) != null;
+            FieldInfo versionField = pluginClass.GetField("currentVersion", BindingFlags.NonPublic | BindingFlags.Static);
+            if (versionField == null)
+            {
+                return null;
+            }
+
+            string versionString = (string)versionField.GetValue(null);
+            if (versionString == null)
+            {
+                return null;
+            }
+
+            return new Version(versionString);
         }
     }
 }


### PR DESCRIPTION
The new release of SteamVR fixed issues VRTK worked around
previously. These workarounds are now wrapped in an #ifdef to
support the new version while maintaining support for the previous
ones.

Additionally the version lookup on both the SteamVR and Oculus SDK
are simplified.