### PR TITLE
fix(SDK): ensure oculus touch uses correct controller for button press

### DIFF
--- a/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusController.cs
@@ -714,7 +714,7 @@ namespace VRTK
             VRTK_TrackedController device = GetTrackedObject(GetControllerByIndex(index));
             if (device != null)
             {
-                OVRInput.Controller controllerMask = GetControllerMask(device.index);
+                OVRInput.Controller controllerMask = GetControllerMask(index);
                 switch (type)
                 {
                     case ButtonPressTypes.Press:
@@ -739,7 +739,7 @@ namespace VRTK
             VRTK_TrackedController device = GetTrackedObject(GetControllerByIndex(index));
             if (device != null)
             {
-                OVRInput.Controller controllerMask = GetControllerMask(device.index);
+                OVRInput.Controller controllerMask = GetControllerMask(index);
                 switch (type)
                 {
                     case ButtonPressTypes.Touch:
@@ -760,6 +760,8 @@ namespace VRTK
 
             switch (activeControllerType)
             {
+                case OVRInput.Controller.Touch:
+                    return (index == 0 ? OVRInput.Controller.LTouch : (index == 1 ? OVRInput.Controller.RTouch : OVRInput.Controller.None));
                 case OVRInput.Controller.LTouch:
                     return (index == 0 ? OVRInput.Controller.LTouch : OVRInput.Controller.None);
                 case OVRInput.Controller.RTouch:


### PR DESCRIPTION
The Oculus controller SDK was returning the same controller type for
both button presses, meaning the left controller (or index 0) was
initiating button presses on both controllers.

This has been fixed now by also checking for the generic `Touch`
controller type and using the given index to determine which
touch controller is being used.