### PR TITLE
feat(Pointer): allow direction indicator to be visible with cursor

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
@@ -19,6 +19,17 @@ namespace VRTK
     /// </remarks>
     public class VRTK_PointerDirectionIndicator : MonoBehaviour
     {
+        /// <summary>
+        /// States of Direction Indicator Visibility.
+        /// </summary>
+        /// <param name="OnWhenPointerActive">Only shows the direction indicator when the pointer is active.</param>
+        /// <param name="AlwaysOnWithPointerCursor">Only shows the direction indicator when the pointer cursor is visible or if the cursor is hidden and the pointer is active.</param>
+        public enum VisibilityState
+        {
+            OnWhenPointerActive,
+            AlwaysOnWithPointerCursor
+        }
+
         [Header("Appearance Settings")]
 
         [Tooltip("If this is checked then the reported rotation will include the offset of the headset rotation in relation to the play area.")]
@@ -27,6 +38,8 @@ namespace VRTK
         public bool displayOnInvalidLocation = true;
         [Tooltip("If this is checked then the pointer valid/invalid colours will also be used to change the colour of the direction indicator.")]
         public bool usePointerColor = false;
+        [Tooltip("Determines when the direction indicator will be visible.")]
+        public VisibilityState indicatorVisibility = VisibilityState.OnWhenPointerActive;
 
         [HideInInspector]
         public bool isActive = true;

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PointerDirectionIndicator.cs
@@ -30,6 +30,10 @@ namespace VRTK
             AlwaysOnWithPointerCursor
         }
 
+        [Header("Control Settings")]
+        [Tooltip("The touchpad axis needs to be above this deadzone for it to register as a valid touchpad angle.")]
+        public Vector2 touchpadDeadzone = Vector2.zero;
+
         [Header("Appearance Settings")]
 
         [Tooltip("If this is checked then the reported rotation will include the offset of the headset rotation in relation to the play area.")]
@@ -125,12 +129,17 @@ namespace VRTK
 
         protected virtual void Update()
         {
-            if (controllerEvents != null && controllerEvents.touchpadTouched && controllerEvents.GetTouchpadAxis() != Vector2.zero)
+            if (controllerEvents != null && controllerEvents.touchpadTouched && !InsideDeadzone(controllerEvents.GetTouchpadAxis()))
             {
                 float touchpadAngle = controllerEvents.GetTouchpadAxisAngle();
                 float angle = ((touchpadAngle > 180) ? touchpadAngle -= 360 : touchpadAngle) + headset.eulerAngles.y;
                 transform.localEulerAngles = new Vector3(0f, angle, 0f);
             }
+        }
+
+        protected virtual bool InsideDeadzone(Vector2 currentAxis)
+        {
+            return (currentAxis == Vector2.zero || (Mathf.Abs(currentAxis.x) <= touchpadDeadzone.x && Mathf.Abs(currentAxis.y) <= touchpadDeadzone.y));
         }
     }
 }

--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -611,7 +611,19 @@ namespace VRTK
         protected virtual void UpdateDirectionIndicator()
         {
             RaycastHit destinationHit = GetDestinationHit();
-            directionIndicator.SetPosition((controllingPointer.IsPointerActive() && destinationHit.collider != null), destinationHit.point);
+            directionIndicator.SetPosition((ShowDirectionIndicator() && destinationHit.collider != null), destinationHit.point);
+        }
+
+        protected virtual bool ShowDirectionIndicator()
+        {
+            switch (directionIndicator.indicatorVisibility)
+            {
+                case VRTK_PointerDirectionIndicator.VisibilityState.OnWhenPointerActive:
+                    return controllingPointer.IsPointerActive();
+                case VRTK_PointerDirectionIndicator.VisibilityState.AlwaysOnWithPointerCursor:
+                    return (IsCursorVisible() || controllingPointer.IsPointerActive());
+            }
+            return false;
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -771,6 +771,7 @@ This can be useful for rotating the play area upon teleporting to face the user 
 
 ### Inspector Parameters
 
+ * **Touchpad Deadzone:** The touchpad axis needs to be above this deadzone for it to register as a valid touchpad angle.
  * **Include Headset Offset:** If this is checked then the reported rotation will include the offset of the headset rotation in relation to the play area.
  * **Display On Invalid Location:** If this is checked then the direction indicator will be displayed when the location is invalid.
  * **Use Pointer Color:** If this is checked then the pointer valid/invalid colours will also be used to change the colour of the direction indicator.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -774,6 +774,13 @@ This can be useful for rotating the play area upon teleporting to face the user 
  * **Include Headset Offset:** If this is checked then the reported rotation will include the offset of the headset rotation in relation to the play area.
  * **Display On Invalid Location:** If this is checked then the direction indicator will be displayed when the location is invalid.
  * **Use Pointer Color:** If this is checked then the pointer valid/invalid colours will also be used to change the colour of the direction indicator.
+ * **Indicator Visibility:** Determines when the direction indicator will be visible.
+
+### Class Variables
+
+ * `public enum VisibilityState` - States of Direction Indicator Visibility.
+  * `OnWhenPointerActive` - Only shows the direction indicator when the pointer is active.
+  * `AlwaysOnWithPointerCursor` - Only shows the direction indicator when the pointer cursor is visible or if the cursor is hidden and the pointer is active.
 
 ### Class Events
 


### PR DESCRIPTION
A new option has been added to the Pointer Direction Indicator
so it can always be visible when the pointer cursor is visible.

This allows for the `Always On` setting for the cursor on the
pointer renderer to always determine if the direction indicator
is also on.

Even if the `Always Off` setting is on for the cursor then the
pointer direction indicator will still become visible when
the pointer is activated.