### PR TITLE
chore(README.md): update contribution instructions for new branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,10 +237,10 @@ previous commit hashes is actively encouraged if they are relevant.
 ## Submitting Changes
   * Push your changes to your topic branch in your repository.
   * Submit a pull request to the repository `thestonefox/VRTK`.
-   * If you're submitting a bug fix pull request then target the
-   repository `master` branch.
-   * If you're submitting a new feature pull request then target
-   the next release branch in the repository. The current next release
-   branch is `3.3.0-alpha`.
+    * If you're submitting a bug fix pull request then target the
+    repository `master` branch.
+    * If you're submitting a new feature pull request then target
+    the next release branch in the repository. The current next release
+    branch is `3.3.0-alpha`.
   * The core team will aim to look at the pull request as soon as
   possible and provide feedback where required.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,11 @@ For the full contribution guidelines see the [CONTRIBUTING.md] document.
 ## Pull requests
 
  1. [Fork] the project, clone your fork, and configure the remotes.
- 2. Create a new topic branch (from `master`) to contain your feature,
- chore, or fix.
+    1. If you're submitting a bug fix or refactor pull request then
+    target the repository `master` branch.
+    2. If you're submitting a new feature or enhancement that changes
+    functionality then target the next release branch in the
+    repository (which is currently `3.3.0-alpha`).
  3. Commit your changes in logical units.
  4. Make sure all the example scenes are still working.
  5. Push your topic branch up to your fork.


### PR DESCRIPTION
The new branch structure for the project requires pull requests
to go into a specific branch. The README.md file didn't reflect these
new requirements, but do now with this commit.