### PR TITLE
fix(Pointer): set object interactor scale correctly on renderer - fixes #1362

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -549,7 +549,7 @@ namespace VRTK
         {
             if (objectInteractor != null)
             {
-                VRTK_SharedMethods.SetGlobalScale(transform, scaleAmount);
+                VRTK_SharedMethods.SetGlobalScale(objectInteractor.transform, scaleAmount);
             }
         }
 


### PR DESCRIPTION
The object interactor renderer was not having the scale set on it
but instead it was the whole transform of the script being rescaled
which was incorrect.