### PR TITLE
fix(Examples): remove unused variable to resolve warning

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerAppearance_Example.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerAppearance_Example.cs
@@ -18,7 +18,6 @@
         private float dimOpacity = 0.8f;
         private float defaultOpacity = 1f;
         private bool highlighted;
-        private bool tooltipEnabled = false;
 
         private void OnEnable()
         {


### PR DESCRIPTION
There was an unused variable introduced in the previous capsense
axis commit. The fix is to remove said variable.