### PR TITLE
fix(pointers): Preserve last known angle for direction indicator.

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
@@ -112,7 +112,7 @@ namespace VRTK
 
         protected virtual void Update()
         {
-            if (controllerEvents != null)
+            if (controllerEvents != null && controllerEvents.touchpadTouched && controllerEvents.touchpadAxisChanged)
             {
                 float touchpadAngle = controllerEvents.GetTouchpadAxisAngle();
                 float angle = ((touchpadAngle > 180) ? touchpadAngle -= 360 : touchpadAngle) + headset.eulerAngles.y;


### PR DESCRIPTION
Made the direction indicator only update when there is valid input rather than snapping back to zero when letting go of the analog stick.  Preserving the last known angle seems like the expected behavior.