### PR TITLE
refactor(Structure): apply coding conventions

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ConsoleViewer.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_ConsoleViewer.cs
@@ -28,21 +28,21 @@ namespace VRTK
         [Tooltip("The colour of the text for an exception log message.")]
         public Color exceptionMessage = Color.red;
 
-        private Dictionary<LogType, Color> logTypeColors;
-        private ScrollRect scrollWindow;
-        private RectTransform consoleRect;
-        private Text consoleOutput;
-        private const string NEWLINE = "\n";
-        private int lineBuffer = 50;
-        private int currentBuffer;
-        private string lastMessage;
-        private bool collapseLog = false;
+        protected Dictionary<LogType, Color> logTypeColors;
+        protected ScrollRect scrollWindow;
+        protected RectTransform consoleRect;
+        protected Text consoleOutput;
+        protected const string NEWLINE = "\n";
+        protected int lineBuffer = 50;
+        protected int currentBuffer;
+        protected string lastMessage;
+        protected bool collapseLog = false;
 
         /// <summary>
         /// The SetCollapse method determines whether the console will collapse same message output into the same line. A state of `true` will collapse messages and `false` will print the same message for each line.
         /// </summary>
         /// <param name="state">The state of whether to collapse the output messages, true will collapse and false will not collapse.</param>
-        public void SetCollapse(bool state)
+        public virtual void SetCollapse(bool state)
         {
             collapseLog = state;
         }
@@ -50,7 +50,7 @@ namespace VRTK
         /// <summary>
         /// The ClearLog method clears the current log view of all messages
         /// </summary>
-        public void ClearLog()
+        public virtual void ClearLog()
         {
             consoleOutput.text = "";
             currentBuffer = 0;
@@ -86,15 +86,15 @@ namespace VRTK
             consoleRect.sizeDelta = Vector2.zero;
         }
 
-        private string GetMessage(string message, LogType type)
+        protected virtual string GetMessage(string message, LogType type)
         {
-            var color = ColorUtility.ToHtmlStringRGBA(logTypeColors[type]);
+            string color = ColorUtility.ToHtmlStringRGBA(logTypeColors[type]);
             return "<color=#" + color + ">" + message + "</color>" + NEWLINE;
         }
 
-        private void HandleLog(string message, string stackTrace, LogType type)
+        protected virtual void HandleLog(string message, string stackTrace, LogType type)
         {
-            var logOutput = GetMessage(message, type);
+            string logOutput = GetMessage(message, type);
 
             if (!collapseLog || lastMessage != logOutput)
             {
@@ -107,7 +107,7 @@ namespace VRTK
             currentBuffer++;
             if (currentBuffer >= lineBuffer)
             {
-                var lines = Regex.Split(consoleOutput.text, NEWLINE).Skip(lineBuffer / 2);
+                IEnumerable<string> lines = Regex.Split(consoleOutput.text, NEWLINE).Skip(lineBuffer / 2);
                 consoleOutput.text = string.Join(NEWLINE, lines.ToArray());
                 currentBuffer = lineBuffer / 2;
             }

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_RadialMenu.cs
@@ -130,7 +130,7 @@ namespace VRTK
         {
             if (currentHover != -1)
             {
-                var pointer = new PointerEventData(EventSystem.current);
+                PointerEventData pointer = new PointerEventData(EventSystem.current);
                 ExecuteEvents.Execute(menuButtons[currentHover], pointer, ExecuteEvents.pointerExitHandler);
                 buttons[currentHover].OnHoverExit.Invoke();
                 currentHover = -1;
@@ -294,7 +294,7 @@ namespace VRTK
             angle = VRTK_SharedMethods.Mod((angle + -offsetRotation), 360); //Offset the touch coordinate with our offset
 
             int buttonID = (int)VRTK_SharedMethods.Mod(((angle + (buttonAngle / 2f)) / buttonAngle), buttons.Count); //Convert angle into ButtonID (This is the magic)
-            var pointer = new PointerEventData(EventSystem.current); //Create a new EventSystem (UI) Event
+            PointerEventData pointer = new PointerEventData(EventSystem.current); //Create a new EventSystem (UI) Event
 
             //If we changed buttons while moving, un-hover and un-click the last button we were on
             if (currentHover != buttonID && currentHover != -1)


### PR DESCRIPTION
Update some scripts that were not adhering to the coding conventions
such as using the `var` keyword or using `private` variables and
methods.