### PR TITLE
feat(Interaction): emit event when controller model is available

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_AvatarHandController.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_AvatarHandController.cs
@@ -190,6 +190,8 @@ namespace VRTK
         protected SDK_BaseController.ButtonTypes savedPinkyAxisButtonState;
         protected SDK_BaseController.ButtonTypes savedThreeFingerAxisButtonState;
 
+        protected VRTK_ControllerReference controllerReference;
+
         #endregion Protected class variables
 
         #region MonoBehaviour methods
@@ -200,6 +202,8 @@ namespace VRTK
             interactTouch = (interactTouch != null ? interactTouch : GetComponentInParent<VRTK_InteractTouch>());
             interactGrab = (interactGrab != null ? interactGrab : GetComponentInParent<VRTK_InteractGrab>());
             interactUse = (interactUse != null ? interactUse : GetComponentInParent<VRTK_InteractUse>());
+
+            controllerReference = VRTK_ControllerReference.GetControllerReference(controllerEvents.gameObject);
         }
 
         protected virtual void OnDisable()
@@ -577,7 +581,7 @@ namespace VRTK
 
         protected virtual void DetectController()
         {
-            controllerType = VRTK_DeviceFinder.GetCurrentControllerType();
+            controllerType = VRTK_DeviceFinder.GetCurrentControllerType(controllerReference);
             if (controllerType != SDK_BaseController.ControllerType.Undefined)
             {
                 if (setFingersForControllerType)

--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamController.cs
@@ -57,8 +57,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Daydream_Controller;
         }
@@ -211,6 +212,16 @@ namespace VRTK
         public override bool IsControllerRightHand(GameObject controller, bool actual)
         {
             return true;
+        }
+
+        /// <summary>
+        /// The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
+        /// </summary>
+        /// <param name="hand">The hand to determine if the controller model will be ready for.</param>
+        /// <returns>Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.</returns>
+        public override bool WaitForControllerModel(ControllerHand hand)
+        {
+            return false;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/SDK/Fallback/SDK_FallbackController.cs
@@ -34,8 +34,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Undefined;
         }
@@ -161,6 +162,16 @@ namespace VRTK
         /// <param name="actual">If true it will check the actual controller, if false it will check the script alias controller.</param>
         /// <returns>Returns true if the given controller is the right hand controller.</returns>
         public override bool IsControllerRightHand(GameObject controller, bool actual)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
+        /// </summary>
+        /// <param name="hand">The hand to determine if the controller model will be ready for.</param>
+        /// <returns>Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.</returns>
+        public override bool WaitForControllerModel(ControllerHand hand)
         {
             return false;
         }

--- a/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimController.cs
@@ -53,8 +53,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Simulator_Hand;
         }
@@ -236,6 +237,16 @@ namespace VRTK
         public override bool IsControllerRightHand(GameObject controller, bool actual)
         {
             return CheckControllerRightHand(controller, actual);
+        }
+
+        /// <summary>
+        /// The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
+        /// </summary>
+        /// <param name="hand">The hand to determine if the controller model will be ready for.</param>
+        /// <returns>Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.</returns>
+        public override bool WaitForControllerModel(ControllerHand hand)
+        {
+            return false;
         }
 
         /// <summary>

--- a/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/VRTK_SDK_Bridge.cs
@@ -22,9 +22,9 @@
             GetControllerSDK().ProcessFixedUpdate(controllerReference, options);
         }
 
-        public static SDK_BaseController.ControllerType GetCurrentControllerType()
+        public static SDK_BaseController.ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
-            return GetControllerSDK().GetCurrentControllerType();
+            return GetControllerSDK().GetCurrentControllerType(controllerReference);
         }
 
         public static string GetControllerDefaultColliderPath(SDK_BaseController.ControllerHand hand)
@@ -99,19 +99,24 @@
             return GetControllerSDK().IsControllerRightHand(controller, actual);
         }
 
+        public static bool WaitForControllerModel(SDK_BaseController.ControllerHand hand)
+        {
+            return GetControllerSDK().WaitForControllerModel(hand);
+        }
+
         public static GameObject GetControllerModel(GameObject controller)
         {
             return GetControllerSDK().GetControllerModel(controller);
         }
 
-        public static SDK_BaseController.ControllerHand GetControllerModelHand(GameObject controllerModel)
-        {
-            return GetControllerSDK().GetControllerModelHand(controllerModel);
-        }
-
         public static GameObject GetControllerModel(SDK_BaseController.ControllerHand hand)
         {
             return GetControllerSDK().GetControllerModel(hand);
+        }
+
+        public static SDK_BaseController.ControllerHand GetControllerModelHand(GameObject controllerModel)
+        {
+            return GetControllerSDK().GetControllerModelHand(controllerModel);
         }
 
         public static GameObject GetControllerRenderModel(VRTK_ControllerReference controllerReference)

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -75,8 +75,9 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public override ControllerType GetCurrentControllerType()
+        public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
             return ControllerType.Ximmerse_Flip;
         }
@@ -271,6 +272,16 @@ namespace VRTK
         public override bool IsControllerRightHand(GameObject controller, bool actual)
         {
             return CheckControllerRightHand(controller, actual);
+        }
+
+        /// <summary>
+        /// The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
+        /// </summary>
+        /// <param name="hand">The hand to determine if the controller model will be ready for.</param>
+        /// <returns>Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.</returns>
+        public override bool WaitForControllerModel(ControllerHand hand)
+        {
+            return false;
         }
 
         /// <summary>
@@ -549,8 +560,9 @@ namespace VRTK
             return false;
         }
 
-        protected virtual void Awake()
+        protected override void Awake()
         {
+            base.Awake();
             SetTrackedControllerCaches(true);
         }
 

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ControllerEvents.cs
@@ -480,6 +480,10 @@ namespace VRTK
         /// Emitted when the controller index changed.
         /// </summary>
         public event ControllerInteractionEventHandler ControllerIndexChanged;
+        /// <summary>
+        /// Emitted when the controller model becomes available.
+        /// </summary>
+        public event ControllerInteractionEventHandler ControllerModelAvailable;
 
         /// <summary>
         /// Emitted when the controller is set to visible.
@@ -503,6 +507,7 @@ namespace VRTK
         protected float pinkyFingerSenseAxis = 0f;
         protected float hairTriggerDelta;
         protected float hairGripDelta;
+        protected VRTK_TrackedController trackedController;
 
         #region event methods
 
@@ -849,6 +854,14 @@ namespace VRTK
             }
         }
 
+        public virtual void OnControllerModelAvailable(ControllerInteractionEventArgs e)
+        {
+            if (ControllerModelAvailable != null)
+            {
+                ControllerModelAvailable(this, e);
+            }
+        }
+
         public virtual void OnControllerVisible(ControllerInteractionEventArgs e)
         {
             controllerVisible = true;
@@ -876,7 +889,7 @@ namespace VRTK
         /// <returns>The payload for a Controller Event.</returns>
         public virtual ControllerInteractionEventArgs SetControllerEvent()
         {
-            var nullBool = false;
+            bool nullBool = false;
             return SetControllerEvent(ref nullBool);
         }
 
@@ -897,6 +910,15 @@ namespace VRTK
             e.touchpadAxis = VRTK_SDK_Bridge.GetControllerAxis(SDK_BaseController.ButtonTypes.Touchpad, controllerReference);
             e.touchpadAngle = CalculateTouchpadAxisAngle(e.touchpadAxis);
             return e;
+        }
+
+        /// <summary>
+        /// The GetControllerType method is a shortcut to retrieve the current controller type the controller events is attached to.
+        /// </summary>
+        /// <returns>The type of controller that the controller events is attached to.</returns>
+        public virtual SDK_BaseController.ControllerType GetControllerType()
+        {
+            return (trackedController != null ? trackedController.GetControllerType() : SDK_BaseController.ControllerType.Undefined);
         }
 
         #region axis getters
@@ -1122,15 +1144,16 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
-            if (actualController)
+            GameObject actualController = VRTK_DeviceFinder.GetActualController(gameObject);
+            if (actualController != null)
             {
-                var controllerTracker = actualController.GetComponent<VRTK_TrackedController>();
-                if (controllerTracker)
+                trackedController = actualController.GetComponentInParent<VRTK_TrackedController>();
+                if (trackedController != null)
                 {
-                    controllerTracker.ControllerEnabled += TrackedControllerEnabled;
-                    controllerTracker.ControllerDisabled += TrackedControllerDisabled;
-                    controllerTracker.ControllerIndexChanged += TrackedControllerIndexChanged;
+                    trackedController.ControllerEnabled += TrackedControllerEnabled;
+                    trackedController.ControllerDisabled += TrackedControllerDisabled;
+                    trackedController.ControllerIndexChanged += TrackedControllerIndexChanged;
+                    trackedController.ControllerModelAvailable += TrackedControllerModelAvailable;
                 }
             }
         }
@@ -1138,14 +1161,15 @@ namespace VRTK
         protected virtual void OnDisable()
         {
             Invoke("DisableEvents", 0f);
-            var actualController = VRTK_DeviceFinder.GetActualController(gameObject);
-            if (actualController)
+            GameObject actualController = VRTK_DeviceFinder.GetActualController(gameObject);
+            if (actualController != null)
             {
-                var controllerTracker = actualController.GetComponent<VRTK_TrackedController>();
-                if (controllerTracker)
+                if (trackedController != null)
                 {
-                    controllerTracker.ControllerEnabled -= TrackedControllerEnabled;
-                    controllerTracker.ControllerDisabled -= TrackedControllerDisabled;
+                    trackedController.ControllerEnabled -= TrackedControllerEnabled;
+                    trackedController.ControllerDisabled -= TrackedControllerDisabled;
+                    trackedController.ControllerIndexChanged -= TrackedControllerIndexChanged;
+                    trackedController.ControllerModelAvailable -= TrackedControllerModelAvailable;
                 }
             }
         }
@@ -1976,6 +2000,11 @@ namespace VRTK
         protected virtual void TrackedControllerIndexChanged(object sender, VRTKTrackedControllerEventArgs e)
         {
             OnControllerIndexChanged(SetControllerEvent());
+        }
+
+        protected virtual void TrackedControllerModelAvailable(object sender, VRTKTrackedControllerEventArgs e)
+        {
+            OnControllerModelAvailable(SetControllerEvent());
         }
 
         protected virtual float CalculateTouchpadAxisAngle(Vector2 axis)

--- a/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_TrackedController.cs
@@ -1,6 +1,7 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+    using System.Collections;
 
     public struct VRTKTrackedControllerEventArgs
     {
@@ -17,8 +18,21 @@
         public event VRTKTrackedControllerEventHandler ControllerEnabled;
         public event VRTKTrackedControllerEventHandler ControllerDisabled;
         public event VRTKTrackedControllerEventHandler ControllerIndexChanged;
+        public event VRTKTrackedControllerEventHandler ControllerModelAvailable;
 
         protected GameObject aliasController;
+        protected SDK_BaseController.ControllerType controllerType = SDK_BaseController.ControllerType.Undefined;
+        protected bool controllerModelWaitSubscribed = false;
+        protected Coroutine emitControllerEnabledRoutine = null;
+        protected Coroutine emitControllerModelAvailableRoutine = null;
+
+        protected VRTK_ControllerReference controllerReference
+        {
+            get
+            {
+                return VRTK_ControllerReference.GetControllerReference(index);
+            }
+        }
 
         public virtual void OnControllerEnabled(VRTKTrackedControllerEventArgs e)
         {
@@ -44,6 +58,19 @@
             }
         }
 
+        public virtual void OnControllerModelAvailable(VRTKTrackedControllerEventArgs e)
+        {
+            if (ControllerModelAvailable != null)
+            {
+                ControllerModelAvailable(this, e);
+            }
+        }
+
+        public virtual SDK_BaseController.ControllerType GetControllerType()
+        {
+            return controllerType;
+        }
+
         protected virtual VRTKTrackedControllerEventArgs SetEventPayload(uint previousIndex = uint.MaxValue)
         {
             VRTKTrackedControllerEventArgs e;
@@ -66,11 +93,15 @@
             }
 
             index = VRTK_DeviceFinder.GetControllerIndex(gameObject);
-            OnControllerEnabled(SetEventPayload());
+            SetControllerType();
+            StartEmitControllerEnabledAtEndOfFrame();
+            ManageControllerModelListeners(true);
         }
 
         protected virtual void OnDisable()
         {
+            CancelCoroutines();
+            ManageControllerModelListeners(false);
             OnControllerDisabled(SetEventPayload());
         }
 
@@ -91,7 +122,14 @@
             {
                 uint previousIndex = index;
                 index = checkIndex;
+                //If the controller model listeners have already been registered, then make sure to unsub and sub when index changes.
+                if (controllerModelWaitSubscribed)
+                {
+                    ManageControllerModelListeners(false);
+                    ManageControllerModelListeners(true);
+                }
                 OnControllerIndexChanged(SetEventPayload(previousIndex));
+                SetControllerType();
             }
 
             VRTK_SDK_Bridge.ControllerProcessUpdate(VRTK_ControllerReference.GetControllerReference(index));
@@ -99,6 +137,123 @@
             if (aliasController != null && gameObject.activeInHierarchy && !aliasController.activeSelf)
             {
                 aliasController.SetActive(true);
+            }
+        }
+
+        protected virtual void ManageLeftControllerListener(bool register, VRTKSDKBaseControllerEventHandler callbackMethod)
+        {
+            if (register)
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().LeftControllerModelReady += callbackMethod;
+            }
+            else
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().LeftControllerModelReady -= callbackMethod;
+            }
+        }
+
+        protected virtual void ManageRightControllerListener(bool register, VRTKSDKBaseControllerEventHandler callbackMethod)
+        {
+            if (register)
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().RightControllerModelReady += callbackMethod;
+            }
+            else
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().RightControllerModelReady -= callbackMethod;
+            }
+        }
+
+        protected virtual void RegisterHandControllerListener(bool register, SDK_BaseController.ControllerHand givenHand)
+        {
+            switch (givenHand)
+            {
+                case SDK_BaseController.ControllerHand.Left:
+                    ManageLeftControllerListener(register, ControllerModelReady);
+                    break;
+                case SDK_BaseController.ControllerHand.Right:
+                    ManageRightControllerListener(register, ControllerModelReady);
+                    break;
+            }
+            controllerModelWaitSubscribed = register;
+        }
+
+        protected virtual void ManageControllerModelListener(bool register, SDK_BaseController.ControllerHand givenHand)
+        {
+            if (VRTK_SDK_Bridge.WaitForControllerModel(givenHand))
+            {
+                RegisterHandControllerListener(register, givenHand);
+            }
+            else
+            {
+                if (register)
+                {
+                    StartEmitControllerModelReadyAtEndOfFrame();
+                }
+                else if (controllerModelWaitSubscribed)
+                {
+                    RegisterHandControllerListener(register, givenHand);
+                }
+            }
+        }
+
+        protected virtual void ManageControllerModelListeners(bool register)
+        {
+            ManageControllerModelListener(register, VRTK_DeviceFinder.GetControllerHand(gameObject));
+        }
+
+        protected virtual void SetControllerType()
+        {
+            controllerType = (controllerReference != null ? VRTK_DeviceFinder.GetCurrentControllerType(controllerReference) : SDK_BaseController.ControllerType.Undefined);
+        }
+
+        protected virtual void StartEmitControllerEnabledAtEndOfFrame()
+        {
+            if (gameObject.activeInHierarchy)
+            {
+                emitControllerEnabledRoutine = StartCoroutine(EmitControllerEnabledAtEndOfFrame());
+            }
+        }
+
+        protected virtual IEnumerator EmitControllerEnabledAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            OnControllerEnabled(SetEventPayload());
+        }
+
+        protected virtual void ControllerModelReady(object sender, VRTKSDKBaseControllerEventArgs e)
+        {
+            SetControllerType();
+            if (e.controllerReference == null || controllerReference == e.controllerReference)
+            {
+                StartEmitControllerModelReadyAtEndOfFrame();
+            }
+        }
+
+        protected virtual void StartEmitControllerModelReadyAtEndOfFrame()
+        {
+            if (gameObject != null && gameObject.activeInHierarchy)
+            {
+                emitControllerModelAvailableRoutine = StartCoroutine(EmitControllerModelReadyAtEndOfFrame());
+            }
+        }
+
+        protected virtual IEnumerator EmitControllerModelReadyAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            OnControllerModelAvailable(SetEventPayload());
+        }
+
+        protected virtual void CancelCoroutines()
+        {
+            if (emitControllerModelAvailableRoutine != null)
+            {
+                StopCoroutine(emitControllerModelAvailableRoutine);
+            }
+
+            if (emitControllerEnabledRoutine != null)
+            {
+                StopCoroutine(emitControllerEnabledRoutine);
             }
         }
     }

--- a/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Utilities/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -64,6 +64,7 @@
         public ControllerInteractionEvent OnControllerEnabled = new ControllerInteractionEvent();
         public ControllerInteractionEvent OnControllerDisabled = new ControllerInteractionEvent();
         public ControllerInteractionEvent OnControllerIndexChanged = new ControllerInteractionEvent();
+        public ControllerInteractionEvent OnControllerModelAvailable = new ControllerInteractionEvent();
 
         public ControllerInteractionEvent OnControllerVisible = new ControllerInteractionEvent();
         public ControllerInteractionEvent OnControllerHidden = new ControllerInteractionEvent();
@@ -112,6 +113,7 @@
             component.ControllerEnabled += ControllerEnabled;
             component.ControllerDisabled += ControllerDisabled;
             component.ControllerIndexChanged += ControllerIndexChanged;
+            component.ControllerModelAvailable += ControllerModelAvailable;
 
             component.ControllerVisible += ControllerVisible;
             component.ControllerHidden += ControllerHidden;
@@ -161,6 +163,7 @@
             component.ControllerEnabled -= ControllerEnabled;
             component.ControllerDisabled -= ControllerDisabled;
             component.ControllerIndexChanged -= ControllerIndexChanged;
+            component.ControllerModelAvailable -= ControllerModelAvailable;
 
             component.ControllerVisible -= ControllerVisible;
             component.ControllerHidden -= ControllerHidden;
@@ -399,6 +402,11 @@
         private void ControllerIndexChanged(object o, ControllerInteractionEventArgs e)
         {
             OnControllerIndexChanged.Invoke(o, e);
+        }
+
+        private void ControllerModelAvailable(object o, ControllerInteractionEventArgs e)
+        {
+            OnControllerModelAvailable.Invoke(o, e);
         }
 
         private void ControllerVisible(object o, ControllerInteractionEventArgs e)

--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -45,10 +45,11 @@ namespace VRTK
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
         /// </summary>
+        /// <param name="controllerReference">The reference to the controller to get type of.</param>
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
-        public static SDK_BaseController.ControllerType GetCurrentControllerType()
+        public static SDK_BaseController.ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
-            return VRTK_SDK_Bridge.GetCurrentControllerType();
+            return VRTK_SDK_Bridge.GetCurrentControllerType(controllerReference);
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
@@ -42,6 +42,28 @@ namespace VRTK
         protected float findControllerAttemptsDelay = 0.1f;
         protected Coroutine attemptFindControllerModel;
 
+        /// <summary>
+        /// The UpdateTransform method updates the Transform data on the current GameObject for the specified settings.
+        /// </summary>
+        /// <param name="controllerReference">An optional reference to the controller to update the transform with.</param>
+        public virtual void UpdateTransform(VRTK_ControllerReference controllerReference = null)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            VRTK_SDKTransformModifiers selectedModifier = GetSelectedModifier(controllerReference);
+
+            //If a modifier is found then change the transform
+            if (selectedModifier != null)
+            {
+                target.localPosition = selectedModifier.position;
+                target.localEulerAngles = selectedModifier.rotation;
+                target.localScale = selectedModifier.scale;
+            }
+        }
+
         protected virtual void OnEnable()
         {
             target = (target != null ? target : transform);
@@ -67,6 +89,14 @@ namespace VRTK
             {
                 StopCoroutine(attemptFindControllerModel);
                 attemptFindControllerModel = null;
+            }
+        }
+
+        protected virtual void OnDestroy()
+        {
+            if (sdkManager != null)
+            {
+                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
             }
         }
 
@@ -97,7 +127,7 @@ namespace VRTK
             UpdateTransform();
         }
 
-        protected virtual VRTK_SDKTransformModifiers GetSelectedModifier()
+        protected virtual VRTK_SDKTransformModifiers GetSelectedModifier(VRTK_ControllerReference controllerReference)
         {
             //attempt to find by the overall SDK set up to start with
             VRTK_SDKTransformModifiers selectedModifier = sdkOverrides.FirstOrDefault(item => item.loadedSDKSetup == sdkManager.loadedSetup);
@@ -105,28 +135,10 @@ namespace VRTK
             //If no sdk set up is found or it is null then try and find by the SDK controller
             if (selectedModifier == null)
             {
-                SDK_BaseController.ControllerType currentController = VRTK_DeviceFinder.GetCurrentControllerType();
+                SDK_BaseController.ControllerType currentController = VRTK_DeviceFinder.GetCurrentControllerType(controllerReference);
                 selectedModifier = sdkOverrides.FirstOrDefault(item => item.controllerType == currentController);
             }
             return selectedModifier;
-        }
-
-        protected virtual void UpdateTransform()
-        {
-            if (target == null)
-            {
-                return;
-            }
-
-            VRTK_SDKTransformModifiers selectedModifier = GetSelectedModifier();
-
-            //If a modifier is found then change the transform
-            if (selectedModifier != null)
-            {
-                target.localPosition = selectedModifier.position;
-                target.localEulerAngles = selectedModifier.rotation;
-                target.localScale = selectedModifier.scale;
-            }
         }
     }
 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2662,6 +2662,7 @@ The script also has a public boolean pressed state for the buttons to allow the 
  * `ControllerEnabled` - Emitted when the controller is enabled.
  * `ControllerDisabled` - Emitted when the controller is disabled.
  * `ControllerIndexChanged` - Emitted when the controller index changed.
+ * `ControllerModelAvailable` - Emitted when the controller model becomes available.
  * `ControllerVisible` - Emitted when the controller is set to visible.
  * `ControllerHidden` - Emitted when the controller is set to hidden.
 
@@ -2703,6 +2704,17 @@ The SetControllerEvent/0 method is used to set the Controller Event payload.
    * `ControllerInteractionEventArgs` - The payload for a Controller Event.
 
 The SetControllerEvent/3 method is used to set the Controller Event payload.
+
+#### GetControllerType/0
+
+  > `public virtual SDK_BaseController.ControllerType GetControllerType()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `SDK_BaseController.ControllerType` - The type of controller that the controller events is attached to.
+
+The GetControllerType method is a shortcut to retrieve the current controller type the controller events is attached to.
 
 #### GetTouchpadAxis/0
 
@@ -3274,6 +3286,17 @@ The ForceStopTouching method will stop the controller from touching an object ev
    * `Collider[]` - An array of colliders that are associated with the controller.
 
 The ControllerColliders method retrieves all of the associated colliders on the controller.
+
+#### GetControllerType/0
+
+  > `public virtual SDK_BaseController.ControllerType GetControllerType()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `SDK_BaseController.ControllerType` - The type of controller that the interact touch is attached to.
+
+The GetControllerType method is a shortcut to retrieve the current controller type the interact touch is attached to.
 
 ### Example
 
@@ -6759,12 +6782,12 @@ The Device Finder offers a collection of static methods that can be called to fi
 
 ### Class Methods
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public static SDK_BaseController.ControllerType GetCurrentControllerType()`
+  > `public static SDK_BaseController.ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `SDK_BaseController.ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -7658,6 +7681,19 @@ The SDK Transform Modify can be used to change a transform orientation at runtim
  * **Target:** The target transform to modify on enable. If this is left blank then the transform the script is attached to will be used.
  * **Sdk Overrides:** A collection of SDK Transform overrides to change the given target transform for each specified SDK.
 
+### Class Methods
+
+#### UpdateTransform/1
+
+  > `public virtual void UpdateTransform(VRTK_ControllerReference controllerReference = null)`
+
+  * Parameters
+   * `VRTK_ControllerReference controllerReference` - An optional reference to the controller to update the transform with.
+  * Returns
+   * _none_
+
+The UpdateTransform method updates the Transform data on the current GameObject for the specified settings.
+
 ---
 
 ## Simulating Headset Movement (VRTK_Simulator)
@@ -8091,12 +8127,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public abstract ControllerType GetCurrentControllerType();`
+  > `public abstract ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null);`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -8238,6 +8274,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public abstract bool WaitForControllerModel(ControllerHand hand);`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 
@@ -8712,12 +8759,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public override ControllerType GetCurrentControllerType()`
+  > `public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -8859,6 +8906,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public override bool WaitForControllerModel(ControllerHand hand)`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 
@@ -9316,12 +9374,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public override ControllerType GetCurrentControllerType()`
+  > `public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -9463,6 +9521,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public override bool WaitForControllerModel(ControllerHand hand)`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 
@@ -9939,12 +10008,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public override ControllerType GetCurrentControllerType()`
+  > `public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -10086,6 +10155,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public override bool WaitForControllerModel(ControllerHand hand)`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 
@@ -10562,12 +10642,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public override ControllerType GetCurrentControllerType()`
+  > `public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -10709,6 +10789,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public override bool WaitForControllerModel(ControllerHand hand)`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 
@@ -11184,12 +11275,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public override ControllerType GetCurrentControllerType()`
+  > `public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -11331,6 +11422,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public override bool WaitForControllerModel(ControllerHand hand)`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 
@@ -11795,12 +11897,12 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
 
-#### GetCurrentControllerType/0
+#### GetCurrentControllerType/1
 
-  > `public override ControllerType GetCurrentControllerType()`
+  > `public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)`
 
   * Parameters
-   * _none_
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to get type of.
   * Returns
    * `ControllerType` - The ControllerType based on the SDK and headset being used.
 
@@ -11942,6 +12044,17 @@ The IsControllerLeftHand/2 method is used to check if the given controller is th
    * `bool` - Returns true if the given controller is the right hand controller.
 
 The IsControllerRightHand/2 method is used to check if the given controller is the the right hand controller.
+
+#### WaitForControllerModel/1
+
+  > `public override bool WaitForControllerModel(ControllerHand hand)`
+
+  * Parameters
+   * `ControllerHand hand` - The hand to determine if the controller model will be ready for.
+  * Returns
+   * `bool` - Returns true if the controller model requires loading in at runtime and therefore needs waiting for. Returns false if the controller model will be available at start.
+
+The WaitForControllerModel method determines whether the controller model for the given hand requires waiting to load in on scene start.
 
 #### GetControllerModel/1
 


### PR DESCRIPTION
The Controller Model is now emitted via a new event on the
TrackedController script (which is also re-thrown by the
ControllerEvents script). This event is emitted when the model
of the connected controller is loaded in.

Previously, a number of scripts would duplicate the same coroutine
for determining when the controller model was available. This new
event removes the need for this duplication as these scripts can just
listen for this event.

The `GetCurrentControllerType` method now accepts a ControllerReference
to determine specific connected controller type. If `null` is passed
then it will attempt to get the right controller first then the left
if the right is not available.