### PR TITLE
Fixes root cause of Issue #1379

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -1235,6 +1235,10 @@ namespace VRTK
                     {
                         snapDropZoneJoint.connectedBody = null;
                     }
+                    if (interactableRigidbody != null) //If it has a rigidbody make sure we did not mess up its Kinematic State
+                    {
+                        interactableRigidbody.isKinematic = previousKinematicState;
+                    }
                     break;
             }
 


### PR DESCRIPTION
Fixes root cause of Default Objects Lock up when unsnapped from code #1379 This time in the correct version of the repo still not sure how that happened last time. This makes sure to restore kinematic state of SnapTypes.UseJoint objects not just SnapTypes.UseKinematic and SnapTypes.UseParenting