### PR TITLE
feat(SDK): add sense axis for capacitive touch buttons

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerAppearance_Example.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerAppearance_Example.cs
@@ -18,8 +18,9 @@
         private float dimOpacity = 0.8f;
         private float defaultOpacity = 1f;
         private bool highlighted;
+        private bool tooltipEnabled = false;
 
-        private void Start()
+        private void OnEnable()
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
@@ -34,25 +35,36 @@
             highlighted = false;
 
             //Setup controller event listeners
-            events.TriggerPressed += new ControllerInteractionEventHandler(DoTriggerPressed);
-            events.TriggerReleased += new ControllerInteractionEventHandler(DoTriggerReleased);
-
-            events.ButtonOnePressed += new ControllerInteractionEventHandler(DoButtonOnePressed);
-            events.ButtonOneReleased += new ControllerInteractionEventHandler(DoButtonOneReleased);
-
-            events.ButtonTwoPressed += new ControllerInteractionEventHandler(DoButtonTwoPressed);
-            events.ButtonTwoReleased += new ControllerInteractionEventHandler(DoButtonTwoReleased);
-
-            events.StartMenuPressed += new ControllerInteractionEventHandler(DoStartMenuPressed);
-            events.StartMenuReleased += new ControllerInteractionEventHandler(DoStartMenuReleased);
-
-            events.GripPressed += new ControllerInteractionEventHandler(DoGripPressed);
-            events.GripReleased += new ControllerInteractionEventHandler(DoGripReleased);
-
-            events.TouchpadPressed += new ControllerInteractionEventHandler(DoTouchpadPressed);
-            events.TouchpadReleased += new ControllerInteractionEventHandler(DoTouchpadReleased);
+            events.TriggerPressed += DoTriggerPressed;
+            events.TriggerReleased += DoTriggerReleased;
+            events.ButtonOnePressed += DoButtonOnePressed;
+            events.ButtonOneReleased += DoButtonOneReleased;
+            events.ButtonTwoPressed += DoButtonTwoPressed;
+            events.ButtonTwoReleased += DoButtonTwoReleased;
+            events.StartMenuPressed += DoStartMenuPressed;
+            events.StartMenuReleased += DoStartMenuReleased;
+            events.GripPressed += DoGripPressed;
+            events.GripReleased += DoGripReleased;
+            events.TouchpadPressed += DoTouchpadPressed;
+            events.TouchpadReleased += DoTouchpadReleased;
 
             tooltips.ToggleTips(false);
+        }
+
+        private void OnDisable()
+        {
+            events.TriggerPressed -= DoTriggerPressed;
+            events.TriggerReleased -= DoTriggerReleased;
+            events.ButtonOnePressed -= DoButtonOnePressed;
+            events.ButtonOneReleased -= DoButtonOneReleased;
+            events.ButtonTwoPressed -= DoButtonTwoPressed;
+            events.ButtonTwoReleased -= DoButtonTwoReleased;
+            events.StartMenuPressed -= DoStartMenuPressed;
+            events.StartMenuReleased -= DoStartMenuReleased;
+            events.GripPressed -= DoGripPressed;
+            events.GripReleased -= DoGripReleased;
+            events.TouchpadPressed -= DoTouchpadPressed;
+            events.TouchpadReleased -= DoTouchpadReleased;
         }
 
         private void PulseTrigger()

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
@@ -4,241 +4,542 @@
 
     public class VRTK_ControllerEvents_ListenerExample : MonoBehaviour
     {
-        private void Start()
+        public enum EventQuickSelect
         {
-            if (GetComponent<VRTK_ControllerEvents>() == null)
+            Custom,
+            None,
+            All,
+            ButtonOnly,
+            AxisOnly,
+            SenseAxisOnly
+        }
+
+        [Header("Quick Select")]
+
+        public EventQuickSelect quickSelect = EventQuickSelect.All;
+
+        [Header("Button Events Debug")]
+
+        public bool triggerButtonEvents = true;
+        public bool gripButtonEvents = true;
+        public bool touchpadButtonEvents = true;
+        public bool buttonOneButtonEvents = true;
+        public bool buttonTwoButtonEvents = true;
+        public bool startMenuButtonEvents = true;
+
+        [Header("Axis Events Debug")]
+
+        public bool triggerAxisEvents = true;
+        public bool gripAxisEvents = true;
+        public bool touchpadAxisEvents = true;
+
+        [Header("Sense Axis Events Debug")]
+
+        public bool triggerSenseAxisEvents = true;
+        public bool touchpadSenseAxisEvents = true;
+        public bool middleFingerSenseAxisEvents = true;
+        public bool ringFingerSenseAxisEvents = true;
+        public bool pinkyFingerSenseAxisEvents = true;
+
+        private VRTK_ControllerEvents controllerEvents;
+
+        private void OnEnable()
+        {
+            controllerEvents = GetComponent<VRTK_ControllerEvents>();
+            if (controllerEvents == null)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_ControllerEvents_ListenerExample", "VRTK_ControllerEvents", "the same"));
                 return;
             }
 
             //Setup controller event listeners
-            GetComponent<VRTK_ControllerEvents>().TriggerPressed += new ControllerInteractionEventHandler(DoTriggerPressed);
-            GetComponent<VRTK_ControllerEvents>().TriggerReleased += new ControllerInteractionEventHandler(DoTriggerReleased);
+            controllerEvents.TriggerPressed += DoTriggerPressed;
+            controllerEvents.TriggerReleased += DoTriggerReleased;
+            controllerEvents.TriggerTouchStart += DoTriggerTouchStart;
+            controllerEvents.TriggerTouchEnd += DoTriggerTouchEnd;
+            controllerEvents.TriggerHairlineStart += DoTriggerHairlineStart;
+            controllerEvents.TriggerHairlineEnd += DoTriggerHairlineEnd;
+            controllerEvents.TriggerClicked += DoTriggerClicked;
+            controllerEvents.TriggerUnclicked += DoTriggerUnclicked;
+            controllerEvents.TriggerAxisChanged += DoTriggerAxisChanged;
+            controllerEvents.TriggerSenseAxisChanged += DoTriggerSenseAxisChanged;
 
-            GetComponent<VRTK_ControllerEvents>().TriggerTouchStart += new ControllerInteractionEventHandler(DoTriggerTouchStart);
-            GetComponent<VRTK_ControllerEvents>().TriggerTouchEnd += new ControllerInteractionEventHandler(DoTriggerTouchEnd);
+            controllerEvents.GripPressed += DoGripPressed;
+            controllerEvents.GripReleased += DoGripReleased;
+            controllerEvents.GripTouchStart += DoGripTouchStart;
+            controllerEvents.GripTouchEnd += DoGripTouchEnd;
+            controllerEvents.GripHairlineStart += DoGripHairlineStart;
+            controllerEvents.GripHairlineEnd += DoGripHairlineEnd;
+            controllerEvents.GripClicked += DoGripClicked;
+            controllerEvents.GripUnclicked += DoGripUnclicked;
+            controllerEvents.GripAxisChanged += DoGripAxisChanged;
 
-            GetComponent<VRTK_ControllerEvents>().TriggerHairlineStart += new ControllerInteractionEventHandler(DoTriggerHairlineStart);
-            GetComponent<VRTK_ControllerEvents>().TriggerHairlineEnd += new ControllerInteractionEventHandler(DoTriggerHairlineEnd);
+            controllerEvents.TouchpadPressed += DoTouchpadPressed;
+            controllerEvents.TouchpadReleased += DoTouchpadReleased;
+            controllerEvents.TouchpadTouchStart += DoTouchpadTouchStart;
+            controllerEvents.TouchpadTouchEnd += DoTouchpadTouchEnd;
+            controllerEvents.TouchpadAxisChanged += DoTouchpadAxisChanged;
+            controllerEvents.TouchpadSenseAxisChanged += DoTouchpadSenseAxisChanged;
 
-            GetComponent<VRTK_ControllerEvents>().TriggerClicked += new ControllerInteractionEventHandler(DoTriggerClicked);
-            GetComponent<VRTK_ControllerEvents>().TriggerUnclicked += new ControllerInteractionEventHandler(DoTriggerUnclicked);
+            controllerEvents.ButtonOnePressed += DoButtonOnePressed;
+            controllerEvents.ButtonOneReleased += DoButtonOneReleased;
+            controllerEvents.ButtonOneTouchStart += DoButtonOneTouchStart;
+            controllerEvents.ButtonOneTouchEnd += DoButtonOneTouchEnd;
 
-            GetComponent<VRTK_ControllerEvents>().TriggerAxisChanged += new ControllerInteractionEventHandler(DoTriggerAxisChanged);
+            controllerEvents.ButtonTwoPressed += DoButtonTwoPressed;
+            controllerEvents.ButtonTwoReleased += DoButtonTwoReleased;
+            controllerEvents.ButtonTwoTouchStart += DoButtonTwoTouchStart;
+            controllerEvents.ButtonTwoTouchEnd += DoButtonTwoTouchEnd;
 
-            GetComponent<VRTK_ControllerEvents>().GripPressed += new ControllerInteractionEventHandler(DoGripPressed);
-            GetComponent<VRTK_ControllerEvents>().GripReleased += new ControllerInteractionEventHandler(DoGripReleased);
+            controllerEvents.StartMenuPressed += DoStartMenuPressed;
+            controllerEvents.StartMenuReleased += DoStartMenuReleased;
 
-            GetComponent<VRTK_ControllerEvents>().GripTouchStart += new ControllerInteractionEventHandler(DoGripTouchStart);
-            GetComponent<VRTK_ControllerEvents>().GripTouchEnd += new ControllerInteractionEventHandler(DoGripTouchEnd);
+            controllerEvents.ControllerEnabled += DoControllerEnabled;
+            controllerEvents.ControllerDisabled += DoControllerDisabled;
+            controllerEvents.ControllerIndexChanged += DoControllerIndexChanged;
 
-            GetComponent<VRTK_ControllerEvents>().GripHairlineStart += new ControllerInteractionEventHandler(DoGripHairlineStart);
-            GetComponent<VRTK_ControllerEvents>().GripHairlineEnd += new ControllerInteractionEventHandler(DoGripHairlineEnd);
+            controllerEvents.MiddleFingerSenseAxisChanged += DoMiddleFingerSenseAxisChanged;
+            controllerEvents.RingFingerSenseAxisChanged += DoRingFingerSenseAxisChanged;
+            controllerEvents.PinkyFingerSenseAxisChanged += DoPinkyFingerSenseAxisChanged;
+        }
 
-            GetComponent<VRTK_ControllerEvents>().GripClicked += new ControllerInteractionEventHandler(DoGripClicked);
-            GetComponent<VRTK_ControllerEvents>().GripUnclicked += new ControllerInteractionEventHandler(DoGripUnclicked);
+        private void OnDisable()
+        {
+            if (controllerEvents != null)
+            {
+                controllerEvents.TriggerPressed -= DoTriggerPressed;
+                controllerEvents.TriggerReleased -= DoTriggerReleased;
+                controllerEvents.TriggerTouchStart -= DoTriggerTouchStart;
+                controllerEvents.TriggerTouchEnd -= DoTriggerTouchEnd;
+                controllerEvents.TriggerHairlineStart -= DoTriggerHairlineStart;
+                controllerEvents.TriggerHairlineEnd -= DoTriggerHairlineEnd;
+                controllerEvents.TriggerClicked -= DoTriggerClicked;
+                controllerEvents.TriggerUnclicked -= DoTriggerUnclicked;
+                controllerEvents.TriggerAxisChanged -= DoTriggerAxisChanged;
+                controllerEvents.TriggerSenseAxisChanged -= DoTriggerSenseAxisChanged;
 
-            GetComponent<VRTK_ControllerEvents>().GripAxisChanged += new ControllerInteractionEventHandler(DoGripAxisChanged);
+                controllerEvents.GripPressed -= DoGripPressed;
+                controllerEvents.GripReleased -= DoGripReleased;
+                controllerEvents.GripTouchStart -= DoGripTouchStart;
+                controllerEvents.GripTouchEnd -= DoGripTouchEnd;
+                controllerEvents.GripHairlineStart -= DoGripHairlineStart;
+                controllerEvents.GripHairlineEnd -= DoGripHairlineEnd;
+                controllerEvents.GripClicked -= DoGripClicked;
+                controllerEvents.GripUnclicked -= DoGripUnclicked;
+                controllerEvents.GripAxisChanged -= DoGripAxisChanged;
 
-            GetComponent<VRTK_ControllerEvents>().TouchpadPressed += new ControllerInteractionEventHandler(DoTouchpadPressed);
-            GetComponent<VRTK_ControllerEvents>().TouchpadReleased += new ControllerInteractionEventHandler(DoTouchpadReleased);
+                controllerEvents.TouchpadPressed -= DoTouchpadPressed;
+                controllerEvents.TouchpadReleased -= DoTouchpadReleased;
+                controllerEvents.TouchpadTouchStart -= DoTouchpadTouchStart;
+                controllerEvents.TouchpadTouchEnd -= DoTouchpadTouchEnd;
+                controllerEvents.TouchpadAxisChanged -= DoTouchpadAxisChanged;
+                controllerEvents.TouchpadSenseAxisChanged -= DoTouchpadSenseAxisChanged;
 
-            GetComponent<VRTK_ControllerEvents>().TouchpadTouchStart += new ControllerInteractionEventHandler(DoTouchpadTouchStart);
-            GetComponent<VRTK_ControllerEvents>().TouchpadTouchEnd += new ControllerInteractionEventHandler(DoTouchpadTouchEnd);
+                controllerEvents.ButtonOnePressed -= DoButtonOnePressed;
+                controllerEvents.ButtonOneReleased -= DoButtonOneReleased;
+                controllerEvents.ButtonOneTouchStart -= DoButtonOneTouchStart;
+                controllerEvents.ButtonOneTouchEnd -= DoButtonOneTouchEnd;
 
-            GetComponent<VRTK_ControllerEvents>().TouchpadAxisChanged += new ControllerInteractionEventHandler(DoTouchpadAxisChanged);
+                controllerEvents.ButtonTwoPressed -= DoButtonTwoPressed;
+                controllerEvents.ButtonTwoReleased -= DoButtonTwoReleased;
+                controllerEvents.ButtonTwoTouchStart -= DoButtonTwoTouchStart;
+                controllerEvents.ButtonTwoTouchEnd -= DoButtonTwoTouchEnd;
 
-            GetComponent<VRTK_ControllerEvents>().ButtonOnePressed += new ControllerInteractionEventHandler(DoButtonOnePressed);
-            GetComponent<VRTK_ControllerEvents>().ButtonOneReleased += new ControllerInteractionEventHandler(DoButtonOneReleased);
+                controllerEvents.StartMenuPressed -= DoStartMenuPressed;
+                controllerEvents.StartMenuReleased -= DoStartMenuReleased;
 
-            GetComponent<VRTK_ControllerEvents>().ButtonOneTouchStart += new ControllerInteractionEventHandler(DoButtonOneTouchStart);
-            GetComponent<VRTK_ControllerEvents>().ButtonOneTouchEnd += new ControllerInteractionEventHandler(DoButtonOneTouchEnd);
+                controllerEvents.ControllerEnabled -= DoControllerEnabled;
+                controllerEvents.ControllerDisabled -= DoControllerDisabled;
+                controllerEvents.ControllerIndexChanged -= DoControllerIndexChanged;
 
-            GetComponent<VRTK_ControllerEvents>().ButtonTwoPressed += new ControllerInteractionEventHandler(DoButtonTwoPressed);
-            GetComponent<VRTK_ControllerEvents>().ButtonTwoReleased += new ControllerInteractionEventHandler(DoButtonTwoReleased);
+                controllerEvents.MiddleFingerSenseAxisChanged -= DoMiddleFingerSenseAxisChanged;
+                controllerEvents.RingFingerSenseAxisChanged -= DoRingFingerSenseAxisChanged;
+                controllerEvents.PinkyFingerSenseAxisChanged -= DoPinkyFingerSenseAxisChanged;
+            }
+        }
 
-            GetComponent<VRTK_ControllerEvents>().ButtonTwoTouchStart += new ControllerInteractionEventHandler(DoButtonTwoTouchStart);
-            GetComponent<VRTK_ControllerEvents>().ButtonTwoTouchEnd += new ControllerInteractionEventHandler(DoButtonTwoTouchEnd);
+        private void LateUpdate()
+        {
+            switch (quickSelect)
+            {
+                case EventQuickSelect.None:
+                    triggerButtonEvents = false;
+                    gripButtonEvents = false;
+                    touchpadButtonEvents = false;
+                    buttonOneButtonEvents = false;
+                    buttonTwoButtonEvents = false;
+                    startMenuButtonEvents = false;
 
-            GetComponent<VRTK_ControllerEvents>().StartMenuPressed += new ControllerInteractionEventHandler(DoStartMenuPressed);
-            GetComponent<VRTK_ControllerEvents>().StartMenuReleased += new ControllerInteractionEventHandler(DoStartMenuReleased);
+                    triggerAxisEvents = false;
+                    gripAxisEvents = false;
+                    touchpadAxisEvents = false;
 
-            GetComponent<VRTK_ControllerEvents>().ControllerEnabled += new ControllerInteractionEventHandler(DoControllerEnabled);
-            GetComponent<VRTK_ControllerEvents>().ControllerDisabled += new ControllerInteractionEventHandler(DoControllerDisabled);
+                    triggerSenseAxisEvents = false;
+                    touchpadSenseAxisEvents = false;
+                    middleFingerSenseAxisEvents = false;
+                    ringFingerSenseAxisEvents = false;
+                    pinkyFingerSenseAxisEvents = false;
+                    break;
+                case EventQuickSelect.All:
+                    triggerButtonEvents = true;
+                    gripButtonEvents = true;
+                    touchpadButtonEvents = true;
+                    buttonOneButtonEvents = true;
+                    buttonTwoButtonEvents = true;
+                    startMenuButtonEvents = true;
 
-            GetComponent<VRTK_ControllerEvents>().ControllerIndexChanged += new ControllerInteractionEventHandler(DoControllerIndexChanged);
+                    triggerAxisEvents = true;
+                    gripAxisEvents = true;
+                    touchpadAxisEvents = true;
+
+                    triggerSenseAxisEvents = true;
+                    touchpadSenseAxisEvents = true;
+                    middleFingerSenseAxisEvents = true;
+                    ringFingerSenseAxisEvents = true;
+                    pinkyFingerSenseAxisEvents = true;
+                    break;
+                case EventQuickSelect.ButtonOnly:
+                    triggerButtonEvents = true;
+                    gripButtonEvents = true;
+                    touchpadButtonEvents = true;
+                    buttonOneButtonEvents = true;
+                    buttonTwoButtonEvents = true;
+                    startMenuButtonEvents = true;
+
+                    triggerAxisEvents = false;
+                    gripAxisEvents = false;
+                    touchpadAxisEvents = false;
+
+                    triggerSenseAxisEvents = false;
+                    touchpadSenseAxisEvents = false;
+                    middleFingerSenseAxisEvents = false;
+                    ringFingerSenseAxisEvents = false;
+                    pinkyFingerSenseAxisEvents = false;
+                    break;
+                case EventQuickSelect.AxisOnly:
+                    triggerButtonEvents = false;
+                    gripButtonEvents = false;
+                    touchpadButtonEvents = false;
+                    buttonOneButtonEvents = false;
+                    buttonTwoButtonEvents = false;
+                    startMenuButtonEvents = false;
+
+                    triggerAxisEvents = true;
+                    gripAxisEvents = true;
+                    touchpadAxisEvents = true;
+
+                    triggerSenseAxisEvents = false;
+                    touchpadSenseAxisEvents = false;
+                    middleFingerSenseAxisEvents = false;
+                    ringFingerSenseAxisEvents = false;
+                    pinkyFingerSenseAxisEvents = false;
+                    break;
+                case EventQuickSelect.SenseAxisOnly:
+                    triggerButtonEvents = false;
+                    gripButtonEvents = false;
+                    touchpadButtonEvents = false;
+                    buttonOneButtonEvents = false;
+                    buttonTwoButtonEvents = false;
+                    startMenuButtonEvents = false;
+
+                    triggerAxisEvents = false;
+                    gripAxisEvents = false;
+                    touchpadAxisEvents = false;
+
+                    triggerSenseAxisEvents = true;
+                    touchpadSenseAxisEvents = true;
+                    middleFingerSenseAxisEvents = true;
+                    ringFingerSenseAxisEvents = true;
+                    pinkyFingerSenseAxisEvents = true;
+                    break;
+            }
         }
 
         private void DebugLogger(uint index, string button, string action, ControllerInteractionEventArgs e)
         {
-            VRTK_Logger.Info("Controller on index '" + index + "' " + button + " has been " + action
-                    + " with a pressure of " + e.buttonPressure + " / trackpad axis at: " + e.touchpadAxis + " (" + e.touchpadAngle + " degrees)");
+            string debugString = "Controller on index '" + index + "' " + button + " has been " + action
+                                 + " with a pressure of " + e.buttonPressure + " / trackpad axis at: " + e.touchpadAxis + " (" + e.touchpadAngle + " degrees)";
+            VRTK_Logger.Info(debugString);
         }
 
         private void DoTriggerPressed(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "pressed", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "pressed", e);
+            }
         }
 
         private void DoTriggerReleased(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "released", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "released", e);
+            }
         }
 
         private void DoTriggerTouchStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "touched", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "touched", e);
+            }
         }
 
         private void DoTriggerTouchEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "untouched", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "untouched", e);
+            }
         }
 
         private void DoTriggerHairlineStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "hairline start", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "hairline start", e);
+            }
         }
 
         private void DoTriggerHairlineEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "hairline end", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "hairline end", e);
+            }
         }
 
         private void DoTriggerClicked(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "clicked", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "clicked", e);
+            }
         }
 
         private void DoTriggerUnclicked(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "unclicked", e);
+            if (triggerButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "unclicked", e);
+            }
         }
 
         private void DoTriggerAxisChanged(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "axis changed", e);
+            if (triggerAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "axis changed", e);
+            }
+        }
+
+        private void DoTriggerSenseAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (triggerSenseAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TRIGGER", "sense axis changed", e);
+            }
         }
 
         private void DoGripPressed(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "pressed", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "pressed", e);
+            }
         }
 
         private void DoGripReleased(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "released", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "released", e);
+            }
         }
 
         private void DoGripTouchStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "touched", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "touched", e);
+            }
         }
 
         private void DoGripTouchEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "untouched", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "untouched", e);
+            }
         }
 
         private void DoGripHairlineStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "hairline start", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "hairline start", e);
+            }
         }
 
         private void DoGripHairlineEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "hairline end", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "hairline end", e);
+            }
         }
 
         private void DoGripClicked(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "clicked", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "clicked", e);
+            }
         }
 
         private void DoGripUnclicked(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "unclicked", e);
+            if (gripButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "unclicked", e);
+            }
         }
 
         private void DoGripAxisChanged(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "axis changed", e);
+            if (gripAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "GRIP", "axis changed", e);
+            }
         }
 
         private void DoTouchpadPressed(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "pressed down", e);
+            if (touchpadButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "pressed down", e);
+            }
         }
 
         private void DoTouchpadReleased(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "released", e);
+            if (touchpadButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "released", e);
+            }
         }
 
         private void DoTouchpadTouchStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "touched", e);
+            if (touchpadButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "touched", e);
+            }
         }
 
         private void DoTouchpadTouchEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "untouched", e);
+            if (touchpadButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "untouched", e);
+            }
         }
 
         private void DoTouchpadAxisChanged(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "axis changed", e);
+            if (touchpadAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "axis changed", e);
+            }
+        }
+
+        private void DoTouchpadSenseAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (touchpadSenseAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "sense axis changed", e);
+            }
         }
 
         private void DoButtonOnePressed(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "pressed down", e);
+            if (buttonOneButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "pressed down", e);
+            }
         }
 
         private void DoButtonOneReleased(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "released", e);
+            if (buttonOneButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "released", e);
+            }
         }
 
         private void DoButtonOneTouchStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "touched", e);
+            if (buttonOneButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "touched", e);
+            }
         }
 
         private void DoButtonOneTouchEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "untouched", e);
+            if (buttonOneButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON ONE", "untouched", e);
+            }
         }
 
         private void DoButtonTwoPressed(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "pressed down", e);
+            if (buttonTwoButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "pressed down", e);
+            }
         }
 
         private void DoButtonTwoReleased(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "released", e);
+            if (buttonTwoButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "released", e);
+            }
         }
 
         private void DoButtonTwoTouchStart(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "touched", e);
+            if (buttonTwoButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "touched", e);
+            }
         }
 
         private void DoButtonTwoTouchEnd(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "untouched", e);
+            if (buttonTwoButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "BUTTON TWO", "untouched", e);
+            }
         }
 
         private void DoStartMenuPressed(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "START MENU", "pressed down", e);
+            if (startMenuButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "START MENU", "pressed down", e);
+            }
         }
 
         private void DoStartMenuReleased(object sender, ControllerInteractionEventArgs e)
         {
-            DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "START MENU", "released", e);
+            if (startMenuButtonEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "START MENU", "released", e);
+            }
         }
 
         private void DoControllerEnabled(object sender, ControllerInteractionEventArgs e)
@@ -254,6 +555,30 @@
         private void DoControllerIndexChanged(object sender, ControllerInteractionEventArgs e)
         {
             DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "CONTROLLER STATE", "INDEX CHANGED", e);
+        }
+
+        private void DoMiddleFingerSenseAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (middleFingerSenseAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "MIDDLE FINGER", "sense axis changed", e);
+            }
+        }
+
+        private void DoRingFingerSenseAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (ringFingerSenseAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "RING FINGER", "sense axis changed", e);
+            }
+        }
+
+        private void DoPinkyFingerSenseAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (pinkyFingerSenseAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "PINKY FINGER", "sense axis changed", e);
+            }
         }
     }
 }

--- a/Assets/VRTK/Prefabs/Resources/ControllerColliders/Simulator.prefab
+++ b/Assets/VRTK/Prefabs/Resources/ControllerColliders/Simulator.prefab
@@ -16,11 +16,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014032533114}
-  - 135: {fileID: 135000013971900078}
-  m_Layer: 0
+  - component: {fileID: 4000014032533114}
+  - component: {fileID: 135000013971900078}
+  m_Layer: 2
   m_Name: Simulator
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -36,10 +36,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &135000013971900078
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/VRTK/Prefabs/Resources/ControllerColliders/SteamVROculusTouch_Right.prefab
+++ b/Assets/VRTK/Prefabs/Resources/ControllerColliders/SteamVROculusTouch_Right.prefab
@@ -16,10 +16,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012949916692}
-  - 65: {fileID: 65000012251195188}
+  - component: {fileID: 4000012949916692}
+  - component: {fileID: 65000012251195188}
   m_Layer: 2
   m_Name: Ring
   m_TagString: Untagged
@@ -32,10 +32,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011210821692}
-  m_Layer: 0
+  - component: {fileID: 4000011210821692}
+  m_Layer: 2
   m_Name: SteamVROculusTouch_Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -47,10 +47,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013477695530}
-  - 65: {fileID: 65000012331975956}
+  - component: {fileID: 4000013477695530}
+  - component: {fileID: 65000012331975956}
   m_Layer: 2
   m_Name: Base
   m_TagString: Untagged
@@ -63,10 +63,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010840394240}
-  - 136: {fileID: 136000012737630932}
+  - component: {fileID: 4000010840394240}
+  - component: {fileID: 136000012737630932}
   m_Layer: 2
   m_Name: Handle
   m_TagString: Untagged
@@ -83,10 +83,10 @@ Transform:
   m_LocalRotation: {x: 0.043619405, y: 0, z: 0, w: 0.9990483}
   m_LocalPosition: {x: -0.0075, y: 0, z: -0.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011210821692}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
 --- !u!4 &4000011210821692
 Transform:
   m_ObjectHideFlags: 1
@@ -96,13 +96,13 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010840394240}
   - {fileID: 4000013477695530}
   - {fileID: 4000012949916692}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012949916692
 Transform:
   m_ObjectHideFlags: 1
@@ -112,10 +112,10 @@ Transform:
   m_LocalRotation: {x: 0.3407186, y: -0.08189965, z: 0.029809028, w: 0.9361168}
   m_LocalPosition: {x: -0.0075, y: 0, z: -0.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 40, y: -10, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011210821692}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 40, y: -10, z: 0}
 --- !u!4 &4000013477695530
 Transform:
   m_ObjectHideFlags: 1
@@ -125,10 +125,10 @@ Transform:
   m_LocalRotation: {x: 0.3420201, y: 0, z: 0, w: 0.9396927}
   m_LocalPosition: {x: -0.0075, y: 0, z: -0.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 40, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011210821692}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 40, y: 0, z: 0}
 --- !u!65 &65000012251195188
 BoxCollider:
   m_ObjectHideFlags: 1

--- a/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Left.prefab
+++ b/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Left.prefab
@@ -9,160 +9,160 @@ Prefab:
     m_Modifications: []
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1000013042522580}
+  m_RootGameObject: {fileID: 1877605160601450}
   m_IsPrefabParent: 1
---- !u!1 &1000011385491572
+--- !u!1 &1029363436515098
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000012621483460}
-  - component: {fileID: 136000012199981656}
+  - component: {fileID: 4319302640555566}
+  - component: {fileID: 136084999345939244}
   m_Layer: 2
-  m_Name: Handle
+  m_Name: Body
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1000011779915676
+--- !u!1 &1059275933282126
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000011664353866}
-  - component: {fileID: 65000010676156206}
+  - component: {fileID: 4691122841853822}
+  - component: {fileID: 65390817921472800}
   m_Layer: 2
-  m_Name: Base
+  m_Name: Strap
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1000013042522580
+--- !u!1 &1161921150162942
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000010969405022}
+  - component: {fileID: 4496749621299668}
+  - component: {fileID: 65112068760584944}
   m_Layer: 2
-  m_Name: SteamVROculusTouch_Left
+  m_Name: Head
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1000014097406818
+--- !u!1 &1877605160601450
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000014178618316}
-  - component: {fileID: 65000011952353700}
+  - component: {fileID: 4390161568080180}
   m_Layer: 2
-  m_Name: Ring
+  m_Name: ValveKnuckles_Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4000010969405022
+--- !u!4 &4319302640555566
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000013042522580}
+  m_GameObject: {fileID: 1029363436515098}
+  m_LocalRotation: {x: -0.17364825, y: 0, z: 0, w: 0.9848078}
+  m_LocalPosition: {x: 0, y: -0.02, z: -0.125}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4390161568080180}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -20, y: 0, z: 0}
+--- !u!4 &4390161568080180
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1877605160601450}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 4000012621483460}
-  - {fileID: 4000011664353866}
-  - {fileID: 4000014178618316}
+  - {fileID: 4319302640555566}
+  - {fileID: 4496749621299668}
+  - {fileID: 4691122841853822}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4000011664353866
+--- !u!4 &4496749621299668
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011779915676}
-  m_LocalRotation: {x: 0.3420201, y: 0, z: 0, w: 0.9396927}
-  m_LocalPosition: {x: 0.0075, y: 0, z: -0.05}
+  m_GameObject: {fileID: 1161921150162942}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0183, y: -0.0062, z: -0.044}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 4000010969405022}
+  m_Father: {fileID: 4390161568080180}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 40, y: 0, z: 0}
---- !u!4 &4000012621483460
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4691122841853822
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011385491572}
-  m_LocalRotation: {x: 0.043619405, y: 0, z: 0, w: 0.9990483}
-  m_LocalPosition: {x: 0.0075, y: 0, z: -0.05}
+  m_GameObject: {fileID: 1059275933282126}
+  m_LocalRotation: {x: -0.25812724, y: -0.07057446, z: -0.018910367, w: 0.96334416}
+  m_LocalPosition: {x: -0.0509, y: -0.0129, z: -0.1158}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 4000010969405022}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
---- !u!4 &4000014178618316
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000014097406818}
-  m_LocalRotation: {x: 0.3407186, y: 0.08189965, z: -0.029809028, w: 0.9361168}
-  m_LocalPosition: {x: 0.0075, y: 0, z: -0.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4000010969405022}
+  m_Father: {fileID: 4390161568080180}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 40, y: 10, z: 0}
---- !u!65 &65000010676156206
+  m_LocalEulerAnglesHint: {x: -30, y: -8.38, z: 0}
+--- !u!65 &65112068760584944
 BoxCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011779915676}
+  m_GameObject: {fileID: 1161921150162942}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.05, y: 0.03, z: 0.05}
-  m_Center: {x: 0, y: -0.015, z: 0}
---- !u!65 &65000011952353700
+  m_Size: {x: 0.05, y: 0.04, z: 0.05}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65390817921472800
 BoxCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000014097406818}
+  m_GameObject: {fileID: 1059275933282126}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.1, y: 0.1, z: 0.02}
-  m_Center: {x: -0.0175, y: -0.04, z: 0.01}
---- !u!136 &136000012199981656
+  m_Size: {x: 0.025, y: 0.03, z: 0.125}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!136 &136084999345939244
 CapsuleCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011385491572}
+  m_GameObject: {fileID: 1029363436515098}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   m_Radius: 0.02
-  m_Height: 0.1
+  m_Height: 0.15
   m_Direction: 2
-  m_Center: {x: -0.015, y: -0.01, z: -0.04}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Left.prefab.meta
+++ b/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Left.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 407fd86db7d97f5488fc7b2099faa676
+timeCreated: 1499366045
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Right.prefab
+++ b/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Right.prefab
@@ -9,160 +9,160 @@ Prefab:
     m_Modifications: []
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1000013042522580}
+  m_RootGameObject: {fileID: 1248754412125716}
   m_IsPrefabParent: 1
---- !u!1 &1000011385491572
+--- !u!1 &1171642808372388
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000012621483460}
-  - component: {fileID: 136000012199981656}
+  - component: {fileID: 4379523316010210}
+  - component: {fileID: 136351595425383000}
   m_Layer: 2
-  m_Name: Handle
+  m_Name: Body
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1000011779915676
+--- !u!1 &1248754412125716
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000011664353866}
-  - component: {fileID: 65000010676156206}
+  - component: {fileID: 4827600060914352}
   m_Layer: 2
-  m_Name: Base
+  m_Name: ValveKnuckles_Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1000013042522580
+--- !u!1 &1385712378491258
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000010969405022}
+  - component: {fileID: 4037409286973756}
+  - component: {fileID: 65474573897593806}
   m_Layer: 2
-  m_Name: SteamVROculusTouch_Left
+  m_Name: Head
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1000014097406818
+--- !u!1 &1467967876325128
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4000014178618316}
-  - component: {fileID: 65000011952353700}
+  - component: {fileID: 4670387259791928}
+  - component: {fileID: 65481938699182388}
   m_Layer: 2
-  m_Name: Ring
+  m_Name: Strap
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4000010969405022
+--- !u!4 &4037409286973756
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000013042522580}
+  m_GameObject: {fileID: 1385712378491258}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.0183, y: -0.0062, z: -0.044}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4827600060914352}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4379523316010210
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1171642808372388}
+  m_LocalRotation: {x: -0.17364825, y: 0, z: 0, w: 0.9848078}
+  m_LocalPosition: {x: 0, y: -0.02, z: -0.125}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4827600060914352}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -20, y: 0, z: 0}
+--- !u!4 &4670387259791928
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1467967876325128}
+  m_LocalRotation: {x: -0.25812724, y: 0.07057456, z: 0.018910393, w: 0.96334416}
+  m_LocalPosition: {x: 0.0509, y: -0.0129, z: -0.1158}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4827600060914352}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -30, y: 8.38, z: 0}
+--- !u!4 &4827600060914352
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1248754412125716}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 4000012621483460}
-  - {fileID: 4000011664353866}
-  - {fileID: 4000014178618316}
+  - {fileID: 4379523316010210}
+  - {fileID: 4037409286973756}
+  - {fileID: 4670387259791928}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4000011664353866
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011779915676}
-  m_LocalRotation: {x: 0.3420201, y: 0, z: 0, w: 0.9396927}
-  m_LocalPosition: {x: 0.0075, y: 0, z: -0.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4000010969405022}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 40, y: 0, z: 0}
---- !u!4 &4000012621483460
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011385491572}
-  m_LocalRotation: {x: 0.043619405, y: 0, z: 0, w: 0.9990483}
-  m_LocalPosition: {x: 0.0075, y: 0, z: -0.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4000010969405022}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 5, y: 0, z: 0}
---- !u!4 &4000014178618316
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000014097406818}
-  m_LocalRotation: {x: 0.3407186, y: 0.08189965, z: -0.029809028, w: 0.9361168}
-  m_LocalPosition: {x: 0.0075, y: 0, z: -0.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4000010969405022}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 40, y: 10, z: 0}
---- !u!65 &65000010676156206
+--- !u!65 &65474573897593806
 BoxCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011779915676}
+  m_GameObject: {fileID: 1385712378491258}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.05, y: 0.03, z: 0.05}
-  m_Center: {x: 0, y: -0.015, z: 0}
---- !u!65 &65000011952353700
+  m_Size: {x: 0.05, y: 0.04, z: 0.05}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65481938699182388
 BoxCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000014097406818}
+  m_GameObject: {fileID: 1467967876325128}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.1, y: 0.1, z: 0.02}
-  m_Center: {x: -0.0175, y: -0.04, z: 0.01}
---- !u!136 &136000012199981656
+  m_Size: {x: 0.025, y: 0.03, z: 0.125}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!136 &136351595425383000
 CapsuleCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011385491572}
+  m_GameObject: {fileID: 1171642808372388}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
   m_Radius: 0.02
-  m_Height: 0.1
+  m_Height: 0.15
   m_Direction: 2
-  m_Center: {x: -0.015, y: -0.01, z: -0.04}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Right.prefab.meta
+++ b/Assets/VRTK/Prefabs/Resources/ControllerColliders/ValveKnuckles_Right.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc85ccbe3e7c4a243a5134fc6272a790
+timeCreated: 1499365927
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -109,6 +109,7 @@ namespace VRTK
         protected TooltipButtons[] availableButtons;
         protected VRTK_ObjectTooltip[] buttonTooltips;
         protected bool[] tooltipStates;
+        protected bool overallState = true;
 
         protected int retryInitCurrentTries = 0;
 
@@ -176,6 +177,7 @@ namespace VRTK
         {
             if (element == TooltipButtons.None)
             {
+                overallState = state;
                 for (int i = 1; i < buttonTooltips.Length; i++)
                 {
                     if (buttonTooltips[i].displayText.Length > 0)
@@ -403,7 +405,7 @@ namespace VRTK
 
             if (headsetControllerAware == null || !hideWhenNotInView)
             {
-                ToggleTips(true);
+                ToggleTips(overallState);
             }
         }
 

--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -23,6 +23,9 @@ namespace VRTK
         /// <param name="Trigger">Trigger on the controller.</param>
         /// <param name="TriggerHairline">Trigger Hairline on the controller.</param>
         /// <param name="Touchpad">Touchpad on the controller.</param>
+        /// <param name="MiddleFinger">Middle Finger on the controller.</param>
+        /// <param name="RingFinger">Ring Finger on the controller.</param>
+        /// <param name="PinkyFinger">Pinky Finger on the controller.</param>
         public enum ButtonTypes
         {
             ButtonOne,
@@ -33,6 +36,9 @@ namespace VRTK
             Trigger,
             TriggerHairline,
             Touchpad,
+            MiddleFinger,
+            RingFinger,
+            PinkyFinger
         }
 
         /// <summary>
@@ -105,6 +111,7 @@ namespace VRTK
         /// <param name="Oculus_OculusTouch">The Oculus Touch controller for Oculus Utilities.</param>
         /// <param name="Daydream_Controller">The Daydream controller for Google Daydream SDK.</param>
         /// <param name="Ximmerse_Flip">The Flip controller for Ximmerse SDK.</param>
+        /// <param name="SteamVR_ValveKnuckles">The Valve Knuckles controller for SteamVR.</param>
         public enum ControllerType
         {
             Undefined,
@@ -114,7 +121,8 @@ namespace VRTK
             SteamVR_OculusTouch,
             Oculus_OculusTouch,
             Daydream_Controller,
-            Ximmerse_Flip
+            Ximmerse_Flip,
+            SteamVR_ValveKnuckles
         }
 
         /// <summary>
@@ -326,6 +334,14 @@ namespace VRTK
         /// <param name="controllerReference">The reference to the controller to check the button axis on.</param>
         /// <returns>A Vector2 of the X/Y values of the button axis. If no axis values exist for the given button, then a Vector2.Zero is returned.</returns>
         public abstract Vector2 GetButtonAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference);
+
+        /// <summary>
+        /// The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+        /// </summary>
+        /// <param name="buttonType">The type of button to check for the sense axis on.</param>
+        /// <param name="controllerReference">The reference to the controller to check the sense axis on.</param>
+        /// <returns>The current sense axis value.</returns>
+        public abstract float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference);
 
         /// <summary>
         /// The GetButtonHairlineDelta method is used to get the difference between the current button press and the previous frame button press.

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -344,6 +344,17 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+        /// </summary>
+        /// <param name="buttonType">The type of button to check for the sense axis on.</param>
+        /// <param name="controllerReference">The reference to the controller to check the sense axis on.</param>
+        /// <returns>The current sense axis value.</returns>
+        public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
+        {
+            return 0f;
+        }
+
+        /// <summary>
         /// The GetButtonHairlineDelta method is used to get the difference between the current button press and the previous frame button press.
         /// </summary>
         /// <param name="buttonType">The type of button to get the hairline delta for.</param>

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -277,6 +277,17 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+        /// </summary>
+        /// <param name="buttonType">The type of button to check for the sense axis on.</param>
+        /// <param name="controllerReference">The reference to the controller to check the sense axis on.</param>
+        /// <returns>The current sense axis value.</returns>
+        public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
+        {
+            return 0f;
+        }
+
+        /// <summary>
         /// The GetButtonHairlineDelta method is used to get the difference between the current button press and the previous frame button press.
         /// </summary>
         /// <param name="buttonType">The type of button to get the hairline delta for.</param>

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
@@ -25,6 +25,8 @@ namespace VRTK
         protected OVRInput.RawAxis2D[] touchpads = new OVRInput.RawAxis2D[] { OVRInput.RawAxis2D.LThumbstick, OVRInput.RawAxis2D.RThumbstick };
         protected OVRInput.RawAxis1D[] triggers = new OVRInput.RawAxis1D[] { OVRInput.RawAxis1D.LIndexTrigger, OVRInput.RawAxis1D.RIndexTrigger };
         protected OVRInput.RawAxis1D[] grips = new OVRInput.RawAxis1D[] { OVRInput.RawAxis1D.LHandTrigger, OVRInput.RawAxis1D.RHandTrigger };
+        protected OVRInput.RawNearTouch[] triggerSense = new OVRInput.RawNearTouch[] { OVRInput.RawNearTouch.LIndexTrigger, OVRInput.RawNearTouch.RIndexTrigger };
+        protected OVRInput.RawNearTouch[] touchpadSense = new OVRInput.RawNearTouch[] { OVRInput.RawNearTouch.LThumbButtons, OVRInput.RawNearTouch.RThumbButtons };
 
         protected Quaternion[] previousControllerRotations = new Quaternion[2];
         protected Quaternion[] currentControllerRotations = new Quaternion[2];
@@ -487,6 +489,36 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+        /// </summary>
+        /// <param name="buttonType">The type of button to check for the sense axis on.</param>
+        /// <param name="controllerReference">The reference to the controller to check the sense axis on.</param>
+        /// <returns>The current sense axis value.</returns>
+        public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
+        {
+            if (!VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                return 0f;
+            }
+            bool senseResult = false;
+            uint index = VRTK_ControllerReference.GetRealIndex(controllerReference);
+            VRTK_TrackedController device = GetTrackedObject(controllerReference.actual);
+            if (device != null)
+            {
+                switch (buttonType)
+                {
+                    case ButtonTypes.Touchpad:
+                        senseResult = OVRInput.Get(touchpadSense[index], touchControllers[index]);
+                        break;
+                    case ButtonTypes.Trigger:
+                        senseResult = OVRInput.Get(triggerSense[index], touchControllers[index]);
+                        break;
+                }
+            }
+            return (senseResult ? 1f : 0f);
+        }
+
+        /// <summary>
         /// The GetButtonHairlineDelta method is used to get the difference between the current button press and the previous frame button press.
         /// </summary>
         /// <param name="buttonType">The type of button to get the hairline delta for.</param>
@@ -749,7 +781,7 @@ namespace VRTK
             if (cachedBoundariesSDK != null)
             {
                 OvrAvatar avatar = cachedBoundariesSDK.GetAvatar();
-                return (avatar && controllersAreVisible && avatar.StartWithControllers);
+                return (avatar != null && controllersAreVisible && avatar.StartWithControllers);
             }
 #endif
             return false;

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -384,6 +384,17 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+        /// </summary>
+        /// <param name="buttonType">The type of button to check for the sense axis on.</param>
+        /// <param name="controllerReference">The reference to the controller to check the sense axis on.</param>
+        /// <returns>The current sense axis value.</returns>
+        public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
+        {
+            return 0f;
+        }
+
+        /// <summary>
         /// The GetButtonHairlineDelta method is used to get the difference between the current button press and the previous frame button press.
         /// </summary>
         /// <param name="buttonType">The type of button to get the hairline delta for.</param>

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -159,6 +159,11 @@
             return GetControllerSDK().GetButtonAxis(buttonType, controllerReference);
         }
 
+        public static float GetControllerSenseAxis(SDK_BaseController.ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
+        {
+            return GetControllerSDK().GetButtonSenseAxis(buttonType, controllerReference);
+        }
+
         public static float GetControllerHairlineDelta(SDK_BaseController.ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
         {
             return GetControllerSDK().GetButtonHairlineDelta(buttonType, controllerReference);

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -472,8 +472,18 @@ namespace VRTK
                     }
                     break;
             }
-
             return Vector2.zero;
+        }
+
+        /// <summary>
+        /// The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+        /// </summary>
+        /// <param name="buttonType">The type of button to check for the sense axis on.</param>
+        /// <param name="controllerReference">The reference to the controller to check the sense axis on.</param>
+        /// <returns>The current sense axis value.</returns>
+        public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)
+        {
+            return 0f;
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -60,6 +60,11 @@ namespace VRTK
         /// <param name="ButtonTwoTouch">The button one is touched.</param>
         /// <param name="ButtonTwoPress">The button one is pressed.</param>
         /// <param name="StartMenuPress">The button one is pressed.</param>
+        /// <param name="TouchpadSense">The touchpad sense touch is active.</param>
+        /// <param name="TriggerSense">The trigger sense touch is active.</param>
+        /// <param name="MiddleFingerSense">The middle finger sense touch is active.</param>
+        /// <param name="RingFingerSense">The ring finger sense touch is active.</param>
+        /// <param name="PinkyFingerSense">The pinky finger sense touch is active.</param>
         public enum ButtonAlias
         {
             Undefined,
@@ -77,19 +82,36 @@ namespace VRTK
             ButtonOnePress,
             ButtonTwoTouch,
             ButtonTwoPress,
-            StartMenuPress
+            StartMenuPress,
+            TouchpadSense,
+            TriggerSense,
+            MiddleFingerSense,
+            RingFingerSense,
+            PinkyFingerSense
         }
 
         [Header("Axis Refinement")]
 
         [Tooltip("The amount of fidelity in the changes on the axis, which is defaulted to 1. Any number higher than 2 will probably give too sensitive results.")]
         public int axisFidelity = 1;
+        [Tooltip("The level on a sense axis to reach before the sense axis is forced to 0f")]
+        [Range(0f, 1f)]
+        public float senseAxisForceZeroThreshold = 0.15f;
+        [Tooltip("The amount of pressure required to be applied to a sense button before considering the sense button pressed.")]
+        [Range(0f, 1f)]
+        public float senseAxisPressThreshold = 0.95f;
+
+        [Header("Trigger Refinement")]
+
         [Tooltip("The level on the trigger axis to reach before a click is registered.")]
         public float triggerClickThreshold = 1f;
         [Tooltip("The level on the trigger axis to reach before the axis is forced to 0f.")]
         public float triggerForceZeroThreshold = 0.01f;
         [Tooltip("If this is checked then the trigger axis will be forced to 0f when the trigger button reports an untouch event.")]
         public bool triggerAxisZeroOnUntouch = false;
+
+        [Header("Grip Refinement")]
+
         [Tooltip("The level on the grip axis to reach before a click is registered.")]
         public float gripClickThreshold = 1f;
         [Tooltip("The level on the grip axis to reach before the axis is forced to 0f.")]
@@ -97,6 +119,9 @@ namespace VRTK
         [Tooltip("If this is checked then the grip axis will be forced to 0f when the grip button reports an untouch event.")]
         public bool gripAxisZeroOnUntouch = false;
 
+        #region bool states
+
+        #region trigger bool states
         /// <summary>
         /// This will be true if the trigger is squeezed about half way in.
         /// </summary>
@@ -122,7 +147,14 @@ namespace VRTK
         /// </summary>
         [HideInInspector]
         public bool triggerAxisChanged = false;
+        /// <summary>
+        /// This will be true if the trigger sense is being touched more or less.
+        /// </summary>
+        [HideInInspector]
+        public bool triggerSenseAxisChanged = false;
+        #endregion trigger bool states
 
+        #region grip bool states
         /// <summary>
         /// This will be true if the grip is squeezed about half way in.
         /// </summary>
@@ -148,7 +180,9 @@ namespace VRTK
         /// </summary>
         [HideInInspector]
         public bool gripAxisChanged = false;
+        #endregion grip bool states
 
+        #region touchpad bool states
         /// <summary>
         /// This will be true if the touchpad is held down.
         /// </summary>
@@ -164,7 +198,14 @@ namespace VRTK
         /// </summary>
         [HideInInspector]
         public bool touchpadAxisChanged = false;
+        /// <summary>
+        /// This will be true if the touchpad sense is being touched more or less.
+        /// </summary>
+        [HideInInspector]
+        public bool touchpadSenseAxisChanged = false;
+        #endregion touchpad bool states
 
+        #region button one bool states
         /// <summary>
         /// This will be true if button one is held down.
         /// </summary>
@@ -175,7 +216,9 @@ namespace VRTK
         /// </summary>
         [HideInInspector]
         public bool buttonOneTouched = false;
+        #endregion button one bool states
 
+        #region button two bool states
         /// <summary>
         /// This will be true if button two is held down.
         /// </summary>
@@ -186,12 +229,33 @@ namespace VRTK
         /// </summary>
         [HideInInspector]
         public bool buttonTwoTouched = false;
+        #endregion button two bool states
 
+        #region start menu bool states
         /// <summary>
         /// This will be true if start menu is held down.
         /// </summary>
         [HideInInspector]
         public bool startMenuPressed = false;
+        #endregion start menu bool states
+
+        #region extra finger bool states
+        /// <summary>
+        /// This will be true if the middle finger sense is being touched more or less.
+        /// </summary>
+        [HideInInspector]
+        public bool middleFingerSenseAxisChanged = false;
+        /// <summary>
+        /// This will be true if the ring finger sense is being touched more or less.
+        /// </summary>
+        [HideInInspector]
+        public bool ringFingerSenseAxisChanged = false;
+        /// <summary>
+        /// This will be true if the pinky finger sense is being touched more or less.
+        /// </summary>
+        [HideInInspector]
+        public bool pinkyFingerSenseAxisChanged = false;
+        #endregion extra finger bool states
 
         /// <summary>
         /// This will be true if the controller model alias renderers are visible.
@@ -199,6 +263,11 @@ namespace VRTK
         [HideInInspector]
         public bool controllerVisible = true;
 
+        #endregion bool states
+
+        #region controller events
+
+        #region controller trigger events
         /// <summary>
         /// Emitted when the trigger is squeezed about half way in.
         /// </summary>
@@ -241,6 +310,13 @@ namespace VRTK
         public event ControllerInteractionEventHandler TriggerAxisChanged;
 
         /// <summary>
+        /// Emitted when the amount of touch on the trigger sense changes.
+        /// </summary>
+        public event ControllerInteractionEventHandler TriggerSenseAxisChanged;
+        #endregion controller trigger events
+
+        #region controller grip events
+        /// <summary>
         /// Emitted when the grip is squeezed about half way in.
         /// </summary>
         public event ControllerInteractionEventHandler GripPressed;
@@ -280,7 +356,9 @@ namespace VRTK
         /// Emitted when the amount of squeeze on the grip changes.
         /// </summary>
         public event ControllerInteractionEventHandler GripAxisChanged;
+        #endregion controller grip events
 
+        #region controller touchpad events
         /// <summary>
         /// Emitted when the touchpad is pressed (to the point of hearing a click).
         /// </summary>
@@ -305,6 +383,13 @@ namespace VRTK
         public event ControllerInteractionEventHandler TouchpadAxisChanged;
 
         /// <summary>
+        /// Emitted when the amount of touch on the touchpad sense changes.
+        /// </summary>
+        public event ControllerInteractionEventHandler TouchpadSenseAxisChanged;
+        #endregion controller touchpad events
+
+        #region controller button one events
+        /// <summary>
         /// Emitted when button one is touched.
         /// </summary>
         public event ControllerInteractionEventHandler ButtonOneTouchStart;
@@ -320,7 +405,9 @@ namespace VRTK
         /// Emitted when button one is released.
         /// </summary>
         public event ControllerInteractionEventHandler ButtonOneReleased;
+        #endregion controller button one events
 
+        #region controller button two events
         /// <summary>
         /// Emitted when button two is touched.
         /// </summary>
@@ -337,7 +424,9 @@ namespace VRTK
         /// Emitted when button two is released.
         /// </summary>
         public event ControllerInteractionEventHandler ButtonTwoReleased;
+        #endregion controller button one events
 
+        #region controller start menu events
         /// <summary>
         /// Emitted when start menu is pressed.
         /// </summary>
@@ -346,7 +435,26 @@ namespace VRTK
         /// Emitted when start menu is released.
         /// </summary>
         public event ControllerInteractionEventHandler StartMenuReleased;
+        #endregion controller start menu events
 
+        #region controller extra finger events
+        /// <summary>
+        /// Emitted when the amount of touch on the middle finger sense changes.
+        /// </summary>
+        public event ControllerInteractionEventHandler MiddleFingerSenseAxisChanged;
+
+        /// <summary>
+        /// Emitted when the amount of touch on the ring finger sense changes.
+        /// </summary>
+        public event ControllerInteractionEventHandler RingFingerSenseAxisChanged;
+
+        /// <summary>
+        /// Emitted when the amount of touch on the pinky finger sense changes.
+        /// </summary>
+        public event ControllerInteractionEventHandler PinkyFingerSenseAxisChanged;
+        #endregion controller extra finger events
+
+        #region controller generic events
         /// <summary>
         /// Emitted when the controller is enabled.
         /// </summary>
@@ -368,13 +476,24 @@ namespace VRTK
         /// Emitted when the controller is set to hidden.
         /// </summary>
         public event ControllerInteractionEventHandler ControllerHidden;
+        #endregion controller generic events
+
+        #endregion controller events
 
         protected Vector2 touchpadAxis = Vector2.zero;
         protected Vector2 triggerAxis = Vector2.zero;
         protected Vector2 gripAxis = Vector2.zero;
+        protected float touchpadSenseAxis = 0f;
+        protected float triggerSenseAxis = 0f;
+        protected float middleFingerSenseAxis = 0f;
+        protected float ringFingerSenseAxis = 0f;
+        protected float pinkyFingerSenseAxis = 0f;
         protected float hairTriggerDelta;
         protected float hairGripDelta;
 
+        #region event methods
+
+        #region event trigger methods
         public virtual void OnTriggerPressed(ControllerInteractionEventArgs e)
         {
             if (TriggerPressed != null)
@@ -447,6 +566,16 @@ namespace VRTK
             }
         }
 
+        public virtual void OnTriggerSenseAxisChanged(ControllerInteractionEventArgs e)
+        {
+            if (TriggerSenseAxisChanged != null)
+            {
+                TriggerSenseAxisChanged(this, e);
+            }
+        }
+        #endregion event trigger methods
+
+        #region event grip methods
         public virtual void OnGripPressed(ControllerInteractionEventArgs e)
         {
             if (GripPressed != null)
@@ -518,7 +647,9 @@ namespace VRTK
                 GripAxisChanged(this, e);
             }
         }
+        #endregion event grip methods
 
+        #region event touchpad methods
         public virtual void OnTouchpadPressed(ControllerInteractionEventArgs e)
         {
             if (TouchpadPressed != null)
@@ -559,6 +690,16 @@ namespace VRTK
             }
         }
 
+        public virtual void OnTouchpadSenseAxisChanged(ControllerInteractionEventArgs e)
+        {
+            if (TouchpadSenseAxisChanged != null)
+            {
+                TouchpadSenseAxisChanged(this, e);
+            }
+        }
+        #endregion event touchpad methods
+
+        #region event button one methods
         public virtual void OnButtonOneTouchStart(ControllerInteractionEventArgs e)
         {
             if (ButtonOneTouchStart != null)
@@ -590,7 +731,9 @@ namespace VRTK
                 ButtonOneReleased(this, e);
             }
         }
+        #endregion event button one methods
 
+        #region event button two methods
         public virtual void OnButtonTwoTouchStart(ControllerInteractionEventArgs e)
         {
             if (ButtonTwoTouchStart != null)
@@ -622,7 +765,9 @@ namespace VRTK
                 ButtonTwoReleased(this, e);
             }
         }
+        #endregion event button two methods
 
+        #region event start menu methods
         public virtual void OnStartMenuPressed(ControllerInteractionEventArgs e)
         {
             if (StartMenuPressed != null)
@@ -638,7 +783,35 @@ namespace VRTK
                 StartMenuReleased(this, e);
             }
         }
+        #endregion event start menu methods
 
+        #region event extra finger methods
+        public virtual void OnMiddleFingerSenseAxisChanged(ControllerInteractionEventArgs e)
+        {
+            if (MiddleFingerSenseAxisChanged != null)
+            {
+                MiddleFingerSenseAxisChanged(this, e);
+            }
+        }
+
+        public virtual void OnRingFingerSenseAxisChanged(ControllerInteractionEventArgs e)
+        {
+            if (RingFingerSenseAxisChanged != null)
+            {
+                RingFingerSenseAxisChanged(this, e);
+            }
+        }
+
+        public virtual void OnPinkyFingerSenseAxisChanged(ControllerInteractionEventArgs e)
+        {
+            if (PinkyFingerSenseAxisChanged != null)
+            {
+                PinkyFingerSenseAxisChanged(this, e);
+            }
+        }
+        #endregion event extra finger methods
+
+        #region event generic methods
         public virtual void OnControllerEnabled(ControllerInteractionEventArgs e)
         {
             if (ControllerEnabled != null)
@@ -680,6 +853,9 @@ namespace VRTK
                 ControllerHidden(this, e);
             }
         }
+        #endregion event generic methods
+
+        #endregion event methods
 
         /// <summary>
         /// The SetControllerEvent/0 method is used to set the Controller Event payload.
@@ -710,6 +886,7 @@ namespace VRTK
             return e;
         }
 
+        #region axis getters
         /// <summary>
         /// The GetTouchpadAxis method returns the coordinates of where the touchpad is being touched and can be used for directional input via the touchpad. The `x` value is the horizontal touch plane and the `y` value is the vertical touch plane.
         /// </summary>
@@ -745,7 +922,9 @@ namespace VRTK
         {
             return gripAxis.x;
         }
+        #endregion axis getters
 
+        #region hairline delta getters
         /// <summary>
         /// The GetHairTriggerDelta method returns a float representing the difference in how much the trigger is being pressed in relation to the hairline threshold start.
         /// </summary>
@@ -763,7 +942,56 @@ namespace VRTK
         {
             return hairGripDelta;
         }
+        #endregion hairline delta getters
 
+        #region sense axis getters
+        /// <summary>
+        /// The GetTouchpadSenseAxis method returns a float representing how much of the touch sensor is being touched.
+        /// </summary>
+        /// <returns>A float representing how much the touch sensor is being touched.</returns>
+        public virtual float GetTouchpadSenseAxis()
+        {
+            return touchpadSenseAxis;
+        }
+
+        /// <summary>
+        /// The GetTriggerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+        /// </summary>
+        /// <returns>A float representing how much the touch sensor is being touched.</returns>
+        public virtual float GetTriggerSenseAxis()
+        {
+            return triggerSenseAxis;
+        }
+
+        /// <summary>
+        /// The GetMiddleFingerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+        /// </summary>
+        /// <returns>A float representing how much the touch sensor is being touched.</returns>
+        public virtual float GetMiddleFingerSenseAxis()
+        {
+            return middleFingerSenseAxis;
+        }
+
+        /// <summary>
+        /// The GetRingFingerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+        /// </summary>
+        /// <returns>A float representing how much the touch sensor is being touched.</returns>
+        public virtual float GetRingFingerSenseAxis()
+        {
+            return ringFingerSenseAxis;
+        }
+
+        /// <summary>
+        /// The GetPinkyFingerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+        /// </summary>
+        /// <returns>A float representing how much the touch sensor is being touched.</returns>
+        public virtual float GetPinkyFingerSenseAxis()
+        {
+            return pinkyFingerSenseAxis;
+        }
+        #endregion sense axis getters
+
+        #region button press getters
         /// <summary>
         /// The AnyButtonPressed method returns true if any of the controller buttons are being pressed and this can be useful to determine if an action can be taken whilst the user is using the controller.
         /// </summary>
@@ -790,6 +1018,8 @@ namespace VRTK
                     return triggerPressed;
                 case ButtonAlias.TriggerClick:
                     return triggerClicked;
+                case ButtonAlias.TriggerSense:
+                    return (triggerSenseAxis >= senseAxisPressThreshold);
                 case ButtonAlias.GripHairline:
                     return gripHairlinePressed;
                 case ButtonAlias.GripTouch:
@@ -802,6 +1032,8 @@ namespace VRTK
                     return touchpadTouched;
                 case ButtonAlias.TouchpadPress:
                     return touchpadPressed;
+                case ButtonAlias.TouchpadSense:
+                    return (touchpadSenseAxis >= senseAxisPressThreshold);
                 case ButtonAlias.ButtonOnePress:
                     return buttonOnePressed;
                 case ButtonAlias.ButtonOneTouch:
@@ -812,10 +1044,18 @@ namespace VRTK
                     return buttonTwoTouched;
                 case ButtonAlias.StartMenuPress:
                     return startMenuPressed;
+                case ButtonAlias.MiddleFingerSense:
+                    return (middleFingerSenseAxis >= senseAxisPressThreshold);
+                case ButtonAlias.RingFingerSense:
+                    return (ringFingerSenseAxis >= senseAxisPressThreshold);
+                case ButtonAlias.PinkyFingerSense:
+                    return (pinkyFingerSenseAxis >= senseAxisPressThreshold);
             }
             return false;
         }
+        #endregion button press getters
 
+        #region subscription managers
         /// <summary>
         /// The SubscribeToButtonAliasEvent method makes it easier to subscribe to a button event on either the start or end action. Upon the event firing, the given callback method is executed.
         /// </summary>
@@ -837,7 +1077,9 @@ namespace VRTK
         {
             ButtonAliasEventSubscription(false, givenButton, startEvent, callbackMethod);
         }
+        #endregion subscription managers
 
+        #region MonoBehaviour methods
         protected virtual void Awake()
         {
             VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
@@ -888,9 +1130,25 @@ namespace VRTK
                 return;
             }
 
+            CheckTriggerEvents(controllerReference);
+            CheckGripEvents(controllerReference);
+            CheckTouchpadEvents(controllerReference);
+            CheckButtonOneEvents(controllerReference);
+            CheckButtonTwoEvents(controllerReference);
+            CheckStartMenuEvents(controllerReference);
+            CheckExtraFingerEvents(controllerReference);
+        }
+        #endregion MonoBehaviour methods
+
+        protected virtual float ProcessSenseAxis(float axisValue)
+        {
+            return (axisValue >= senseAxisForceZeroThreshold ? axisValue : 0f);
+        }
+
+        protected virtual void CheckTriggerEvents(VRTK_ControllerReference controllerReference)
+        {
             Vector2 currentTriggerAxis = VRTK_SDK_Bridge.GetControllerAxis(SDK_BaseController.ButtonTypes.Trigger, controllerReference);
-            Vector2 currentGripAxis = VRTK_SDK_Bridge.GetControllerAxis(SDK_BaseController.ButtonTypes.Grip, controllerReference);
-            Vector2 currentTouchpadAxis = VRTK_SDK_Bridge.GetControllerAxis(SDK_BaseController.ButtonTypes.Touchpad, controllerReference);
+            float currentTriggerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.Trigger, controllerReference));
 
             //Trigger Touched
             if (VRTK_SDK_Bridge.GetControllerButtonState(SDK_BaseController.ButtonTypes.Trigger, SDK_BaseController.ButtonPressTypes.TouchDown, controllerReference))
@@ -949,6 +1207,25 @@ namespace VRTK
                 OnTriggerAxisChanged(SetControllerEvent(ref triggerAxisChanged, true, currentTriggerAxis.x));
             }
 
+            //Trigger Sense Axis
+            if(VRTK_SharedMethods.RoundFloat(triggerSenseAxis, axisFidelity) == VRTK_SharedMethods.RoundFloat(currentTriggerSenseAxis, axisFidelity))
+            {
+                triggerSenseAxisChanged = false;
+            }
+            else
+            {
+                OnTriggerSenseAxisChanged(SetControllerEvent(ref triggerSenseAxisChanged, true, currentTriggerSenseAxis));
+            }
+
+            triggerAxis = (triggerAxisChanged ? new Vector2(currentTriggerAxis.x, currentTriggerAxis.y) : triggerAxis);
+            triggerSenseAxis = (triggerSenseAxisChanged ? currentTriggerSenseAxis : triggerSenseAxis);
+            hairTriggerDelta = VRTK_SDK_Bridge.GetControllerHairlineDelta(SDK_BaseController.ButtonTypes.TriggerHairline, controllerReference);
+        }
+
+        protected virtual void CheckGripEvents(VRTK_ControllerReference controllerReference)
+        {
+            Vector2 currentGripAxis = VRTK_SDK_Bridge.GetControllerAxis(SDK_BaseController.ButtonTypes.Grip, controllerReference);
+
             //Grip Touched
             if (VRTK_SDK_Bridge.GetControllerButtonState(SDK_BaseController.ButtonTypes.Grip, SDK_BaseController.ButtonPressTypes.TouchDown, controllerReference))
             {
@@ -1006,6 +1283,15 @@ namespace VRTK
                 OnGripAxisChanged(SetControllerEvent(ref gripAxisChanged, true, currentGripAxis.x));
             }
 
+            gripAxis = (gripAxisChanged ? new Vector2(currentGripAxis.x, currentGripAxis.y) : gripAxis);
+            hairGripDelta = VRTK_SDK_Bridge.GetControllerHairlineDelta(SDK_BaseController.ButtonTypes.GripHairline, controllerReference);
+        }
+
+        protected virtual void CheckTouchpadEvents(VRTK_ControllerReference controllerReference)
+        {
+            Vector2 currentTouchpadAxis = VRTK_SDK_Bridge.GetControllerAxis(SDK_BaseController.ButtonTypes.Touchpad, controllerReference);
+            float currentTouchpadSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.Touchpad, controllerReference));
+
             //Touchpad Touched
             if (VRTK_SDK_Bridge.GetControllerButtonState(SDK_BaseController.ButtonTypes.Touchpad, SDK_BaseController.ButtonPressTypes.TouchDown, controllerReference))
             {
@@ -1039,6 +1325,22 @@ namespace VRTK
                 OnTouchpadAxisChanged(SetControllerEvent(ref touchpadAxisChanged, true, 1f));
             }
 
+            //Touchpad Sense Axis
+            if (VRTK_SharedMethods.RoundFloat(touchpadSenseAxis, axisFidelity) == VRTK_SharedMethods.RoundFloat(currentTouchpadSenseAxis, axisFidelity))
+            {
+                touchpadSenseAxisChanged = false;
+            }
+            else
+            {
+                OnTouchpadSenseAxisChanged(SetControllerEvent(ref touchpadSenseAxisChanged, true, currentTouchpadSenseAxis));
+            }
+
+            touchpadAxis = (touchpadAxisChanged ? new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y) : touchpadAxis);
+            touchpadSenseAxis = (touchpadSenseAxisChanged ? currentTouchpadSenseAxis : touchpadSenseAxis);
+        }
+
+        protected virtual void CheckButtonOneEvents(VRTK_ControllerReference controllerReference)
+        {
             //ButtonOne Touched
             if (VRTK_SDK_Bridge.GetControllerButtonState(SDK_BaseController.ButtonTypes.ButtonOne, SDK_BaseController.ButtonPressTypes.TouchDown, controllerReference))
             {
@@ -1060,7 +1362,10 @@ namespace VRTK
             {
                 OnButtonOneTouchEnd(SetControllerEvent(ref buttonOneTouched, false, 0f));
             }
+        }
 
+        protected virtual void CheckButtonTwoEvents(VRTK_ControllerReference controllerReference)
+        {
             //ButtonTwo Touched
             if (VRTK_SDK_Bridge.GetControllerButtonState(SDK_BaseController.ButtonTypes.ButtonTwo, SDK_BaseController.ButtonPressTypes.TouchDown, controllerReference))
             {
@@ -1082,7 +1387,10 @@ namespace VRTK
             {
                 OnButtonTwoTouchEnd(SetControllerEvent(ref buttonTwoTouched, false, 0f));
             }
+        }
 
+        protected virtual void CheckStartMenuEvents(VRTK_ControllerReference controllerReference)
+        {
             //StartMenu Pressed
             if (VRTK_SDK_Bridge.GetControllerButtonState(SDK_BaseController.ButtonTypes.StartMenu, SDK_BaseController.ButtonPressTypes.PressDown, controllerReference))
             {
@@ -1092,14 +1400,47 @@ namespace VRTK
             {
                 OnStartMenuReleased(SetControllerEvent(ref startMenuPressed, false, 0f));
             }
+        }
 
-            // Save current touch and trigger settings to detect next change.
-            touchpadAxis = (touchpadAxisChanged ? new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y) : touchpadAxis);
-            triggerAxis = (triggerAxisChanged ? new Vector2(currentTriggerAxis.x, currentTriggerAxis.y) : triggerAxis);
-            gripAxis = (gripAxisChanged ? new Vector2(currentGripAxis.x, currentGripAxis.y) : gripAxis);
+        protected virtual void CheckExtraFingerEvents(VRTK_ControllerReference controllerReference)
+        {
+            float currentMiddleFingerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.MiddleFinger, controllerReference));
+            float currentRingFingerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.RingFinger, controllerReference));
+            float currentPinkyFingerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.PinkyFinger, controllerReference));
 
-            hairTriggerDelta = VRTK_SDK_Bridge.GetControllerHairlineDelta(SDK_BaseController.ButtonTypes.TriggerHairline, controllerReference);
-            hairGripDelta = VRTK_SDK_Bridge.GetControllerHairlineDelta(SDK_BaseController.ButtonTypes.GripHairline, controllerReference);
+            //Middle Finger Sense Axis
+            if (VRTK_SharedMethods.RoundFloat(middleFingerSenseAxis, axisFidelity) == VRTK_SharedMethods.RoundFloat(currentMiddleFingerSenseAxis, axisFidelity))
+            {
+                middleFingerSenseAxisChanged = false;
+            }
+            else
+            {
+                OnMiddleFingerSenseAxisChanged(SetControllerEvent(ref middleFingerSenseAxisChanged, true, currentMiddleFingerSenseAxis));
+            }
+
+            //Ring Finger Sense Axis
+            if (VRTK_SharedMethods.RoundFloat(ringFingerSenseAxis, axisFidelity) == VRTK_SharedMethods.RoundFloat(currentRingFingerSenseAxis, axisFidelity))
+            {
+                ringFingerSenseAxisChanged = false;
+            }
+            else
+            {
+                OnRingFingerSenseAxisChanged(SetControllerEvent(ref ringFingerSenseAxisChanged, true, currentRingFingerSenseAxis));
+            }
+
+            //Pinky Finger Sense Axis
+            if (VRTK_SharedMethods.RoundFloat(pinkyFingerSenseAxis, axisFidelity) == VRTK_SharedMethods.RoundFloat(currentPinkyFingerSenseAxis, axisFidelity))
+            {
+                pinkyFingerSenseAxisChanged = false;
+            }
+            else
+            {
+                OnPinkyFingerSenseAxisChanged(SetControllerEvent(ref pinkyFingerSenseAxisChanged, true, currentPinkyFingerSenseAxis));
+            }
+
+            middleFingerSenseAxis = (middleFingerSenseAxisChanged ? currentMiddleFingerSenseAxis : middleFingerSenseAxis);
+            ringFingerSenseAxis = (ringFingerSenseAxisChanged ? currentRingFingerSenseAxis : ringFingerSenseAxis);
+            pinkyFingerSenseAxis = (pinkyFingerSenseAxisChanged ? currentPinkyFingerSenseAxis : pinkyFingerSenseAxis);
         }
 
         protected virtual void ButtonAliasEventSubscription(bool subscribe, ButtonAlias givenButton, bool startEvent, ControllerInteractionEventHandler callbackMethod)
@@ -1576,6 +1917,11 @@ namespace VRTK
             triggerAxisChanged = false;
             gripAxisChanged = false;
             touchpadAxisChanged = false;
+            triggerSenseAxisChanged = false;
+            touchpadSenseAxisChanged = false;
+            middleFingerSenseAxisChanged = false;
+            ringFingerSenseAxisChanged = false;
+            pinkyFingerSenseAxisChanged = false;
 
             VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(gameObject);
 
@@ -1591,6 +1937,12 @@ namespace VRTK
                 gripAxis = new Vector2(currentGripAxis.x, currentGripAxis.y);
                 hairTriggerDelta = VRTK_SDK_Bridge.GetControllerHairlineDelta(SDK_BaseController.ButtonTypes.TriggerHairline, controllerReference);
                 hairGripDelta = VRTK_SDK_Bridge.GetControllerHairlineDelta(SDK_BaseController.ButtonTypes.GripHairline, controllerReference);
+
+                triggerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.Trigger, controllerReference));
+                touchpadSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.Touchpad, controllerReference));
+                middleFingerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.MiddleFinger, controllerReference));
+                ringFingerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.RingFinger, controllerReference));
+                pinkyFingerSenseAxis = ProcessSenseAxis(VRTK_SDK_Bridge.GetControllerSenseAxis(SDK_BaseController.ButtonTypes.PinkyFinger, controllerReference));
             }
         }
     }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -87,6 +87,9 @@ namespace VRTK
         protected GameObject undroppableGrabbedObject;
         protected Rigidbody originalControllerAttachPoint;
         protected Coroutine attemptSetCurrentControllerAttachPoint;
+        protected int findControllerAttempts = 25;
+        protected float findControllerAttemptsDelay = 0.1f;
+
         protected VRTK_ControllerReference controllerReference
         {
             get
@@ -338,7 +341,7 @@ namespace VRTK
                 //attempt to find the attach point on the controller
                 SDK_BaseController.ControllerHand handType = VRTK_DeviceFinder.GetControllerHand(interactTouch.gameObject);
                 string elementPath = VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.AttachPoint, handType);
-                attemptSetCurrentControllerAttachPoint = StartCoroutine(SetCurrentControllerAttachPoint(elementPath, 10, 0.1f));
+                attemptSetCurrentControllerAttachPoint = StartCoroutine(SetCurrentControllerAttachPoint(elementPath, findControllerAttempts, findControllerAttemptsDelay));
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2381,6 +2381,8 @@ The script also has a public boolean pressed state for the buttons to allow the 
 ### Inspector Parameters
 
  * **Axis Fidelity:** The amount of fidelity in the changes on the axis, which is defaulted to 1. Any number higher than 2 will probably give too sensitive results.
+ * **Sense Axis Force Zero Threshold:** The level on a sense axis to reach before the sense axis is forced to 0f
+ * **Sense Axis Press Threshold:** The amount of pressure required to be applied to a sense button before considering the sense button pressed.
  * **Trigger Click Threshold:** The level on the trigger axis to reach before a click is registered.
  * **Trigger Force Zero Threshold:** The level on the trigger axis to reach before the axis is forced to 0f.
  * **Trigger Axis Zero On Untouch:** If this is checked then the trigger axis will be forced to 0f when the trigger button reports an untouch event.
@@ -2407,11 +2409,17 @@ The script also has a public boolean pressed state for the buttons to allow the 
   * `ButtonTwoTouch` - The button one is touched.
   * `ButtonTwoPress` - The button one is pressed.
   * `StartMenuPress` - The button one is pressed.
+  * `TouchpadSense` - The touchpad sense touch is active.
+  * `TriggerSense` - The trigger sense touch is active.
+  * `MiddleFingerSense` - The middle finger sense touch is active.
+  * `RingFingerSense` - The ring finger sense touch is active.
+  * `PinkyFingerSense` - The pinky finger sense touch is active.
  * `public bool triggerPressed` - This will be true if the trigger is squeezed about half way in. Default: `false`
  * `public bool triggerTouched` - This will be true if the trigger is squeezed a small amount. Default: `false`
  * `public bool triggerHairlinePressed` - This will be true if the trigger is squeezed a small amount more from any previous squeeze on the trigger. Default: `false`
  * `public bool triggerClicked` - This will be true if the trigger is squeezed all the way down. Default: `false`
  * `public bool triggerAxisChanged` - This will be true if the trigger has been squeezed more or less. Default: `false`
+ * `public bool triggerSenseAxisChanged` - This will be true if the trigger sense is being touched more or less. Default: `false`
  * `public bool gripPressed` - This will be true if the grip is squeezed about half way in. Default: `false`
  * `public bool gripTouched` - This will be true if the grip is touched. Default: `false`
  * `public bool gripHairlinePressed` - This will be true if the grip is squeezed a small amount more from any previous squeeze on the grip. Default: `false`
@@ -2420,11 +2428,15 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `public bool touchpadPressed` - This will be true if the touchpad is held down. Default: `false`
  * `public bool touchpadTouched` - This will be true if the touchpad is being touched. Default: `false`
  * `public bool touchpadAxisChanged` - This will be true if the touchpad touch position has changed. Default: `false`
+ * `public bool touchpadSenseAxisChanged` - This will be true if the touchpad sense is being touched more or less. Default: `false`
  * `public bool buttonOnePressed` - This will be true if button one is held down. Default: `false`
  * `public bool buttonOneTouched` - This will be true if button one is being touched. Default: `false`
  * `public bool buttonTwoPressed` - This will be true if button two is held down. Default: `false`
  * `public bool buttonTwoTouched` - This will be true if button two is being touched. Default: `false`
  * `public bool startMenuPressed` - This will be true if start menu is held down. Default: `false`
+ * `public bool middleFingerSenseAxisChanged` - This will be true if the middle finger sense is being touched more or less. Default: `false`
+ * `public bool ringFingerSenseAxisChanged` - This will be true if the ring finger sense is being touched more or less. Default: `false`
+ * `public bool pinkyFingerSenseAxisChanged` - This will be true if the pinky finger sense is being touched more or less. Default: `false`
  * `public bool controllerVisible` - This will be true if the controller model alias renderers are visible. Default: `true`
 
 ### Class Events
@@ -2438,6 +2450,7 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `TriggerClicked` - Emitted when the trigger is squeezed all the way down.
  * `TriggerUnclicked` - Emitted when the trigger is no longer being held all the way down.
  * `TriggerAxisChanged` - Emitted when the amount of squeeze on the trigger changes.
+ * `TriggerSenseAxisChanged` - Emitted when the amount of touch on the trigger sense changes.
  * `GripPressed` - Emitted when the grip is squeezed about half way in.
  * `GripReleased` - Emitted when the grip is released under half way.
  * `GripTouchStart` - Emitted when the grip is squeezed a small amount.
@@ -2452,6 +2465,7 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `TouchpadTouchStart` - Emitted when the touchpad is touched (without pressing down to click).
  * `TouchpadTouchEnd` - Emitted when the touchpad is no longer being touched.
  * `TouchpadAxisChanged` - Emitted when the touchpad is being touched in a different location.
+ * `TouchpadSenseAxisChanged` - Emitted when the amount of touch on the touchpad sense changes.
  * `ButtonOneTouchStart` - Emitted when button one is touched.
  * `ButtonOneTouchEnd` - Emitted when button one is no longer being touched.
  * `ButtonOnePressed` - Emitted when button one is pressed.
@@ -2462,6 +2476,9 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `ButtonTwoReleased` - Emitted when button two is released.
  * `StartMenuPressed` - Emitted when start menu is pressed.
  * `StartMenuReleased` - Emitted when start menu is released.
+ * `MiddleFingerSenseAxisChanged` - Emitted when the amount of touch on the middle finger sense changes.
+ * `RingFingerSenseAxisChanged` - Emitted when the amount of touch on the ring finger sense changes.
+ * `PinkyFingerSenseAxisChanged` - Emitted when the amount of touch on the pinky finger sense changes.
  * `ControllerEnabled` - Emitted when the controller is enabled.
  * `ControllerDisabled` - Emitted when the controller is disabled.
  * `ControllerIndexChanged` - Emitted when the controller index changed.
@@ -2572,6 +2589,61 @@ The GetHairTriggerDelta method returns a float representing the difference in ho
    * `float` - A float representing the difference in the trigger pressure from the hairline threshold start to current position.
 
 The GetHairTriggerDelta method returns a float representing the difference in how much the trigger is being pressed in relation to the hairline threshold start.
+
+#### GetTouchpadSenseAxis/0
+
+  > `public virtual float GetTouchpadSenseAxis()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `float` - A float representing how much the touch sensor is being touched.
+
+The GetTouchpadSenseAxis method returns a float representing how much of the touch sensor is being touched.
+
+#### GetTriggerSenseAxis/0
+
+  > `public virtual float GetTriggerSenseAxis()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `float` - A float representing how much the touch sensor is being touched.
+
+The GetTriggerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+
+#### GetMiddleFingerSenseAxis/0
+
+  > `public virtual float GetMiddleFingerSenseAxis()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `float` - A float representing how much the touch sensor is being touched.
+
+The GetMiddleFingerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+
+#### GetRingFingerSenseAxis/0
+
+  > `public virtual float GetRingFingerSenseAxis()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `float` - A float representing how much the touch sensor is being touched.
+
+The GetRingFingerSenseAxis method returns a float representing how much of the touch sensor is being touched.
+
+#### GetPinkyFingerSenseAxis/0
+
+  > `public virtual float GetPinkyFingerSenseAxis()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `float` - A float representing how much the touch sensor is being touched.
+
+The GetPinkyFingerSenseAxis method returns a float representing how much of the touch sensor is being touched.
 
 #### AnyButtonPressed/0
 
@@ -7735,6 +7807,9 @@ This is an abstract class to implement the interface required by all implemented
   * `Trigger` - Trigger on the controller.
   * `TriggerHairline` - Trigger Hairline on the controller.
   * `Touchpad` - Touchpad on the controller.
+  * `MiddleFinger` - Middle Finger on the controller.
+  * `RingFinger` - Ring Finger on the controller.
+  * `PinkyFinger` - Pinky Finger on the controller.
  * `public enum ButtonPressTypes` - Concepts of controller button press
   * `Press` - The button is currently being pressed.
   * `PressDown` - The button has just been pressed down.
@@ -7766,6 +7841,7 @@ This is an abstract class to implement the interface required by all implemented
   * `Oculus_OculusTouch` - The Oculus Touch controller for Oculus Utilities.
   * `Daydream_Controller` - The Daydream controller for Google Daydream SDK.
   * `Ximmerse_Flip` - The Flip controller for Ximmerse SDK.
+  * `SteamVR_ValveKnuckles` - The Valve Knuckles controller for SteamVR.
 
 ### Class Methods
 
@@ -8078,6 +8154,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
    * `Vector2` - A Vector2 of the X/Y values of the button axis. If no axis values exist for the given button, then a Vector2.Zero is returned.
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
+
+#### GetButtonSenseAxis/2
+
+  > `public abstract float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference);`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
 
 #### GetButtonHairlineDelta/2
 
@@ -8677,6 +8765,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
 
+#### GetButtonSenseAxis/2
+
+  > `public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+
 #### GetButtonHairlineDelta/2
 
   > `public override float GetButtonHairlineDelta(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -9268,6 +9368,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
    * `Vector2` - A Vector2 of the X/Y values of the button axis. If no axis values exist for the given button, then a Vector2.Zero is returned.
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
+
+#### GetButtonSenseAxis/2
+
+  > `public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
 
 #### GetButtonHairlineDelta/2
 
@@ -9880,6 +9992,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
 
+#### GetButtonSenseAxis/2
+
+  > `public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+
 #### GetButtonHairlineDelta/2
 
   > `public override float GetButtonHairlineDelta(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -10491,6 +10615,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
 
+#### GetButtonSenseAxis/2
+
+  > `public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+
 #### GetButtonHairlineDelta/2
 
   > `public override float GetButtonHairlineDelta(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -11101,6 +11237,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
 
+#### GetButtonSenseAxis/2
+
+  > `public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
+
 #### GetButtonHairlineDelta/2
 
   > `public override float GetButtonHairlineDelta(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
@@ -11699,6 +11847,18 @@ The IsTouchpadStatic method is used to determine if the touchpad is currently no
    * `Vector2` - A Vector2 of the X/Y values of the button axis. If no axis values exist for the given button, then a Vector2.Zero is returned.
 
 The GetButtonAxis method retrieves the current X/Y axis values for the given button type on the given controller reference.
+
+#### GetButtonSenseAxis/2
+
+  > `public override float GetButtonSenseAxis(ButtonTypes buttonType, VRTK_ControllerReference controllerReference)`
+
+  * Parameters
+   * `ButtonTypes buttonType` - The type of button to check for the sense axis on.
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to check the sense axis on.
+  * Returns
+   * `float` - The current sense axis value.
+
+The GetButtonSenseAxis method retrieves the current sense axis value for the given button type on the given controller reference.
 
 #### GetButtonHairlineDelta/2
 


### PR DESCRIPTION
The new Valve knuckle controllers contain cap sense buttons for
all fingers, so a new `SenseAxis` concept has been added to VRTK
that allows to check the intensity that a cap sense sensor is
being affected between `0f` and `1f`.

The Oculus Touch also supports limited cap sense buttons too so
the Oculus NearTouch concept is also supported through this new
`SenseAxis` concept.

The Valve knuckle controllers are also now supported as a means
of testing and proving the new `SenseAxis` concept works.