### PR TITLE
feat(Simulator): deprecate VRTK Simulator

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs
@@ -12,6 +12,7 @@ namespace VRTK
     /// Supported movements are: forward, backward, strafe left, strafe right, turn left, turn right, up, down.
     /// </remarks>
     [AddComponentMenu("VRTK/Scripts/Utilities/VRTK_Simulator")]
+    [System.Obsolete("`VRTK_Simulator` has been superseded by the VRTK SDK Simulator. This script will be removed in a future version of VRTK.")]
     public class VRTK_Simulator : MonoBehaviour
     {
         [System.Serializable]

--- a/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs.meta
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_Simulator.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
 guid: a5761c48d9dd95c41b36acc5584d7803
-timeCreated: 1469620307
+timeCreated: 1502921174
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  icon: {fileID: 2800000, guid: 9392d92117790dd45b98c0a5a516b274, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6472,7 +6472,6 @@ A collection of scripts that provide useful functionality to aid the creation pr
  * [Transform Follow](#transform-follow-vrtk_transformfollow)
  * [SDK Object Alias](#sdk-object-alias-vrtk_sdkobjectalias)
  * [SDK Transform Modify](#sdk-transform-modify-vrtk_sdktransformmodify)
- * [Simulating Headset Movement](#simulating-headset-movement-vrtk_simulator)
 
 ---
 
@@ -7695,25 +7694,6 @@ The SDK Transform Modify can be used to change a transform orientation at runtim
    * _none_
 
 The UpdateTransform method updates the Transform data on the current GameObject for the specified settings.
-
----
-
-## Simulating Headset Movement (VRTK_Simulator)
-
-### Overview
-
-To test a scene it is often necessary to use the headset to move to a location. This increases turn-around times and can become cumbersome.
-
-The simulator allows navigating through the scene using the keyboard instead, without the need to put on the headset. One can then move around (also through walls) while looking at the monitor and still use the controllers to interact.
-
-Supported movements are: forward, backward, strafe left, strafe right, turn left, turn right, up, down.
-
-### Inspector Parameters
-
- * **Keys:** Per default the keys on the left-hand side of the keyboard are used (WASD). They can be individually set as needed. The reset key brings the camera to its initial location.
- * **Only In Editor:** Typically the simulator should be turned off when not testing anymore. This option will do this automatically when outside the editor.
- * **Step Size:** Depending on the scale of the world the step size can be defined to increase or decrease movement speed.
- * **Cam Start:** An optional game object marking the position and rotation at which the camera should be initially placed.
 
 ---
 


### PR DESCRIPTION
The VRTK Simulator has been superseded by the VRTK SDK Simulator which
simulates the entire SDK setup rather than just enabling the camera rig
to move around with key presses.

This means there is little reason to keep this old simulator.