### PR TITLE
fix(Locomotion): set rotation before teleport - fixes #1291

### DIFF
--- a/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -162,13 +162,13 @@ namespace VRTK
         {
             DestinationMarkerEventArgs teleportArgs = BuildTeleportArgs(null, destinationPosition, destinationRotation);
             StartTeleport(this, teleportArgs);
+            Quaternion updatedRotation = SetNewRotation(destinationRotation);
             CalculateBlinkDelay(blinkTransitionSpeed, destinationPosition);
             Blink(blinkTransitionSpeed);
             if (ValidRigObjects())
             {
                 playArea.position = destinationPosition;
             }
-            Quaternion updatedRotation = SetNewRotation(destinationRotation);
             ProcessOrientation(this, teleportArgs, destinationPosition, updatedRotation);
             EndTeleport(this, teleportArgs);
         }
@@ -248,11 +248,11 @@ namespace VRTK
             if (enableTeleport && ValidLocation(e.target, e.destinationPosition) && e.enableTeleport)
             {
                 StartTeleport(sender, e);
+                Quaternion updatedRotation = SetNewRotation(e.destinationRotation);
                 Vector3 newPosition = GetNewPosition(e.destinationPosition, e.target, e.forceDestinationPosition);
                 CalculateBlinkDelay(blinkTransitionSpeed, newPosition);
                 Blink(blinkTransitionSpeed);
                 Vector3 updatedPosition = SetNewPosition(newPosition, e.target, e.forceDestinationPosition);
-                Quaternion updatedRotation = SetNewRotation(e.destinationRotation);
                 ProcessOrientation(sender, e, updatedPosition, updatedRotation);
                 EndTeleport(sender, e);
             }


### PR DESCRIPTION
If the rotation is set after the new teleport position
is set then the final position of the user is in the wrong
position especially if the headset compensation is on.

The fix is to ensure rotation is done before any new location
position is determined.