### PR TITLE
fix(UpdatePrompt): long changelog error

### DIFF
--- a/Assets/VRTK/Editor/VRTK_EditorUtilities.cs
+++ b/Assets/VRTK/Editor/VRTK_EditorUtilities.cs
@@ -51,5 +51,21 @@
             drawAction(destructiveButtonStyle);
             GUI.backgroundColor = previousBackgroundColor;
         }
+
+        public static void DrawScrollableSelectableLabel(ref Vector2 scrollPosition, ref float width, string text, GUIStyle style)
+        {
+            using (EditorGUILayout.ScrollViewScope scrollViewScope = new EditorGUILayout.ScrollViewScope(scrollPosition))
+            {
+                scrollPosition = scrollViewScope.scrollPosition;
+
+                float textHeight = style.CalcHeight(new GUIContent(text), width);
+                EditorGUILayout.SelectableLabel(text, style, GUILayout.MinHeight(textHeight));
+
+                if (Event.current.type == EventType.Repaint)
+                {
+                    width = GUILayoutUtility.GetLastRect().width;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Long changelogs resulted in Unity logging an error. The fix is to
add pagination to the changelog so less text is rendered at one
point.

Additionally the changelog is updated to follow the markdown look a
bit more.