### PR TITLE
feat(SDK): allow Android support for Oculus SDK

### DIFF
--- a/Assets/VRTK/SDK/Oculus/SDK_OculusBoundaries.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusBoundaries.cs
@@ -9,6 +9,7 @@ namespace VRTK
     /// The Oculus Boundaries SDK script provides a bridge to the Oculus SDK play area.
     /// </summary>
     [SDK_Description(typeof(SDK_OculusSystem))]
+    [SDK_Description(typeof(SDK_OculusSystem), 1)]
     public class SDK_OculusBoundaries
 #if VRTK_DEFINE_SDK_OCULUS
         : SDK_BaseBoundaries

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
@@ -10,6 +10,7 @@ namespace VRTK
     /// The Oculus Controller SDK script provides a bridge to SDK methods that deal with the input devices.
     /// </summary>
     [SDK_Description(typeof(SDK_OculusSystem))]
+    [SDK_Description(typeof(SDK_OculusSystem), 1)]
     public class SDK_OculusController
 #if VRTK_DEFINE_SDK_OCULUS
         : SDK_BaseController

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusDefines.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusDefines.cs
@@ -18,25 +18,28 @@ namespace VRTK
         /// </summary>
         public const string AvatarScriptingDefineSymbol = SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "SDK_OCULUS_AVATAR";
 
-        private const string BuildTargetGroupName = "Standalone";
-
-        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
-        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUS_UTILITIES_1_12_0_OR_NEWER", BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Standalone")]
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Android")]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUS_UTILITIES_1_12_0_OR_NEWER", "Standalone")]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUS_UTILITIES_1_12_0_OR_NEWER", "Android")]
         private static bool IsUtilitiesVersion1120OrNewer()
         {
             Version wrapperVersion = GetOculusWrapperVersion();
             return wrapperVersion != null && wrapperVersion >= new Version(1, 12, 0);
         }
 
-        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, BuildTargetGroupName)]
-        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUS_UTILITIES_1_11_0_OR_OLDER", BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Standalone")]
+        [SDK_ScriptingDefineSymbolPredicate(ScriptingDefineSymbol, "Android")]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUS_UTILITIES_1_11_0_OR_OLDER", "Standalone")]
+        [SDK_ScriptingDefineSymbolPredicate(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix + "OCULUS_UTILITIES_1_11_0_OR_OLDER", "Android")]
         private static bool IsUtilitiesVersion1110OrOlder()
         {
             Version wrapperVersion = GetOculusWrapperVersion();
             return wrapperVersion != null && wrapperVersion < new Version(1, 12, 0);
         }
 
-        [SDK_ScriptingDefineSymbolPredicate(AvatarScriptingDefineSymbol, BuildTargetGroupName)]
+        [SDK_ScriptingDefineSymbolPredicate(AvatarScriptingDefineSymbol, "Standalone")]
+        [SDK_ScriptingDefineSymbolPredicate(AvatarScriptingDefineSymbol, "Android")]
         private static bool IsAvatarAvailable()
         {
             return (IsUtilitiesVersion1120OrNewer() || IsUtilitiesVersion1110OrOlder())

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusHeadset.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusHeadset.cs
@@ -10,6 +10,7 @@ namespace VRTK
     /// The Oculus Headset SDK script provides a bridge to the Oculus SDK.
     /// </summary>
     [SDK_Description(typeof(SDK_OculusSystem))]
+    [SDK_Description(typeof(SDK_OculusSystem), 1)]
     public class SDK_OculusHeadset
 #if VRTK_DEFINE_SDK_OCULUS
         : SDK_BaseHeadset

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusSystem.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusSystem.cs
@@ -4,7 +4,8 @@ namespace VRTK
     /// <summary>
     /// The Oculus System SDK script provides a bridge to the Oculus SDK.
     /// </summary>
-    [SDK_Description("Oculus", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
+    [SDK_Description("Oculus (Rift)", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
+    [SDK_Description("Oculus (GearVR)", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Android", 1)]
     public class SDK_OculusSystem
 #if VRTK_DEFINE_SDK_OCULUS
         : SDK_BaseSystem


### PR DESCRIPTION
The Oculus SDK has been updated to also support the Android build
platform. This means that building with the Oculus SDK will allow
to be deployed on Android for GearVR.