### PR TITLE
chore(SDK): provide more meaningful SDK pretty names

### DIFF
--- a/Assets/VRTK/SDK/Daydream/SDK_DaydreamSystem.cs
+++ b/Assets/VRTK/SDK/Daydream/SDK_DaydreamSystem.cs
@@ -4,7 +4,7 @@ namespace VRTK
     /// <summary>
     /// The Daydream System SDK script provides dummy functions for system functions.
     /// </summary>
-    [SDK_Description("Daydream", SDK_DaydreamDefines.ScriptingDefineSymbol, "Daydream", "Android")]
+    [SDK_Description("Google Daydream (Android:Daydream)", SDK_DaydreamDefines.ScriptingDefineSymbol, "Daydream", "Android")]
     public class SDK_DaydreamSystem
 #if VRTK_DEFINE_SDK_DAYDREAM
         : SDK_BaseSystem

--- a/Assets/VRTK/SDK/HyperealVR/SDK_HyperealVRSystem.cs
+++ b/Assets/VRTK/SDK/HyperealVR/SDK_HyperealVRSystem.cs
@@ -8,7 +8,7 @@ namespace VRTK
     /// <summary>
     /// The HyperealVR System SDK script provides a bridge to the HyperealVR SDK.
     /// </summary>
-    [SDK_Description("HyperealVR", SDK_HyperealVRDefines.ScriptingDefineSymbol, null, "Standalone")]
+    [SDK_Description("HyperealVR (Standalone)", SDK_HyperealVRDefines.ScriptingDefineSymbol, null, "Standalone")]
     public class SDK_HyperealVRSystem
 #if VRTK_DEFINE_SDK_HYPEREALVR
         : SDK_BaseSystem

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusSystem.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusSystem.cs
@@ -4,8 +4,8 @@ namespace VRTK
     /// <summary>
     /// The Oculus System SDK script provides a bridge to the Oculus SDK.
     /// </summary>
-    [SDK_Description("Oculus (Rift)", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
-    [SDK_Description("Oculus (GearVR)", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Android", 1)]
+    [SDK_Description("Oculus Rift (Standalone:Oculus)", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
+    [SDK_Description("GearVR (Android:Oculus)", SDK_OculusDefines.ScriptingDefineSymbol, "Oculus", "Android", 1)]
     public class SDK_OculusSystem
 #if VRTK_DEFINE_SDK_OCULUS
         : SDK_BaseSystem

--- a/Assets/VRTK/SDK/Simulator/SDK_SimSystem.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_SimSystem.cs
@@ -4,7 +4,7 @@ namespace VRTK
     /// <summary>
     /// The Sim System SDK script provides dummy functions for system functions.
     /// </summary>
-    [SDK_Description("Simulator", null, null, "Standalone")]
+    [SDK_Description("Simulator (Standalone)", null, null, "Standalone")]
     public class SDK_SimSystem : SDK_BaseSystem
     {
         /// <summary>

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRSystem.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRSystem.cs
@@ -8,7 +8,7 @@ namespace VRTK
     /// <summary>
     /// The SteamVR System SDK script provides a bridge to the SteamVR SDK.
     /// </summary>
-    [SDK_Description("SteamVR", SDK_SteamVRDefines.ScriptingDefineSymbol, "OpenVR", "Standalone")]
+    [SDK_Description("SteamVR (Standalone:OpenVR)", SDK_SteamVRDefines.ScriptingDefineSymbol, "OpenVR", "Standalone")]
     public class SDK_SteamVRSystem
 #if VRTK_DEFINE_SDK_STEAMVR
         : SDK_BaseSystem

--- a/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseSystem.cs
+++ b/Assets/VRTK/SDK/Ximmerse/SDK_XimmerseSystem.cs
@@ -4,8 +4,8 @@ namespace VRTK
     /// <summary>
     /// The Ximmerse System SDK script provides a bridge to the Ximmerse SDK.
     /// </summary>
-    [SDK_Description("Ximmerse (Oculus)", SDK_XimmerseDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
-    [SDK_Description("Ximmerse (Daydream)", SDK_XimmerseDefines.ScriptingDefineSymbol, "Daydream", "Android", 1)]
+    [SDK_Description("Ximmerse (Standalone:Oculus)", SDK_XimmerseDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
+    [SDK_Description("Ximmerse (Android:Daydream)", SDK_XimmerseDefines.ScriptingDefineSymbol, "Daydream", "Android", 1)]
     public class SDK_XimmerseSystem
 #if VRTK_DEFINE_SDK_XIMMERSE
         : SDK_BaseSystem


### PR DESCRIPTION
The pretty names for each SDK platform and build target has been
updated to include the library and build target to make it easier
to see which SDK option is for which output device.