### PR TITLE
fix(Pointer): ignore trigger colliders with play area cursor

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -522,7 +522,7 @@ namespace VRTK
 
         protected virtual bool ValidTarget(Collider collider)
         {
-            return (!VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && !(VRTK_PolicyList.Check(collider.gameObject, targetListPolicy)));
+            return (!collider.isTrigger && !VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && !(VRTK_PolicyList.Check(collider.gameObject, targetListPolicy)));
         }
     }
 }


### PR DESCRIPTION
The Play Area Cursor was considering a collision with a trigger
collider an actual collision therefore teleporting into trigger
colliders was not possible.

This fix ensures that colliders that are set to trigger are no
longer considered a valid collision target.