### PR TITLE
fix(Utilities): prevent crash when switching sdk setup

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_FramesPerSecondViewer.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_FramesPerSecondViewer.cs
@@ -88,7 +88,10 @@ namespace VRTK
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
-            SetCanvasCamera();
+            if (sdkManager != null && gameObject.activeInHierarchy)
+            {
+                SetCanvasCamera();
+            }
         }
 
         protected virtual void InitCanvas()

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKObjectAlias.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKObjectAlias.cs
@@ -44,7 +44,7 @@ namespace VRTK
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
-            if (sdkManager != null)
+            if (sdkManager != null && gameObject.activeInHierarchy)
             {
                 ChildToSDKObject();
             }

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SDKTransformModify.cs
@@ -61,7 +61,10 @@ namespace VRTK
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
-            UpdateTransform();
+            if (sdkManager != null && gameObject.activeInHierarchy)
+            {
+                UpdateTransform();
+            }
         }
 
         protected virtual VRTK_SDKTransformModifiers GetSelectedModifier()


### PR DESCRIPTION
There was an issue with the `LoadedSetupChanged` method that it
would attempt to access objects or destroy objects when the SDK
was finally unloaded because the object in question had already
been destroyed (e.g. when ending the scene).

This fix just ensures the sdk setup changes only call their intended
methods if the game object the script is on is still active in the
hierarchy.