### PR TITLE
feat(Interaction): emit event when controller type is available

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_AvatarHandController.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_AvatarHandController.cs
@@ -190,6 +190,8 @@ namespace VRTK
         protected SDK_BaseController.ButtonTypes savedPinkyAxisButtonState;
         protected SDK_BaseController.ButtonTypes savedThreeFingerAxisButtonState;
 
+        protected VRTK_ControllerReference controllerReference;
+
         #endregion Protected class variables
 
         #region MonoBehaviour methods
@@ -200,6 +202,8 @@ namespace VRTK
             interactTouch = (interactTouch != null ? interactTouch : GetComponentInParent<VRTK_InteractTouch>());
             interactGrab = (interactGrab != null ? interactGrab : GetComponentInParent<VRTK_InteractGrab>());
             interactUse = (interactUse != null ? interactUse : GetComponentInParent<VRTK_InteractUse>());
+
+            controllerReference = VRTK_ControllerReference.GetControllerReference(controllerEvents.gameObject);
         }
 
         protected virtual void OnDisable()
@@ -577,7 +581,7 @@ namespace VRTK
 
         protected virtual void DetectController()
         {
-            controllerType = VRTK_DeviceFinder.GetCurrentControllerType();
+            controllerType = VRTK_DeviceFinder.GetCurrentControllerType(controllerReference);
             if (controllerType != SDK_BaseController.ControllerType.Undefined)
             {
                 if (setFingersForControllerType)

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -92,8 +92,13 @@ namespace VRTK
         public VRTK_HeadsetControllerAware headsetControllerAware;
         [Tooltip("If this is checked then the tooltips will be hidden when the headset is not looking at the controller.")]
         public bool hideWhenNotInView = true;
+
+        [HideInInspector]
+        [System.Obsolete("`VRTK_ControllerTooltips.retryInitMaxTries` has been deprecated as tooltip initialisation now uses the `VRTK_TrackedController.ControllerTypeAvailable` event.")]
         [Tooltip("The total number of initialisation attempts to make when waiting for the button transforms to initialise.")]
         public int retryInitMaxTries = 10;
+        [HideInInspector]
+        [System.Obsolete("`VRTK_ControllerTooltips.retryInitCounter` has been deprecated as tooltip initialisation now uses the `VRTK_TrackedController.ControllerTypeAvailable` event.")]
         [Tooltip("The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.")]
         public float retryInitCounter = 0.1f;
 
@@ -106,12 +111,11 @@ namespace VRTK
         /// </summary>
         public event ControllerTooltipsEventHandler ControllerTooltipOff;
 
-        protected bool overallState = true;
         protected TooltipButtons[] availableButtons = new TooltipButtons[0];
         protected VRTK_ObjectTooltip[] buttonTooltips = new VRTK_ObjectTooltip[0];
         protected bool[] tooltipStates = new bool[0];
-
-        protected int retryInitCurrentTries = 0;
+        protected bool overallState = true;
+        protected VRTK_TrackedController trackedController;
 
         public virtual void OnControllerTooltipOn(ControllerTooltipsEventArgs e)
         {
@@ -217,6 +221,11 @@ namespace VRTK
                 controllerEvents.ControllerEnabled -= DoControllerEnabled;
                 controllerEvents.ControllerVisible -= DoControllerVisible;
                 controllerEvents.ControllerHidden -= DoControllerInvisible;
+                controllerEvents.ControllerTypeAvailable -= DoControllerTypeAvailable;
+            }
+            else if (trackedController != null)
+            {
+                trackedController.ControllerTypeAvailable -= TrackedControllerDoControllerTypeAvailable;
             }
 
             if (headsetControllerAware != null)
@@ -265,8 +274,6 @@ namespace VRTK
             {
                 buttonTooltips[i] = transform.Find(availableButtons[i].ToString()).GetComponent<VRTK_ObjectTooltip>();
             }
-
-            retryInitCurrentTries = retryInitMaxTries;
         }
 
         protected virtual void InitListeners()
@@ -276,6 +283,15 @@ namespace VRTK
                 controllerEvents.ControllerEnabled += DoControllerEnabled;
                 controllerEvents.ControllerVisible += DoControllerVisible;
                 controllerEvents.ControllerHidden += DoControllerInvisible;
+                controllerEvents.ControllerTypeAvailable += DoControllerTypeAvailable;
+            }
+            else
+            {
+                trackedController = GetComponentInParent<VRTK_TrackedController>();
+                if (trackedController != null)
+                {
+                    trackedController.ControllerTypeAvailable += TrackedControllerDoControllerTypeAvailable;
+                }
             }
 
             headsetControllerAware = (headsetControllerAware != null ? headsetControllerAware : FindObjectOfType<VRTK_HeadsetControllerAware>());
@@ -316,6 +332,16 @@ namespace VRTK
             ToggleTips(false);
         }
 
+        protected virtual void DoControllerTypeAvailable(object sender, ControllerInteractionEventArgs e)
+        {
+            ResetTooltip();
+        }
+
+
+        protected virtual void TrackedControllerDoControllerTypeAvailable(object sender, VRTKTrackedControllerEventArgs e)
+        {
+            ResetTooltip();
+        }
 
         protected virtual void DoGlanceEnterController(object sender, HeadsetControllerAwareEventArgs e)
         {
@@ -394,13 +420,6 @@ namespace VRTK
                 {
                     tooltip.gameObject.SetActive(false);
                 }
-            }
-
-            if (!initComplete && retryInitCurrentTries > 0)
-            {
-                retryInitCurrentTries--;
-                Invoke("ResetTooltip", retryInitCounter);
-                return;
             }
 
             if (headsetControllerAware == null || !hideWhenNotInView)

--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -150,8 +150,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public abstract ControllerType GetCurrentControllerType();
+        public abstract ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null);
 
         /// <summary>
         /// The GetControllerDefaultColliderPath returns the path to the prefab that contains the collider objects for the default controller of this SDK.

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -57,8 +57,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Daydream_Controller;
         }

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -34,8 +34,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Undefined;
         }

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
@@ -89,8 +89,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             switch (OVRInput.GetActiveController())
             {

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -53,8 +53,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Simulator_Hand;
         }

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRController.cs
@@ -76,13 +76,14 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
                 case VRTK_DeviceFinder.Headsets.Vive:
-                    return GetSteamVRControllerType();
+                    return GetSteamVRControllerType(controllerReference);
                 case VRTK_DeviceFinder.Headsets.OculusRift:
                     return ControllerType.SteamVR_OculusTouch;
             }
@@ -763,17 +764,26 @@ namespace VRTK
             return null;
         }
 
-        protected virtual ControllerType GetSteamVRControllerType()
+        protected virtual ControllerType GetSteamVRControllerType(VRTK_ControllerReference controllerReference)
         {
-            VRTK_ControllerReference leftHand = VRTK_ControllerReference.GetControllerReference(GetControllerLeftHand());
-            VRTK_ControllerReference rightHand = VRTK_ControllerReference.GetControllerReference(GetControllerRightHand());
-
-            if (!VRTK_ControllerReference.IsValid(leftHand) && !VRTK_ControllerReference.IsValid(rightHand))
+            uint checkIndex;
+            if (VRTK_ControllerReference.IsValid(controllerReference))
             {
-                return ControllerType.Undefined;
+                checkIndex = controllerReference.index;
+            }
+            else
+            {
+                VRTK_ControllerReference leftHand = VRTK_ControllerReference.GetControllerReference(GetControllerLeftHand());
+                VRTK_ControllerReference rightHand = VRTK_ControllerReference.GetControllerReference(GetControllerRightHand());
+
+                if (!VRTK_ControllerReference.IsValid(leftHand) && !VRTK_ControllerReference.IsValid(rightHand))
+                {
+                    return ControllerType.Undefined;
+                }
+
+                checkIndex = (VRTK_ControllerReference.IsValid(rightHand) ? rightHand.index : leftHand.index);
             }
 
-            uint checkIndex = (VRTK_ControllerReference.IsValid(rightHand) ? rightHand.index : leftHand.index);
             string controllerType = GetRenderModelName(checkIndex).ToLower();
             if (controllerType.Contains("knuckles"))
             {

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -22,9 +22,9 @@
             GetControllerSDK().ProcessFixedUpdate(controllerReference, options);
         }
 
-        public static SDK_BaseController.ControllerType GetCurrentControllerType()
+        public static SDK_BaseController.ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
-            return GetControllerSDK().GetCurrentControllerType();
+            return GetControllerSDK().GetCurrentControllerType(controllerReference);
         }
 
         public static string GetControllerDefaultColliderPath(SDK_BaseController.ControllerHand hand)

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -75,8 +75,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Ximmerse_Flip;
         }

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -2,7 +2,6 @@
 namespace VRTK
 {
     using UnityEngine;
-    using System.Collections;
     using System.Collections.Generic;
 
     /// <summary>
@@ -75,9 +74,7 @@ namespace VRTK
         protected bool triggerWasColliding = false;
         protected bool rigidBodyForcedActive = false;
         protected Rigidbody touchRigidBody;
-        protected Coroutine attemptCreateColliderRoutine;
-        protected int findControllerAttempts = 25;
-        protected float findControllerAttemptsDelay = 0.1f;
+        protected VRTK_TrackedController trackedController;
 
         protected VRTK_ControllerReference controllerReference
         {
@@ -245,6 +242,15 @@ namespace VRTK
             return (controllerCollisionDetector != null && controllerCollisionDetector.GetComponents<Collider>().Length > 0 ? controllerCollisionDetector.GetComponents<Collider>() : controllerCollisionDetector.GetComponentsInChildren<Collider>());
         }
 
+        /// <summary>
+        /// The GetControllerType method is a shortcut to retrieve the current controller type the interact touch is attached to.
+        /// </summary>
+        /// <returns>The type of controller that the interact touch is attached to.</returns>
+        public virtual SDK_BaseController.ControllerType GetControllerType()
+        {
+            return (trackedController != null ? trackedController.GetControllerType() : SDK_BaseController.ControllerType.Undefined);
+        }
+
         protected virtual void Awake()
         {
             VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
@@ -255,18 +261,21 @@ namespace VRTK
             destroyColliderOnDisable = false;
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
             triggerRumble = false;
-            attemptCreateColliderRoutine = StartCoroutine(AttemptCreateCollider(findControllerAttempts, findControllerAttemptsDelay));
             CreateTouchRigidBody();
+            trackedController = GetComponentInParent<VRTK_TrackedController>();
+            if(trackedController != null)
+            {
+                trackedController.ControllerTypeAvailable += DoControllerTypeAvailable;
+            }
         }
 
         protected virtual void OnDisable()
         {
             ForceStopTouching();
             DestroyTouchCollider();
-            if (attemptCreateColliderRoutine != null)
+            if (trackedController != null)
             {
-                StopCoroutine(attemptCreateColliderRoutine);
-                attemptCreateColliderRoutine = null;
+                trackedController.ControllerTypeAvailable -= DoControllerTypeAvailable;
             }
         }
 
@@ -345,6 +354,11 @@ namespace VRTK
             {
                 CheckStopTouching();
             }
+        }
+
+        protected virtual void DoControllerTypeAvailable(object sender, VRTKTrackedControllerEventArgs e)
+        {
+            CreateTouchCollider();
         }
 
         protected virtual GameObject GetColliderInteractableObject(Collider collider)
@@ -492,20 +506,6 @@ namespace VRTK
                 }
             }
             return false;
-        }
-
-        protected virtual IEnumerator AttemptCreateCollider(int attempts, float delay)
-        {
-            WaitForSeconds delayInstruction = new WaitForSeconds(delay);
-            SDK_BaseController.ControllerType controllerType = VRTK_SDK_Bridge.GetCurrentControllerType();
-            while (controllerType == SDK_BaseController.ControllerType.Undefined && attempts > 0)
-            {
-                controllerType = VRTK_SDK_Bridge.GetCurrentControllerType();
-                attempts--;
-                yield return delayInstruction;
-            }
-
-            CreateTouchCollider();
         }
 
         protected virtual void CreateTouchCollider()

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
@@ -1,6 +1,7 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+    using System.Collections;
 
     public struct VRTKTrackedControllerEventArgs
     {
@@ -17,8 +18,15 @@
         public event VRTKTrackedControllerEventHandler ControllerEnabled;
         public event VRTKTrackedControllerEventHandler ControllerDisabled;
         public event VRTKTrackedControllerEventHandler ControllerIndexChanged;
+        public event VRTKTrackedControllerEventHandler ControllerTypeAvailable;
 
         protected GameObject aliasController;
+        protected Coroutine attemptFindControllerTypeRoutine;
+        protected Coroutine attemptEmitFoundControllerTypeRoutine;
+        protected int findControllerTypeAttempts = 30;
+        protected float findControllerTypeAttemptsDelay = 0.1f;
+        protected SDK_BaseController.ControllerType controllerType = SDK_BaseController.ControllerType.Undefined;
+        protected float controllerModelInitTime = 0.5f;
 
         public virtual void OnControllerEnabled(VRTKTrackedControllerEventArgs e)
         {
@@ -44,6 +52,19 @@
             }
         }
 
+        public virtual void OnControllerTypeAvailable(VRTKTrackedControllerEventArgs e)
+        {
+            if (ControllerTypeAvailable != null)
+            {
+                ControllerTypeAvailable(this, e);
+            }
+        }
+
+        public virtual SDK_BaseController.ControllerType GetControllerType()
+        {
+            return controllerType;
+        }
+
         protected virtual VRTKTrackedControllerEventArgs SetEventPayload(uint previousIndex = uint.MaxValue)
         {
             VRTKTrackedControllerEventArgs e;
@@ -67,10 +88,21 @@
 
             index = VRTK_DeviceFinder.GetControllerIndex(gameObject);
             OnControllerEnabled(SetEventPayload());
+            attemptFindControllerTypeRoutine = StartCoroutine(AttemptFindControllerType(findControllerTypeAttempts, findControllerTypeAttemptsDelay));
         }
 
         protected virtual void OnDisable()
         {
+            if (attemptFindControllerTypeRoutine != null)
+            {
+                StopCoroutine(attemptFindControllerTypeRoutine);
+            }
+
+            if (attemptEmitFoundControllerTypeRoutine != null)
+            {
+                StopCoroutine(attemptEmitFoundControllerTypeRoutine);
+            }
+
             OnControllerDisabled(SetEventPayload());
         }
 
@@ -100,6 +132,30 @@
             {
                 aliasController.SetActive(true);
             }
+        }
+
+        protected virtual IEnumerator AttemptFindControllerType(int attempts, float delay)
+        {
+            WaitForSeconds delayInstruction = new WaitForSeconds(delay);
+            controllerType = VRTK_DeviceFinder.GetCurrentControllerType(VRTK_ControllerReference.GetControllerReference(index));
+            while (controllerType == SDK_BaseController.ControllerType.Undefined && attempts > 0)
+            {
+                controllerType = VRTK_DeviceFinder.GetCurrentControllerType(VRTK_ControllerReference.GetControllerReference(index));
+                attempts--;
+                yield return delayInstruction;
+            }
+
+            if (controllerType != SDK_BaseController.ControllerType.Undefined)
+            {
+                attemptEmitFoundControllerTypeRoutine = StartCoroutine(EmitControllerTypeAvailableAfterPause());
+            }
+        }
+
+        protected virtual IEnumerator EmitControllerTypeAvailableAfterPause()
+        {
+            //pause for a short time to allow models to prep
+            yield return new WaitForSeconds(controllerModelInitTime);
+            OnControllerTypeAvailable(SetEventPayload());
         }
     }
 }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -64,6 +64,7 @@
         public ControllerInteractionEvent OnControllerEnabled = new ControllerInteractionEvent();
         public ControllerInteractionEvent OnControllerDisabled = new ControllerInteractionEvent();
         public ControllerInteractionEvent OnControllerIndexChanged = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnControllerTypeAvailable = new ControllerInteractionEvent();
 
         public ControllerInteractionEvent OnControllerVisible = new ControllerInteractionEvent();
         public ControllerInteractionEvent OnControllerHidden = new ControllerInteractionEvent();
@@ -112,6 +113,7 @@
             component.ControllerEnabled += ControllerEnabled;
             component.ControllerDisabled += ControllerDisabled;
             component.ControllerIndexChanged += ControllerIndexChanged;
+            component.ControllerTypeAvailable += ControllerTypeAvailable;
 
             component.ControllerVisible += ControllerVisible;
             component.ControllerHidden += ControllerHidden;
@@ -161,6 +163,7 @@
             component.ControllerEnabled -= ControllerEnabled;
             component.ControllerDisabled -= ControllerDisabled;
             component.ControllerIndexChanged -= ControllerIndexChanged;
+            component.ControllerTypeAvailable -= ControllerTypeAvailable;
 
             component.ControllerVisible -= ControllerVisible;
             component.ControllerHidden -= ControllerHidden;
@@ -399,6 +402,11 @@
         private void ControllerIndexChanged(object o, ControllerInteractionEventArgs e)
         {
             OnControllerIndexChanged.Invoke(o, e);
+        }
+
+        private void ControllerTypeAvailable(object o, ControllerInteractionEventArgs e)
+        {
+            OnControllerTypeAvailable.Invoke(o, e);
         }
 
         private void ControllerVisible(object o, ControllerInteractionEventArgs e)

--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -45,10 +45,11 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public static SDK_BaseController.ControllerType GetCurrentControllerType()
+        public static SDK_BaseController.ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
-            return VRTK_SDK_Bridge.GetCurrentControllerType();
+            return VRTK_SDK_Bridge.GetCurrentControllerType(controllerReference);
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
@@ -42,6 +42,28 @@ namespace VRTK
         protected float findControllerAttemptsDelay = 0.1f;
         protected Coroutine attemptFindControllerModel;
 
+        /// <summary>
+        /// The UpdateTransform method updates the Transform data on the current GameObject for the specified settings.
+        /// </summary>
+        /// <param name="controllerReference">An optional reference to the controller to update the transform with.</param>
+        public virtual void UpdateTransform(VRTK_ControllerReference controllerReference = null)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            VRTK_SDKTransformModifiers selectedModifier = GetSelectedModifier(controllerReference);
+
+            //If a modifier is found then change the transform
+            if (selectedModifier != null)
+            {
+                target.localPosition = selectedModifier.position;
+                target.localEulerAngles = selectedModifier.rotation;
+                target.localScale = selectedModifier.scale;
+            }
+        }
+
         protected virtual void OnEnable()
         {
             target = (target != null ? target : transform);
@@ -97,7 +119,7 @@ namespace VRTK
             UpdateTransform();
         }
 
-        protected virtual VRTK_SDKTransformModifiers GetSelectedModifier()
+        protected virtual VRTK_SDKTransformModifiers GetSelectedModifier(VRTK_ControllerReference controllerReference)
         {
             //attempt to find by the overall SDK set up to start with
             VRTK_SDKTransformModifiers selectedModifier = sdkOverrides.FirstOrDefault(item => item.loadedSDKSetup == sdkManager.loadedSetup);
@@ -105,28 +127,10 @@ namespace VRTK
             //If no sdk set up is found or it is null then try and find by the SDK controller
             if (selectedModifier == null)
             {
-                SDK_BaseController.ControllerType currentController = VRTK_DeviceFinder.GetCurrentControllerType();
+                SDK_BaseController.ControllerType currentController = VRTK_DeviceFinder.GetCurrentControllerType(controllerReference);
                 selectedModifier = sdkOverrides.FirstOrDefault(item => item.controllerType == currentController);
             }
             return selectedModifier;
-        }
-
-        protected virtual void UpdateTransform()
-        {
-            if (target == null)
-            {
-                return;
-            }
-
-            VRTK_SDKTransformModifiers selectedModifier = GetSelectedModifier();
-
-            //If a modifier is found then change the transform
-            if (selectedModifier != null)
-            {
-                target.localPosition = selectedModifier.position;
-                target.localEulerAngles = selectedModifier.rotation;
-                target.localScale = selectedModifier.scale;
-            }
         }
     }
 }


### PR DESCRIPTION
The Controller Type is now emitted via a new event on the
TrackedController script (which is also re-thrown by the
ControllerEvents script). This event is emitted when the type
of connected controller is known.

Previously, a number of scripts would duplicate the same coroutine
for determining when the controller type was known. This new event
removes the need for this duplication as these scripts can just
listen for this event.

The `GetCurrentControllerType` method now accepts a ControllerReference
to determine specific connected controller type. If `null` is passed
then it will attempt to get the right controller first then the left
if the right is not available.