### PR TITLE
fix(Pointer): ensure direction indicator is only set on touch

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
@@ -112,7 +112,7 @@ namespace VRTK
 
         protected virtual void Update()
         {
-            if (controllerEvents != null)
+            if (controllerEvents != null && controllerEvents.touchpadTouched)
             {
                 float touchpadAngle = controllerEvents.GetTouchpadAxisAngle();
                 float angle = ((touchpadAngle > 180) ? touchpadAngle -= 360 : touchpadAngle) + headset.eulerAngles.y;


### PR DESCRIPTION
The Pointer Direction Indicator would always have its rotation set
in the update even when releasing the touchpad which would cause
the pointer direction indicator rotation to be reset to the default
and make it look as if it snapped back to the original rotation.

This fix only updates the rotation if the touchpad is being touched.