### PR TITLE
fix(SDKManager): fall back to Simulator SDK Setup

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -518,7 +518,7 @@ namespace VRTK
             bool isDeviceAlreadyLoaded = sdkSetups[0].usedVRDeviceNames.Contains(loadedDeviceName);
             if (!isDeviceAlreadyLoaded)
             {
-                if (!tryToReinitialize && !VRSettings.enabled && !string.IsNullOrEmpty(loadedDeviceName))
+                if (!tryToReinitialize && !VRSettings.enabled && loadedDeviceName != "None")
                 {
                     sdkSetups = sdkSetups.Where(setup => !setup.usedVRDeviceNames.Contains(loadedDeviceName))
                                          .ToArray();


### PR DESCRIPTION
The SDK Manager never fell back to the Simulator SDK Setup after the
recent changes to allow for single SDK Setup configurations. The fix
is to update a check that previously relied on the fact that a
variable was null or an empty string, but is now always set.