### PR TITLE
fix(Interaction): prevent coroutine running if game object is disabled

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractObjectAppearance.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractObjectAppearance.cs
@@ -362,19 +362,22 @@ namespace VRTK
 
         protected virtual bool IsValidInteractingObject(GameObject givenObject, ValidInteractingObject givenInteractingObjectValidType)
         {
-            VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(givenObject);
-            switch (givenInteractingObjectValidType)
+            if (gameObject.activeInHierarchy)
             {
-                case ValidInteractingObject.Anything:
-                    return true;
-                case ValidInteractingObject.EitherController:
-                    return VRTK_ControllerReference.IsValid(controllerReference);
-                case ValidInteractingObject.NeitherController:
-                    return !VRTK_ControllerReference.IsValid(controllerReference);
-                case ValidInteractingObject.LeftControllerOnly:
-                    return (VRTK_ControllerReference.IsValid(controllerReference) && controllerReference.hand == SDK_BaseController.ControllerHand.Left);
-                case ValidInteractingObject.RightControllerOnly:
-                    return (VRTK_ControllerReference.IsValid(controllerReference) && controllerReference.hand == SDK_BaseController.ControllerHand.Right);
+                VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(givenObject);
+                switch (givenInteractingObjectValidType)
+                {
+                    case ValidInteractingObject.Anything:
+                        return true;
+                    case ValidInteractingObject.EitherController:
+                        return VRTK_ControllerReference.IsValid(controllerReference);
+                    case ValidInteractingObject.NeitherController:
+                        return !VRTK_ControllerReference.IsValid(controllerReference);
+                    case ValidInteractingObject.LeftControllerOnly:
+                        return (VRTK_ControllerReference.IsValid(controllerReference) && controllerReference.hand == SDK_BaseController.ControllerHand.Left);
+                    case ValidInteractingObject.RightControllerOnly:
+                        return (VRTK_ControllerReference.IsValid(controllerReference) && controllerReference.hand == SDK_BaseController.ControllerHand.Right);
+                }
             }
             return false;
         }


### PR DESCRIPTION
The Interact Object Appearance script was throwing an error if the
co routine to determine the appearance was being run but the script
GameObject had been disabled (e.g. when the play mode was stopped).

This has been fixed by checking that the GameObject is active in
the hierarchy to determine if it's a valid interaction.