### PR TITLE
refactor(Structure): replace occurrences of Equals with ==

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/Scripts/Archery/BowAim.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/Archery/BowAim.cs
@@ -99,7 +99,7 @@
                     fired = false;
                     fireOffset = Time.time;
                 }
-                if (!releaseRotation.Equals(baseRotation))
+                if (releaseRotation != baseRotation)
                 {
                     transform.localRotation = Quaternion.Lerp(releaseRotation, baseRotation, (Time.time - fireOffset) * 8);
                 }
@@ -161,7 +161,7 @@
             currentPull = Mathf.Clamp((Vector3.Distance(holdControl.transform.position, stringControl.transform.position) - pullOffset) * pullMultiplier, 0, maxPullDistance);
             bowAnimation.SetFrame(currentPull);
 
-            if (!currentPull.ToString("F2").Equals(previousPull.ToString("F2")))
+            if (currentPull.ToString("F2") != previousPull.ToString("F2"))
             {
                 VRTK_ControllerHaptics.TriggerHapticPulse(VRTK_ControllerReference.GetControllerReference(holdControl.gameObject), bowVibration);
                 VRTK_ControllerHaptics.TriggerHapticPulse(VRTK_ControllerReference.GetControllerReference(stringControl.gameObject), stringVibration);

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_DestinationPoint.cs
@@ -326,7 +326,7 @@ namespace VRTK
 
         protected virtual void ToggleCursor(object sender, bool state)
         {
-            if ((hidePointerCursorOnHover || hideDirectionIndicatorOnHover) && sender.GetType().Equals(typeof(VRTK_Pointer)))
+            if ((hidePointerCursorOnHover || hideDirectionIndicatorOnHover) && sender.GetType() == typeof(VRTK_Pointer))
             {
                 VRTK_Pointer pointer = (VRTK_Pointer)sender;
                 if (pointer != null && pointer.pointerRenderer != null)

--- a/Assets/VRTK/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseController.cs
@@ -379,7 +379,7 @@ namespace VRTK
             VRTK_SDKManager sdkManager = VRTK_SDKManager.instance;
             if (sdkManager != null && controller != null)
             {
-                return (actual ? controller.Equals(sdkManager.loadedSetup.actualLeftController) : controller.Equals(sdkManager.scriptAliasLeftController));
+                return (actual ? controller == sdkManager.loadedSetup.actualLeftController : controller == sdkManager.scriptAliasLeftController);
             }
             return false;
         }
@@ -389,7 +389,7 @@ namespace VRTK
             VRTK_SDKManager sdkManager = VRTK_SDKManager.instance;
             if (sdkManager != null && controller != null)
             {
-                return (actual ? controller.Equals(sdkManager.loadedSetup.actualRightController) : controller.Equals(sdkManager.scriptAliasRightController));
+                return (actual ? controller == sdkManager.loadedSetup.actualRightController : controller == sdkManager.scriptAliasRightController);
             }
             return false;
         }

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Slider.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Slider.cs
@@ -86,7 +86,7 @@ namespace VRTK
                 Vector3 sliderDiff = transform.localScale / 2f;
 
                 //The right ray has found the min on the right, so max is on the left
-                if (rightHasHit && hitRight.collider.gameObject.Equals(minimumLimit.gameObject))
+                if (rightHasHit && hitRight.collider.gameObject == minimumLimit.gameObject)
                 {
                     finalDirection = Direction.x;
                     minimumLimitDiff = CalculateDiff(minimumLimit.transform.localPosition, Vector3.right, minimumLimit.transform.localScale.x, sliderDiff.x, false);
@@ -94,7 +94,7 @@ namespace VRTK
                 }
 
                 //The right ray has found the max on the right, so min is on the left
-                if (rightHasHit && hitRight.collider.gameObject.Equals(maximumLimit.gameObject))
+                if (rightHasHit && hitRight.collider.gameObject == maximumLimit.gameObject)
                 {
                     finalDirection = Direction.x;
                     minimumLimitDiff = CalculateDiff(minimumLimit.transform.localPosition, Vector3.right, minimumLimit.transform.localScale.x, sliderDiff.x, true);
@@ -102,7 +102,7 @@ namespace VRTK
                 }
 
                 // the up ray has found the min above, so max is below
-                if (upHasHit && hitUp.collider.gameObject.Equals(minimumLimit.gameObject))
+                if (upHasHit && hitUp.collider.gameObject == minimumLimit.gameObject)
                 {
                     finalDirection = Direction.y;
                     minimumLimitDiff = CalculateDiff(minimumLimit.transform.localPosition, Vector3.up, minimumLimit.transform.localScale.y, sliderDiff.y, false);
@@ -110,7 +110,7 @@ namespace VRTK
                 }
 
                 //the up ray has found the max above, so the min ix below
-                if (upHasHit && hitUp.collider.gameObject.Equals(maximumLimit.gameObject))
+                if (upHasHit && hitUp.collider.gameObject == maximumLimit.gameObject)
                 {
                     finalDirection = Direction.y;
                     minimumLimitDiff = CalculateDiff(minimumLimit.transform.localPosition, Vector3.up, minimumLimit.transform.localScale.y, sliderDiff.y, true);
@@ -118,7 +118,7 @@ namespace VRTK
                 }
 
                 //the forward ray has found the min in front, so the max is behind
-                if (forwardHasHit && hitForward.collider.gameObject.Equals(minimumLimit.gameObject))
+                if (forwardHasHit && hitForward.collider.gameObject == minimumLimit.gameObject)
                 {
                     finalDirection = Direction.z;
                     minimumLimitDiff = CalculateDiff(minimumLimit.transform.localPosition, Vector3.forward, minimumLimit.transform.localScale.y, sliderDiff.y, false);
@@ -126,7 +126,7 @@ namespace VRTK
                 }
 
                 //the forward ray has found the max in front, so the min is behind
-                if (forwardHasHit && hitForward.collider.gameObject.Equals(maximumLimit.gameObject))
+                if (forwardHasHit && hitForward.collider.gameObject == maximumLimit.gameObject)
                 {
                     finalDirection = Direction.z;
                     minimumLimitDiff = CalculateDiff(minimumLimit.transform.localPosition, Vector3.forward, minimumLimit.transform.localScale.z, sliderDiff.z, true);

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -281,14 +281,14 @@ namespace VRTK
 
         protected virtual void ManageGrabListener(bool state)
         {
-            if (controllerEvents != null && subscribedGrabButton != VRTK_ControllerEvents.ButtonAlias.Undefined && (!state || !grabButton.Equals(subscribedGrabButton)))
+            if (controllerEvents != null && subscribedGrabButton != VRTK_ControllerEvents.ButtonAlias.Undefined && (!state || grabButton != subscribedGrabButton))
             {
                 controllerEvents.UnsubscribeToButtonAliasEvent(subscribedGrabButton, true, DoGrabObject);
                 controllerEvents.UnsubscribeToButtonAliasEvent(subscribedGrabButton, false, DoReleaseObject);
                 subscribedGrabButton = VRTK_ControllerEvents.ButtonAlias.Undefined;
             }
 
-            if (controllerEvents != null && state && grabButton != VRTK_ControllerEvents.ButtonAlias.Undefined && !grabButton.Equals(subscribedGrabButton))
+            if (controllerEvents != null && state && grabButton != VRTK_ControllerEvents.ButtonAlias.Undefined && grabButton != subscribedGrabButton)
             {
                 controllerEvents.SubscribeToButtonAliasEvent(grabButton, true, DoGrabObject);
                 controllerEvents.SubscribeToButtonAliasEvent(grabButton, false, DoReleaseObject);

--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractUse.cs
@@ -242,14 +242,14 @@ namespace VRTK
 
         protected virtual void ManageUseListener(bool state)
         {
-            if (controllerEvents != null && subscribedUseButton != VRTK_ControllerEvents.ButtonAlias.Undefined && (!state || !useButton.Equals(subscribedUseButton)))
+            if (controllerEvents != null && subscribedUseButton != VRTK_ControllerEvents.ButtonAlias.Undefined && (!state || useButton != subscribedUseButton))
             {
                 controllerEvents.UnsubscribeToButtonAliasEvent(subscribedUseButton, true, DoStartUseObject);
                 controllerEvents.UnsubscribeToButtonAliasEvent(subscribedUseButton, false, DoStopUseObject);
                 subscribedUseButton = VRTK_ControllerEvents.ButtonAlias.Undefined;
             }
 
-            if (controllerEvents != null && state && useButton != VRTK_ControllerEvents.ButtonAlias.Undefined && !useButton.Equals(subscribedUseButton))
+            if (controllerEvents != null && state && useButton != VRTK_ControllerEvents.ButtonAlias.Undefined && useButton != subscribedUseButton)
             {
                 controllerEvents.SubscribeToButtonAliasEvent(useButton, true, DoStartUseObject);
                 controllerEvents.SubscribeToButtonAliasEvent(useButton, false, DoStopUseObject);

--- a/Assets/VRTK/Scripts/Internal/VRTK_ControllerReference.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_ControllerReference.cs
@@ -160,7 +160,7 @@
             {
                 return false;
             }
-            return (index.Equals(other.index));
+            return (index == other.index);
         }
 
         protected virtual GameObject GetValidObjectFromIndex()

--- a/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
@@ -62,7 +62,7 @@
                 return false;
             }
 
-            if (target.Equals(source))
+            if (target == source)
             {
                 return true;
             }

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -504,12 +504,12 @@ namespace VRTK
 
         protected virtual bool CheckValidCollision(GameObject checkObject)
         {
-            return (!VRTK_PlayerObject.IsPlayerObject(checkObject) && (!onGround || (currentValidFloorObject != null && !currentValidFloorObject.Equals(checkObject))));
+            return (!VRTK_PlayerObject.IsPlayerObject(checkObject) && (!onGround || (currentValidFloorObject != null && currentValidFloorObject != checkObject)));
         }
 
         protected virtual bool CheckExistingCollision(GameObject checkObject)
         {
-            return (currentCollidingObject != null && currentCollidingObject.Equals(checkObject));
+            return (currentCollidingObject != null && currentCollidingObject == checkObject);
         }
 
         protected virtual void SetupPlayArea()
@@ -719,7 +719,7 @@ namespace VRTK
 
         protected virtual void SetCurrentStandingPosition()
         {
-            if (playArea != null && !playArea.transform.position.Equals(lastPlayAreaPosition))
+            if (playArea != null && playArea.transform.position != lastPlayAreaPosition)
             {
                 Vector3 playareaDifference = playArea.transform.position - lastPlayAreaPosition;
                 currentStandingPosition = new Vector2(currentStandingPosition.x + playareaDifference.x, currentStandingPosition.y + playareaDifference.z);


### PR DESCRIPTION
Unity3d creates garbage when dealing with `Equals` as it's considered
a Boxing method and therefore is less efficient than simply comparing
with `==`

This information can be found at:

https://unity3d.com/learn/tutorials/topics/performance-optimization/optimizing-garbage-collection-unity-games

This refactor replaces all of the occurrences of `Equals` with `==`
to provide the efficiency improvements.

The MoveInPlace script has also been slightly refactored to use a
`switch` statement rather than a collection of `if/else` statements
that all in turn used the `Equals` method as well.