### PR TITLE
feat(SDKManager): simplify single SDK Setup configurations

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Prefabs/SDKSetups.prefab
+++ b/Assets/VRTK/Examples/ExampleResources/Prefabs/SDKSetups.prefab
@@ -809,9 +809,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4000010242415096}
-  - component: {fileID: 20000012316479598}
   - component: {fileID: 114000011243730024}
-  - component: {fileID: 92000014137301068}
   m_Layer: 0
   m_Name: Camera (head)
   m_TagString: MainCamera
@@ -1578,7 +1576,8 @@ GameObject:
   - component: {fileID: 4000012660741642}
   - component: {fileID: 20000011176388890}
   - component: {fileID: 124000012904963108}
-  - component: {fileID: 114000012849300506}
+  - component: {fileID: 92569260401678672}
+  - component: {fileID: 114085069478805808}
   m_Layer: 0
   m_Name: Camera (eye)
   m_TagString: MainCamera
@@ -3427,40 +3426,6 @@ Camera:
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
   m_StereoMirrorMode: 0
---- !u!20 &20000012316479598
-Camera:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011840228368}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 4
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0.019607844}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0
-  far clip plane: 1
-  field of view: 60
-  orthographic: 1
-  orthographic size: 1
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 0
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 0
-  m_OcclusionCulling: 0
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!20 &20000013040785452
 Camera:
   m_ObjectHideFlags: 1
@@ -5053,12 +5018,12 @@ Behaviour:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000010426818160}
   m_Enabled: 1
---- !u!92 &92000014137301068
+--- !u!92 &92569260401678672
 Behaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011840228368}
+  m_GameObject: {fileID: 1000014132296520}
   m_Enabled: 1
 --- !u!92 &92889010644976706
 Behaviour:
@@ -5964,20 +5929,6 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.09803922}
   m_EffectDistance: {x: 1, y: 1}
   m_UseGraphicAlpha: 0
---- !u!114 &114000012849300506
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000014132296520}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6bca9ccf900ccc84c887d783321d27e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _head: {fileID: 4000010242415096}
-  _ears: {fileID: 4000013003015800}
-  wireframe: 0
 --- !u!114 &114000013231417920
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -6426,6 +6377,20 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+--- !u!114 &114085069478805808
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000014132296520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bca9ccf900ccc84c887d783321d27e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _head: {fileID: 4000010242415096}
+  _ears: {fileID: 4000013003015800}
+  wireframe: 0
 --- !u!114 &114139617658199918
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -540,14 +540,14 @@ namespace VRTK
 
             if (index == 1)
             {
-                if (!rightController.Selected)
+                if (rightController == null || !rightController.Selected)
                 {
                     return false;
                 }
             }
             else if (index == 2)
             {
-                if (!leftController.Selected)
+                if (leftController == null || !leftController.Selected)
                 {
                     return false;
                 }

--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -178,7 +178,20 @@ namespace VRTK
         /// <summary>
         /// The loaded SDK Setup. <see langword="null"/> if no setup is currently loaded.
         /// </summary>
-        public VRTK_SDKSetup loadedSetup { get; private set; }
+        public VRTK_SDKSetup loadedSetup
+        {
+            get
+            {
+                if (_loadedSetup == null && setups.Length == 1 && setups[0].isValid && setups[0].isActiveAndEnabled)
+                {
+                    _loadedSetup = setups[0];
+                }
+
+                return _loadedSetup;
+            }
+            private set { _loadedSetup = value; }
+        }
+        private VRTK_SDKSetup _loadedSetup;
         private static HashSet<VRTK_SDKInfo> _previouslyUsedSetupInfos = new HashSet<VRTK_SDKInfo>();
 
         /// <summary>
@@ -332,14 +345,20 @@ namespace VRTK
                 .ToDictionary(grouping => grouping.Key,
                               grouping => grouping.Select(info => info.description.vrDeviceName)
                                                   .Distinct()
-                                                  .Except(new[] { "None" })
                                                   .ToArray());
 
             foreach (BuildTargetGroup targetGroup in VRTK_SharedMethods.GetValidBuildTargetGroups())
             {
                 string[] deviceNames;
                 deviceNamesByTargetGroup.TryGetValue(targetGroup, out deviceNames);
+
+                int setupCount = deviceNames == null ? 0 : deviceNames.Length;
                 bool vrEnabled = deviceNames != null && deviceNames.Length > 0;
+
+                if (deviceNames != null)
+                {
+                    deviceNames = deviceNames.Except(new[] { "None" }).ToArray();
+                }
 
 #if UNITY_5_5_OR_NEWER
                 VREditor.SetVREnabledOnTargetGroup(targetGroup, vrEnabled);
@@ -347,13 +366,25 @@ namespace VRTK
                 VREditor.SetVREnabled(targetGroup, vrEnabled);
 #endif
 
+                string[] devices;
+                if (vrEnabled)
+                {
+                    devices = setupCount > 1
+                                  ? new[] { "None" }.Concat(deviceNames).ToArray()
+                                  : deviceNames;
+                }
+                else
+                {
+                    devices = new string[0];
+                }
+
 #if UNITY_5_5_OR_NEWER
                 VREditor.SetVREnabledDevicesOnTargetGroup(
 #else
                 VREditor.SetVREnabledDevices(
 #endif
                     targetGroup,
-                    vrEnabled ? new[] { "None" }.Concat(deviceNames).ToArray() : new string[0]
+                    devices
                 );
             }
         }
@@ -483,18 +514,18 @@ namespace VRTK
                 previousLoadedSetup.OnUnloaded(this);
             }
 
-            bool isDeviceAlreadyLoaded = VRSettings.enabled
-                                         && sdkSetups[0].usedVRDeviceNames.Contains(VRSettings.loadedDeviceName);
+            string loadedDeviceName = string.IsNullOrEmpty(VRSettings.loadedDeviceName) ? "None" : VRSettings.loadedDeviceName;
+            bool isDeviceAlreadyLoaded = sdkSetups[0].usedVRDeviceNames.Contains(loadedDeviceName);
             if (!isDeviceAlreadyLoaded)
             {
-                if (!tryToReinitialize && !VRSettings.enabled && !string.IsNullOrEmpty(VRSettings.loadedDeviceName))
+                if (!tryToReinitialize && !VRSettings.enabled && !string.IsNullOrEmpty(loadedDeviceName))
                 {
-                    sdkSetups = sdkSetups.Where(setup => !setup.usedVRDeviceNames.Contains(VRSettings.loadedDeviceName))
+                    sdkSetups = sdkSetups.Where(setup => !setup.usedVRDeviceNames.Contains(loadedDeviceName))
                                          .ToArray();
                 }
 
                 VRTK_SDKSetup[] missingVRDeviceSetups = sdkSetups
-                    .Where(setup => setup.usedVRDeviceNames.Except(VRSettings.supportedDevices).Any())
+                    .Where(setup => setup.usedVRDeviceNames.Except(VRSettings.supportedDevices.Concat(new[] { "None" })).Any())
                     .ToArray();
                 foreach (VRTK_SDKSetup missingVRDeviceSetup in missingVRDeviceSetups)
                 {
@@ -603,7 +634,7 @@ namespace VRTK
 
             CreateInstance();
 
-            if (autoLoadSetup)
+            if (loadedSetup == null && autoLoadSetup)
             {
                 TryLoadSDKSetupFromList();
             }

--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetupSwitcher.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKSetupSwitcher.cs
@@ -6,6 +6,7 @@ namespace VRTK
     using UnityEngine.UI;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// The SDK Setup Switcher adds a GUI overlay to allow switching the loaded VRTK_SDKSetup of the the current VRTK_SDKManager.
@@ -112,7 +113,9 @@ namespace VRTK
                     return;
             }
 
-            fallbackCamera.gameObject.SetActive(VRTK_DeviceFinder.HeadsetCamera() == null);
+            bool isAnyOtherCameraUsed = sdkManager.setups.Any(setup => setup != null && setup.gameObject.activeSelf)
+                                        || VRTK_DeviceFinder.HeadsetCamera() != null;
+            fallbackCamera.gameObject.SetActive(!isAnyOtherCameraUsed);
             eventSystem.gameObject.SetActive(EventSystem.current == null || EventSystem.current == eventSystem);
         }
 


### PR DESCRIPTION
Supporting multiple SDKs means VRTK had to disable all the SDK 
Setups that are used automatically to ensure they're usable for
runtime switching. This change allows to completely bypass the
runtime loading and that requirement in case only one SDK Setup is
used. This means users of VRTK don't have to bother with handling
when an SDK Setup is loaded and usable, nor do they have to
re-enable their SDK Setups game objects again to work on them in the
editor while they're visible.