### PR TITLE
fix(Controls): ensure drawer snap force handles rotation correctly - fixes #1397

### DIFF
--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Drawer.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Drawer.cs
@@ -169,7 +169,7 @@ namespace VRTK
             }
             if (drawerSnapForceCreated)
             {
-                drawerSnapForce.force = GetThirdDirection(drawerJoint.axis, drawerJoint.secondaryAxis) * (subDirection * -50f);
+                drawerSnapForce.force = transform.TransformDirection(drawerJoint.axis) * (subDirection * 50f);
             }
 
             return true;


### PR DESCRIPTION
The Drawer 3D Control would not deal with the snap force correctly
if the drawer was rotated and it would apply the snap force in the
wrong direction causing the drawer to push open on it's own.

Thanks to @RobCob for the fix.