### PR TITLE
fix(Utilities): use local space for velocity estimation samples - fixes #1440

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_VelocityEstimator.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_VelocityEstimator.cs
@@ -137,8 +137,8 @@ namespace VRTK
         {
             currentSampleCount = 0;
 
-            Vector3 previousPosition = transform.position;
-            Quaternion previousRotation = transform.rotation;
+            Vector3 previousPosition = transform.localPosition;
+            Quaternion previousRotation = transform.localRotation;
             while (true)
             {
                 yield return new WaitForEndOfFrame();
@@ -149,8 +149,8 @@ namespace VRTK
                 int w = currentSampleCount % angularVelocitySamples.Length;
                 currentSampleCount++;
 
-                velocitySamples[v] = velocityFactor * (transform.position - previousPosition);
-                Quaternion deltaRotation = transform.rotation * Quaternion.Inverse(previousRotation);
+                velocitySamples[v] = velocityFactor * (transform.localPosition - previousPosition);
+                Quaternion deltaRotation = transform.localRotation * Quaternion.Inverse(previousRotation);
 
                 float theta = 2.0f * Mathf.Acos(Mathf.Clamp(deltaRotation.w, -1.0f, 1.0f));
                 if (theta > Mathf.PI)
@@ -166,8 +166,8 @@ namespace VRTK
 
                 angularVelocitySamples[w] = angularVelocity;
 
-                previousPosition = transform.position;
-                previousRotation = transform.rotation;
+                previousPosition = transform.localPosition;
+                previousRotation = transform.localRotation;
             }
         }
     }


### PR DESCRIPTION
The Velocity Estimator was using world space to determine the samples
for velocity and angular velocity, which would cause problems if the
Velocity Estimator was attached to a GameObject that's parent was
rotated.

It could be seen in the Unity SDK by simply rotating the CameraRig
around the Y axis and then the throwing mechanism would throw
things in the wrong direction.

The solution is to simply use local space for position and rotation
as then the actual object the Velocity Estimator is attached to
will be used for the relative position and rotation.