### PR TITLE
refactor(ControllerTooltips): initialise arrays in declaration

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ControllerTooltips.cs
@@ -106,9 +106,9 @@ namespace VRTK
         /// </summary>
         public event ControllerTooltipsEventHandler ControllerTooltipOff;
 
-        protected TooltipButtons[] availableButtons;
-        protected VRTK_ObjectTooltip[] buttonTooltips;
-        protected bool[] tooltipStates;
+        protected TooltipButtons[] availableButtons = new TooltipButtons[0];
+        protected VRTK_ObjectTooltip[] buttonTooltips = new VRTK_ObjectTooltip[0];
+        protected bool[] tooltipStates = new bool[0];
 
         protected int retryInitCurrentTries = 0;
 


### PR DESCRIPTION
To prevent any unwanted null reference exceptions, the arrays in
the controller tooltips have been initialised to a default size
so if they're called before the init code is run then they at
least will be valid empty arrays.