### PR TITLE
fix(Interaction): prevent double unuse event

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/FireExtinguisher_Base.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/FireExtinguisher_Base.cs
@@ -1,6 +1,5 @@
 ﻿namespace VRTK.Examples
 {
-    using System;
     using UnityEngine;
 
     public class FireExtinguisher_Base : VRTK_InteractableObject
@@ -10,15 +9,15 @@
 
         private VRTK_ControllerEvents controllerEvents;
 
-        public override void StartUsing(VRTK_InteractUse usingObject)
+        public override void StartUsing(VRTK_InteractUse currentUsingObject = null)
         {
-            base.StartUsing(usingObject);
-            controllerEvents = usingObject.GetComponent<VRTK_ControllerEvents>();
+            base.StartUsing(currentUsingObject);
+            controllerEvents = currentUsingObject.GetComponent<VRTK_ControllerEvents>();
         }
 
-        public override void StopUsing(VRTK_InteractUse previousUsingObject)
+        public override void StopUsing(VRTK_InteractUse previousUsingObject = null, bool resetUsingObjectState = true)
         {
-            base.StopUsing(previousUsingObject);
+            base.StopUsing(previousUsingObject, resetUsingObjectState);
             controllerEvents = null;
         }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/LightSaber.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/LightSaber.cs
@@ -14,18 +14,18 @@
         private Color targetColor;
         private Color[] bladePhaseColors;
 
-        public override void StartUsing(VRTK_InteractUse usingObject)
+        public override void StartUsing(VRTK_InteractUse currentUsingObject = null)
         {
-            base.StartUsing(usingObject);
+            base.StartUsing(currentUsingObject);
             beamExtendSpeed = 5f;
             bladePhaseColors = new Color[2] { Color.blue, Color.cyan };
             activeColor = bladePhaseColors[0];
             targetColor = bladePhaseColors[1];
         }
 
-        public override void StopUsing(VRTK_InteractUse usingObject)
+        public override void StopUsing(VRTK_InteractUse previousUsingObject = null, bool resetUsingObjectState = true)
         {
-            base.StopUsing(usingObject);
+            base.StopUsing(previousUsingObject, resetUsingObjectState);
             beamExtendSpeed = -5f;
         }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/UseRotate.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/UseRotate.cs
@@ -20,15 +20,15 @@
 
         private float spinSpeed = 0f;
 
-        public override void StartUsing(VRTK_InteractUse usingObject)
+        public override void StartUsing(VRTK_InteractUse currentUsingObject = null)
         {
-            base.StartUsing(usingObject);
+            base.StartUsing(currentUsingObject);
             spinSpeed = activeSpinSpeed;
         }
 
-        public override void StopUsing(VRTK_InteractUse usingObject)
+        public override void StopUsing(VRTK_InteractUse previousUsingObject = null, bool resetUsingObjectState = true)
         {
-            base.StopUsing(usingObject);
+            base.StopUsing(previousUsingObject, resetUsingObjectState);
             spinSpeed = idleSpinSpeed;
         }
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Whirlygig.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Whirlygig.cs
@@ -7,15 +7,15 @@
         float spinSpeed = 0f;
         Transform rotator;
 
-        public override void StartUsing(VRTK_InteractUse usingObject)
+        public override void StartUsing(VRTK_InteractUse currentUsingObject = null)
         {
-            base.StartUsing(usingObject);
+            base.StartUsing(currentUsingObject);
             spinSpeed = 360f;
         }
 
-        public override void StopUsing(VRTK_InteractUse usingObject)
+        public override void StopUsing(VRTK_InteractUse previousUsingObject = null, bool resetUsingObjectState = true)
         {
-            base.StopUsing(usingObject);
+            base.StopUsing(previousUsingObject, resetUsingObjectState);
             spinSpeed = 0f;
         }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -354,7 +354,7 @@ namespace VRTK
                 VRTK_InteractableObject usingObjectCheck = usingObject.GetComponent<VRTK_InteractableObject>();
                 if (usingObjectCheck != null && completeStop)
                 {
-                    usingObjectCheck.StopUsing(this);
+                    usingObjectCheck.StopUsing(this, false);
                 }
                 ToggleControllerVisibility(true);
                 OnControllerUnuseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -421,11 +421,15 @@ namespace VRTK
         /// The StopUsing method is called automatically when the object has stopped being used. It is also a virtual method to allow for overriding in inherited classes.
         /// </summary>
         /// <param name="previousUsingObject">The object that was previously using this object.</param>
-        public virtual void StopUsing(VRTK_InteractUse previousUsingObject = null)
+        /// <param name="resetUsingObjectState">Resets the using object state to reset it's using action.</param>
+        public virtual void StopUsing(VRTK_InteractUse previousUsingObject = null, bool resetUsingObjectState = true)
         {
             GameObject previousUsingGameObject = (previousUsingObject != null ? previousUsingObject.gameObject : null);
             OnInteractableObjectUnused(SetInteractableObjectEvent(previousUsingGameObject));
-            ResetUsingObject();
+            if (resetUsingObjectState)
+            {
+                ResetUsingObject();
+            }
             usingState = 0;
             usingObject = null;
         }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3456,12 +3456,13 @@ The Ungrabbed method is called automatically when the object has stopped being g
 
 The StartUsing method is called automatically when the object is used initially. It is also a virtual method to allow for overriding in inherited classes.
 
-#### StopUsing/1
+#### StopUsing/2
 
-  > `public virtual void StopUsing(VRTK_InteractUse previousUsingObject = null)`
+  > `public virtual void StopUsing(VRTK_InteractUse previousUsingObject = null, bool resetUsingObjectState = true)`
 
   * Parameters
    * `VRTK_InteractUse previousUsingObject` - The object that was previously using this object.
+   * `bool resetUsingObjectState` - Resets the using object state to reset it's using action.
   * Returns
    * _none_
 


### PR DESCRIPTION
The Interact Use script was emitting two unuse events because the
Interact Use script calls StopUsing on the Interactable Object and
the Interactable Object script calls ForceResetUsing on the
Interact Use script, which would then in turn emit the unuse event
before the original StopUsing routine had finished. This would
result in two unuse events being emitted.

The fix for this is to add another check into the Interactable Object
StopUsing method that can be used to bypass the ForceResetUsing call
as it's not needed to reset the Interact Use object if the StopUsing
on the Interact Use has been called as it will already reset the state
anyway.