### PR TITLE
fix(Locomotion): get correct body physics collider in object control - fixes #1357

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
@@ -28,6 +28,7 @@ namespace VRTK
         protected float colliderHeight = 0f;
         protected Transform controlledTransform;
         protected Transform playArea;
+        protected VRTK_BodyPhysics internalBodyPhysics;
 
         protected abstract void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive);
 
@@ -51,6 +52,7 @@ namespace VRTK
                         break;
                 }
             }
+            internalBodyPhysics = (internalBodyPhysics == null ? VRTK_SharedMethods.FindEvenInactiveComponent<VRTK_BodyPhysics>() : internalBodyPhysics);
         }
 
         protected virtual void OnDisable()
@@ -110,15 +112,22 @@ namespace VRTK
 
                 if (checkObject == playArea)
                 {
-                    CapsuleCollider playAreaCollider = playArea.GetComponentInChildren<CapsuleCollider>();
-                    centerCollider = playAreaCollider;
-                    if (playAreaCollider != null)
+                    bool centerColliderSet = false;
+
+                    if (internalBodyPhysics != null && internalBodyPhysics.GetBodyColliderContainer() != null)
                     {
-                        colliderRadius = playAreaCollider.radius;
-                        colliderHeight = playAreaCollider.height;
-                        colliderCenter = playAreaCollider.center;
+                        CapsuleCollider playAreaCollider = internalBodyPhysics.GetBodyColliderContainer().GetComponent<CapsuleCollider>();
+                        centerCollider = playAreaCollider;
+                        if (playAreaCollider != null)
+                        {
+                            centerColliderSet = true;
+                            colliderRadius = playAreaCollider.radius;
+                            colliderHeight = playAreaCollider.height;
+                            colliderCenter = playAreaCollider.center;
+                        }
                     }
-                    else
+
+                    if (!centerColliderSet)
                     {
                         VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "PlayArea", "CapsuleCollider", "the same or child"));
                     }

--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SlideObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_SlideObjectControlAction.cs
@@ -41,6 +41,12 @@ namespace VRTK
             Move(controlledGameObject, directionDevice, axisDirection);
         }
 
+        protected override void OnEnable()
+        {
+            internalBodyPhysics = bodyPhysics;
+            base.OnEnable();
+        }
+
         protected virtual float CalculateSpeed(float inputValue, bool currentlyFalling, bool modifierActive)
         {
             float speed = currentSpeed;

--- a/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_WarpObjectControlAction.cs
+++ b/Assets/VRTK/Scripts/Locomotion/ObjectControlActions/VRTK_WarpObjectControlAction.cs
@@ -48,6 +48,7 @@ namespace VRTK
 
         protected override void OnEnable()
         {
+            internalBodyPhysics = bodyPhysics;
             base.OnEnable();
             headset = VRTK_DeviceFinder.HeadsetTransform();
         }


### PR DESCRIPTION
The ObjectControlAction scripts were not always getting the correct
BodyPhysics collider if no BodyPhysics was available as they were
just looking for the child CapsuleCollider and this could exist
in any of the CameraRig children such as on the Controller Objects.

This fix ensures it uses the BodyPhysics script and get the body
collider to use in the ObjectControlAction scripts.