### PR TITLE
refactor(SnapDropZone): reduce GetComponent calls in update

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -100,6 +100,7 @@ namespace VRTK
         protected GameObject highlightObject;
         protected GameObject highlightEditorObject = null;
         protected List<GameObject> currentValidSnapObjects = new List<GameObject>();
+        protected List<VRTK_InteractableObject> currentValidSnapInteractableObjects = new List<VRTK_InteractableObject>();
         protected GameObject currentSnappedObject = null;
         protected GameObject objectToClone = null;
         protected bool[] clonedObjectColliderStates = new bool[0];
@@ -110,6 +111,7 @@ namespace VRTK
         protected bool isHighlighted = false;
         protected Coroutine transitionInPlace;
         protected bool originalJointCollisionState = false;
+        protected VRTK_InteractableObject cachedCheckObject;
 
         protected const string HIGHLIGHT_CONTAINER_NAME = "HighlightContainer";
         protected const string HIGHLIGHT_OBJECT_NAME = "HighlightObject";
@@ -325,8 +327,11 @@ namespace VRTK
 
         protected virtual VRTK_InteractableObject ValidSnapObject(GameObject checkObject, bool grabState, bool checkGrabState = true)
         {
-            var ioCheck = checkObject.GetComponentInParent<VRTK_InteractableObject>();
-            return (ioCheck != null && (!checkGrabState || ioCheck.IsGrabbed() == grabState) && !VRTK_PolicyList.Check(ioCheck.gameObject, validObjectListPolicy) ? ioCheck : null);
+            if (cachedCheckObject == null || checkObject != cachedCheckObject.gameObject)
+            {
+                cachedCheckObject = checkObject.GetComponentInParent<VRTK_InteractableObject>();
+            }
+            return (cachedCheckObject != null && (!checkGrabState || cachedCheckObject.IsGrabbed() == grabState) && !VRTK_PolicyList.Check(cachedCheckObject.gameObject, validObjectListPolicy) ? cachedCheckObject : null);
         }
 
         protected virtual string ObjectPath(string name)
@@ -392,11 +397,11 @@ namespace VRTK
             //If there is a current valid snap object
             for (int i = 0; i < currentValidSnapObjects.Count; i++)
             {
-                var currentIOCheck = currentValidSnapObjects[i].GetComponentInParent<VRTK_InteractableObject>();
+                VRTK_InteractableObject currentIOCheck = currentValidSnapInteractableObjects[i];
                 //and the interactbale object associated with it has been snapped to another zone, then unset the current valid snap object
                 if (currentIOCheck != null && currentIOCheck.GetStoredSnapDropZone() != null && currentIOCheck.GetStoredSnapDropZone() != gameObject)
                 {
-                    RemoveCurrentValidSnapObject(currentValidSnapObjects[i]);
+                    RemoveCurrentValidSnapObject(currentIOCheck);
                     if (isHighlighted && highlightObject != null && !highlightAlwaysActive)
                     {
                         highlightObject.SetActive(false);
@@ -627,7 +632,7 @@ namespace VRTK
 
         protected virtual void SetSnapDropZoneJoint(Rigidbody snapTo)
         {
-            var snapDropZoneJoint = GetComponent<Joint>();
+            Joint snapDropZoneJoint = GetComponent<Joint>();
             if (snapDropZoneJoint == null)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "SnapDropZone:" + name, "Joint", "the same", " because the `Snap Type` is set to `Use Joint`"));
@@ -647,7 +652,7 @@ namespace VRTK
 
         protected virtual void ResetSnapDropZoneJoint()
         {
-            var snapDropZoneJoint = GetComponent<Joint>();
+            Joint snapDropZoneJoint = GetComponent<Joint>();
             if (snapDropZoneJoint != null)
             {
                 snapDropZoneJoint.enableCollision = originalJointCollisionState;
@@ -656,17 +661,49 @@ namespace VRTK
 
         protected virtual void AddCurrentValidSnapObject(GameObject givenObject)
         {
-            if (!currentValidSnapObjects.Contains(givenObject))
+            if (givenObject != null)
             {
-                currentValidSnapObjects.Add(givenObject);
+                AddCurrentValidSnapObject(givenObject.GetComponentInParent<VRTK_InteractableObject>());
+            }
+        }
+
+        protected virtual void AddCurrentValidSnapObject(VRTK_InteractableObject givenObject)
+        {
+            if (givenObject != null)
+            {
+                if (!currentValidSnapObjects.Contains(givenObject.gameObject))
+                {
+                    currentValidSnapObjects.Add(givenObject.gameObject);
+                }
+
+                if (!currentValidSnapInteractableObjects.Contains(givenObject))
+                {
+                    currentValidSnapInteractableObjects.Add(givenObject);
+                }
             }
         }
 
         protected virtual void RemoveCurrentValidSnapObject(GameObject givenObject)
         {
-            if (currentValidSnapObjects.Contains(givenObject))
+            if (givenObject != null)
             {
-                currentValidSnapObjects.Remove(givenObject);
+                RemoveCurrentValidSnapObject(givenObject.GetComponentInParent<VRTK_InteractableObject>());
+            }
+        }
+
+        protected virtual void RemoveCurrentValidSnapObject(VRTK_InteractableObject givenObject)
+        {
+            if (givenObject != null)
+            {
+                if (currentValidSnapObjects.Contains(givenObject.gameObject))
+                {
+                    currentValidSnapObjects.Remove(givenObject.gameObject);
+                }
+
+                if (currentValidSnapInteractableObjects.Contains(givenObject))
+                {
+                    currentValidSnapInteractableObjects.Remove(givenObject);
+                }
             }
         }
 
@@ -772,9 +809,10 @@ namespace VRTK
             if (highlightObject != null && highlightEditorObject == null && transform.Find(ObjectPath(HIGHLIGHT_EDITOR_OBJECT_NAME)) == null)
             {
                 CopyObject(highlightObject, ref highlightEditorObject, HIGHLIGHT_EDITOR_OBJECT_NAME);
-                foreach (Renderer renderer in highlightEditorObject.GetComponentsInChildren<Renderer>())
+                Renderer[] renderers = highlightEditorObject.GetComponentsInChildren<Renderer>();
+                for (int i = 0; i < renderers.Length; i++)
                 {
-                    renderer.material = Resources.Load("SnapDropZoneEditorObject") as Material;
+                    renderers[i].material = Resources.Load("SnapDropZoneEditorObject") as Material;
                 }
                 highlightEditorObject.SetActive(true);
             }
@@ -783,7 +821,7 @@ namespace VRTK
         protected virtual void CleanHighlightObject(GameObject objectToClean)
         {
             //If the highlight object has any child snap zones, then force delete these
-            var deleteSnapZones = objectToClean.GetComponentsInChildren<VRTK_SnapDropZone>(true);
+            VRTK_SnapDropZone[] deleteSnapZones = objectToClean.GetComponentsInChildren<VRTK_SnapDropZone>(true);
             for (int i = 0; i < deleteSnapZones.Length; i++)
             {
                 ChooseDestroyType(deleteSnapZones[i].gameObject);
@@ -793,17 +831,17 @@ namespace VRTK
             string[] validComponents = new string[] { "Transform", "MeshFilter", "MeshRenderer", "SkinnedMeshRenderer", "VRTK_GameObjectLinker" };
 
             //go through all of the components on the highlighted object and delete any components that aren't in the valid component list
-            var components = objectToClean.GetComponentsInChildren<Component>(true);
+            Component[] components = objectToClean.GetComponentsInChildren<Component>(true);
             for (int i = 0; i < components.Length; i++)
             {
                 Component component = components[i];
-                var valid = false;
+                bool valid = false;
 
                 //Loop through each valid component and check to see if this component is valid
-                foreach (string validComponent in validComponents)
+                for (int j = 0; j < validComponents.Length; j++)
                 {
                     //if it's a valid component then break the check
-                    if (component.GetType().ToString().Contains("." + validComponent))
+                    if (component.GetType().ToString().Contains("." + validComponents[j]))
                     {
                         valid = true;
                         break;
@@ -843,11 +881,12 @@ namespace VRTK
             //if the object highlighter is using a cloned object then disable the created highlight object's renderers
             if (objectHighlighter.UsesClonedObject())
             {
-                foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+                Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+                for (int i = 0; i < renderers.Length; i++)
                 {
-                    if (!VRTK_PlayerObject.IsPlayerObject(renderer.gameObject, VRTK_PlayerObject.ObjectTypes.Highlighter))
+                    if (!VRTK_PlayerObject.IsPlayerObject(renderers[i].gameObject, VRTK_PlayerObject.ObjectTypes.Highlighter))
                     {
-                        renderer.enabled = false;
+                        renderers[i].enabled = false;
                     }
                 }
             }


### PR DESCRIPTION
The SnapDropZone script would continually call `GetComponent` in the
`Update` method as well as in the `OnTriggerStay` method to attempt
to get the Interactable Object component of the snappable GameObject.

This was an inefficient call and has been replaced with a cached
version of the interactable object to ensure the inefficient
`GetComponent` call is removed from the `Update` and `OnTriggerStay`
methods.