### PR TITLE
feat(Interaction): determine if object is hovered over snap drop zone

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -692,7 +692,7 @@ namespace VRTK
                     OnInteractableObjectExitedSnapDropZone(SetInteractableObjectEvent(snapDropZone.gameObject));
                 }
             }
-            hoveredOverSnapDropZone = hoveredSnapObjects.Count > 0;
+            hoveredOverSnapDropZone = (hoveredSnapObjects.Count > 0);
         }
 
         /// <summary>
@@ -702,6 +702,15 @@ namespace VRTK
         public virtual VRTK_SnapDropZone GetStoredSnapDropZone()
         {
             return storedSnapDropZone;
+        }
+
+        /// <summary>
+        /// The IsHoveredOverSnapDropZone method returns whether the interactable object is currently hovering over a snap drop zone.
+        /// </summary>
+        /// <returns>Returns true if the interactable object is currently hovering over a snap drop zone.</returns>
+        public virtual bool IsHoveredOverSnapDropZone()
+        {
+            return hoveredOverSnapDropZone;
         }
 
         /// <summary>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3873,6 +3873,17 @@ The SetSnapDropZoneHover method sets whether the interactable object is currentl
 
 The GetStoredSnapDropZone method returns the snap drop zone that the interactable object is currently snapped to.
 
+#### IsHoveredOverSnapDropZone/0
+
+  > `public virtual bool IsHoveredOverSnapDropZone()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Returns true if the interactable object is currently hovering over a snap drop zone.
+
+The IsHoveredOverSnapDropZone method returns whether the interactable object is currently hovering over a snap drop zone.
+
 #### IsDroppable/0
 
   > `public virtual bool IsDroppable()`


### PR DESCRIPTION
The Interactable Object has a new method that can be called to see
if the object is currently being hovered over a snap drop zone.