### PR TITLE
fix(SDK): SteamVR SDK Setup unusable in build

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRDefines.cs
@@ -20,55 +20,82 @@ namespace VRTK
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_2_OR_NEWER", BuildTargetGroupName)]
         private static bool IsPluginVersion122OrNewer()
         {
-            Version version = GetVersion();
-            return version != null && version >= new Version(1, 2, 2);
+            Type controllerManagerClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_ControllerManager");
+            if (controllerManagerClass == null)
+            {
+                return false;
+            }
+
+            return controllerManagerClass.GetMethod("SetUniqueObject", BindingFlags.NonPublic | BindingFlags.Instance) != null;
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_1_OR_NEWER", BuildTargetGroupName)]
         private static bool IsPluginVersion121OrNewer()
         {
-            Version version = GetVersion();
-            return version != null && version >= new Version(1, 2, 1);
+            Type eventClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Events");
+            if (eventClass == null)
+            {
+                return false;
+            }
+
+            MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
+            if (systemMethod == null)
+            {
+                return false;
+            }
+
+            ParameterInfo[] systemMethodParameters = systemMethod.GetParameters();
+            if (systemMethodParameters.Length != 1)
+            {
+                return false;
+            }
+
+            return systemMethodParameters[0].ParameterType == VRTK_SharedMethods.GetTypeUnknownAssembly("Valve.VR.EVREventType");
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_2_0", BuildTargetGroupName)]
         private static bool IsPluginVersion120()
         {
-            Version version = GetVersion();
-            return version != null && version == new Version(1, 2, 0);
+            Type eventClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Events");
+            if (eventClass == null)
+            {
+                return false;
+            }
+
+            MethodInfo systemMethod = eventClass.GetMethod("System", BindingFlags.Public | BindingFlags.Static);
+            if (systemMethod == null)
+            {
+                return false;
+            }
+
+            ParameterInfo[] systemMethodParameters = systemMethod.GetParameters();
+            if (systemMethodParameters.Length != 1)
+            {
+                return false;
+            }
+
+            return systemMethodParameters[0].ParameterType == typeof(string);
         }
 
         [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
         [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "STEAMVR_PLUGIN_1_1_1_OR_OLDER", BuildTargetGroupName)]
         private static bool IsPluginVersion111OrOlder()
         {
-            Version version = GetVersion();
-            return version != null && version <= new Version(1, 1, 1);
-        }
-
-        private static Version GetVersion()
-        {
-            Type pluginClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Update");
-            if (pluginClass == null)
+            Type utilsClass = VRTK_SharedMethods.GetTypeUnknownAssembly("SteamVR_Utils");
+            if (utilsClass == null)
             {
-                return null;
+                return false;
             }
 
-            FieldInfo versionField = pluginClass.GetField("currentVersion", BindingFlags.NonPublic | BindingFlags.Static);
-            if (versionField == null)
+            Type eventClass = utilsClass.GetNestedType("Event");
+            if (eventClass == null)
             {
-                return null;
+                return false;
             }
 
-            string versionString = (string)versionField.GetValue(null);
-            if (versionString == null)
-            {
-                return null;
-            }
-
-            return new Version(versionString);
+            return eventClass.GetMethod("Listen", BindingFlags.Public | BindingFlags.Static) != null;
         }
     }
 }


### PR DESCRIPTION
The SteamVR scripting define symbols were defined based on
`SteamVR_Update.currentVersion`, but that type is only available in
the Editor assembly, which is not included in builds. The fix is to
revert back to the old method of identifying the used SteamVR plugin
version and to add new identification logic for the SteamVR plugin
version 1.2.2.