### PR TITLE
fix(Pointer): child straight pointer renderer to smoothing object - fixes #1394

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_StraightPointerRenderer.cs
@@ -48,7 +48,7 @@ namespace VRTK
         /// </summary>
         public override void UpdateRenderer()
         {
-            if ((controllingPointer && controllingPointer.IsPointerActive()) || IsVisible())
+            if ((controllingPointer != null && controllingPointer.IsPointerActive()) || IsVisible())
             {
                 float tracerLength = CastRayForward();
                 SetPointerAppearance(tracerLength);
@@ -75,13 +75,16 @@ namespace VRTK
         protected override void CreatePointerObjects()
         {
             actualContainer = new GameObject(VRTK_SharedMethods.GenerateVRTKObjectName(true, gameObject.name, "StraightPointerRenderer_Container"));
+            actualContainer.transform.SetParent(pointerOriginTransformFollowGameObject.transform);
             actualContainer.transform.localPosition = Vector3.zero;
+            actualContainer.transform.localRotation = Quaternion.identity;
+            actualContainer.transform.localScale = Vector3.one;
             VRTK_PlayerObject.SetPlayerObject(actualContainer, VRTK_PlayerObject.ObjectTypes.Pointer);
 
             CreateTracer();
             CreateCursor();
             Toggle(false, false);
-            if (controllingPointer)
+            if (controllingPointer != null)
             {
                 controllingPointer.ResetActivationTimer(true);
                 controllingPointer.ResetSelectionTimer(true);
@@ -107,7 +110,7 @@ namespace VRTK
         {
             base.UpdateObjectInteractor();
             //if the object interactor is too far from the pointer tip then set it to the pointer tip position to prevent glitching.
-            if (objectInteractor && actualCursor && Vector3.Distance(objectInteractor.transform.position, actualCursor.transform.position) > 0f)
+            if (objectInteractor != null && actualCursor != null && Vector3.Distance(objectInteractor.transform.position, actualCursor.transform.position) > 0f)
             {
                 objectInteractor.transform.position = actualCursor.transform.position;
             }
@@ -115,7 +118,7 @@ namespace VRTK
 
         protected virtual void CreateTracer()
         {
-            if (customTracer)
+            if (customTracer != null)
             {
                 actualTracer = Instantiate(customTracer);
             }
@@ -137,7 +140,7 @@ namespace VRTK
 
         protected virtual void CreateCursor()
         {
-            if (customCursor)
+            if (customCursor != null)
             {
                 actualCursor = Instantiate(customCursor);
             }
@@ -160,7 +163,7 @@ namespace VRTK
 
         protected virtual void CheckRayMiss(bool rayHit, RaycastHit pointerCollidedWith)
         {
-            if (!rayHit || (destinationHit.collider && destinationHit.collider != pointerCollidedWith.collider))
+            if (!rayHit || (destinationHit.collider != null && destinationHit.collider != pointerCollidedWith.collider))
             {
                 if (destinationHit.collider != null)
                 {
@@ -206,7 +209,7 @@ namespace VRTK
 
         protected virtual void SetPointerAppearance(float tracerLength)
         {
-            if (actualContainer)
+            if (actualContainer != null)
             {
                 //if the additional decimal isn't added then the beam position glitches
                 float beamPosition = tracerLength / (2f + BEAM_ADJUST_OFFSET);
@@ -217,13 +220,11 @@ namespace VRTK
                 actualCursor.transform.localPosition = new Vector3(0f, 0f, tracerLength);
 
                 Transform origin = GetOrigin();
-                actualContainer.transform.position = origin.position;
-                actualContainer.transform.rotation = origin.rotation;
 
                 float objectInteractorScaleIncrease = 1.05f;
                 ScaleObjectInteractor(actualCursor.transform.lossyScale * objectInteractorScaleIncrease);
 
-                if (destinationHit.transform)
+                if (destinationHit.transform != null)
                 {
                     if (cursorMatchTargetRotation)
                     {


### PR DESCRIPTION
There was an issue with the Straight Pointer Renderer with GearVR
and the Simulator where it would lag behind the controller due to
how the position of the pointer tracer was being updated to always
match the smoothing object position, which was in turn being matched
to the actual controller position with TransformFollow.

The solution is simply childing the pointer container to the
smoothing Game Object so it doesn't need the secondary update which
causes the lag.