### PR TITLE
Added null check to commandLineArgs.

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -420,16 +420,19 @@ namespace VRTK
             {
                 // If '-vrmode none' was used try to load the respective SDK Setup
                 string[] commandLineArgs = Environment.GetCommandLineArgs();
-                int commandLineArgIndex = Array.IndexOf(commandLineArgs, "-vrmode", 1);
-                if (VRSettings.loadedDeviceName == "None"
-                    || (commandLineArgIndex != -1
-                        && commandLineArgIndex + 1 < commandLineArgs.Length
-                        && commandLineArgs[commandLineArgIndex + 1].ToLowerInvariant() == "none"))
-                {
-                    index = Array.FindIndex(
-                        setups,
-                        setup => setup.usedVRDeviceNames.All(vrDeviceName => vrDeviceName == "None")
-                    );
+                if(commandLineArgs != null)
+                { 
+                    int commandLineArgIndex = Array.IndexOf(commandLineArgs, "-vrmode", 1);
+                    if (VRSettings.loadedDeviceName == "None"
+                        || (commandLineArgIndex != -1
+                            && commandLineArgIndex + 1 < commandLineArgs.Length
+                            && commandLineArgs[commandLineArgIndex + 1].ToLowerInvariant() == "none"))
+                    {
+                        index = Array.FindIndex(
+                            setups,
+                            setup => setup.usedVRDeviceNames.All(vrDeviceName => vrDeviceName == "None")
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
This null check is required for e.g. Android when not using VR, but VRTK.
E.g. if you use Simulator mode or custom mobile controls.

It's really just the added
if(commandLineArgs != null)