### PR TITLE
fix(Interaction): remove valid controller check from secondary action - fixes #1453

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -446,14 +446,6 @@ namespace VRTK
 
         protected virtual void InitSecondaryGrab(VRTK_InteractableObject currentGrabbedObject)
         {
-            if (!currentGrabbedObject.IsValidInteractableController(gameObject, currentGrabbedObject.allowedGrabControllers))
-            {
-                grabbedObject = null;
-                influencingGrabbedObject = false;
-                currentGrabbedObject.Ungrabbed(this);
-                return;
-            }
-
             influencingGrabbedObject = true;
             currentGrabbedObject.Grabbed(this);
         }


### PR DESCRIPTION
The Secondary Grab Action was checking to see if the controller was a
valid grab controller on the interactable object.

This did not make sense as if the right controller was a valid grab
controller then only the right controller could pick up the object
but then the left controller could never initiate a secondary grab
action as the right controller was the only one denoted as being
valid to initiate a grab action.