### PR TITLE
fix(SnapDropZone): ensure highlight always active option is honoured - fixes #1421

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_SnapDropZone.cs
@@ -360,7 +360,12 @@ namespace VRTK
         {
             if (highlightAlwaysActive && !isSnapped && !isHighlighted)
             {
-                highlightObject.SetActive(true);
+                SetHighlightObjectActive(true);
+            }
+
+            if (!highlightAlwaysActive && isHighlighted && !ValidSnappableObjectIsHovering())
+            {
+                SetHighlightObjectActive(false);
             }
         }
 
@@ -404,7 +409,7 @@ namespace VRTK
                     RemoveCurrentValidSnapObject(currentIOCheck);
                     if (isHighlighted && highlightObject != null && !highlightAlwaysActive)
                     {
-                        highlightObject.SetActive(false);
+                        SetHighlightObjectActive(false);
                     }
                 }
             }
@@ -473,7 +478,7 @@ namespace VRTK
                     if (highlightObject != null)
                     {
                         //Turn off the drop zone highlighter
-                        highlightObject.SetActive(false);
+                        SetHighlightObjectActive(false);
                     }
 
                     Vector3 newLocalScale = GetNewLocalScale(ioCheck);
@@ -729,11 +734,10 @@ namespace VRTK
             if (highlightObject != null && ioCheck != null)
             {
                 //Toggle the highlighter state
-                highlightObject.SetActive(state);
+                SetHighlightObjectActive(state);
                 ioCheck.SetSnapDropZoneHover(this, state);
 
                 willSnap = state;
-                isHighlighted = state;
 
                 if (state)
                 {
@@ -789,11 +793,17 @@ namespace VRTK
                 DeleteHighlightObject();
             }
 
+            SetHighlightObjectActive(false);
+            SetContainer();
+        }
+
+        protected virtual void SetHighlightObjectActive(bool state)
+        {
             if (highlightObject != null)
             {
-                highlightObject.SetActive(false);
+                highlightObject.SetActive(state);
+                isHighlighted = state;
             }
-            SetContainer();
         }
 
         protected virtual void DeleteHighlightObject()


### PR DESCRIPTION
There was an issue withe the Highlight Always Active option where it
could be turned on at scene run, but then if it was turned off during
play it would not turn off the highlighter even though the state of
the option would dictate otherwise.

The fix is to ensure the `isHighlighted` flag is always correctly
set and an additional check is done to make sure to turn the
highlighter off if it shouldn't be on due to this option being false.