### PR TITLE
refactor(Structure): apply coding conventions to codebase - fixes #1459

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PanelMenuController.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_PanelMenuController.cs
@@ -64,6 +64,7 @@ namespace VRTK
         protected bool isPendingSwipeCheck = false;
         protected bool isGrabbed = false;
         protected bool isShown = false;
+        protected Coroutine tweenMenuScaleRoutine;
 
         /// <summary>
         /// The ToggleMenu method is used to show or hide the menu.
@@ -88,11 +89,7 @@ namespace VRTK
             if (!isShown)
             {
                 isShown = true;
-                StopCoroutine("TweenMenuScale");
-                if (enabled)
-                {
-                    StartCoroutine("TweenMenuScale", isShown);
-                }
+                InitTweenMenuScale(isShown);
             }
         }
 
@@ -105,11 +102,7 @@ namespace VRTK
             if (isShown && force)
             {
                 isShown = false;
-                StopCoroutine("TweenMenuScale");
-                if (enabled)
-                {
-                    StartCoroutine("TweenMenuScale", isShown);
-                }
+                InitTweenMenuScale(isShown);
             }
         }
 
@@ -248,6 +241,18 @@ namespace VRTK
             }
         }
 
+        protected virtual void InitTweenMenuScale(bool show)
+        {
+            if (tweenMenuScaleRoutine != null)
+            {
+                StopCoroutine(tweenMenuScaleRoutine);
+            }
+            if (enabled)
+            {
+                tweenMenuScaleRoutine = StartCoroutine(TweenMenuScale(show));
+            }
+        }
+
         protected virtual IEnumerator TweenMenuScale(bool show)
         {
             float targetScale = 0;
@@ -266,7 +271,6 @@ namespace VRTK
                 i++;
             }
             transform.localScale = direction * targetScale;
-            StopCoroutine("TweenMenuScale");
 
             if (!show)
             {
@@ -303,7 +307,7 @@ namespace VRTK
         {
             if (isGrabbed)
             {
-                var pressPosition = CalculateTouchpadPressPosition();
+                TouchpadPressPosition pressPosition = CalculateTouchpadPressPosition();
                 switch (pressPosition)
                 {
                     case TouchpadPressPosition.Top:

--- a/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Resources/Scripts/VRTK_RadialMenu.cs
@@ -80,6 +80,7 @@ namespace VRTK
 
         protected int currentHover = -1;
         protected int currentPress = -1;
+        protected Coroutine tweenMenuScaleRoutine;
 
         /// <summary>
         /// The HoverButton method is used to set the button hover at a given angle.
@@ -145,8 +146,7 @@ namespace VRTK
             if (!isShown)
             {
                 isShown = true;
-                StopCoroutine("TweenMenuScale");
-                StartCoroutine("TweenMenuScale", isShown);
+                InitTweenMenuScale(isShown);
             }
         }
 
@@ -173,8 +173,7 @@ namespace VRTK
             if (isShown && (hideOnRelease || force))
             {
                 isShown = false;
-                StopCoroutine("TweenMenuScale");
-                StartCoroutine("TweenMenuScale", isShown);
+                InitTweenMenuScale(isShown);
             }
         }
 
@@ -338,6 +337,16 @@ namespace VRTK
             currentHover = buttonID; //Set current hover ID, need this to un-hover if selected button changes
         }
 
+
+        protected virtual void InitTweenMenuScale(bool isShown)
+        {
+            if (tweenMenuScaleRoutine != null)
+            {
+                StopCoroutine(tweenMenuScaleRoutine);
+            }
+            tweenMenuScaleRoutine = StartCoroutine(TweenMenuScale(isShown));
+        }
+
         //Simple tweening for menu, scales linearly from 0 to 1 and 1 to 0
         protected virtual IEnumerator TweenMenuScale(bool show)
         {
@@ -356,7 +365,6 @@ namespace VRTK
                 i++;
             }
             transform.localScale = Dir * targetScale;
-            StopCoroutine("TweenMenuScale");
         }
 
         protected virtual void AttempHapticPulse(float strength)

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
@@ -83,16 +83,18 @@ namespace VRTK.Highlighters
 
             if (faderRoutines != null)
             {
-                foreach (var fadeRoutine in faderRoutines)
+                foreach (KeyValuePair<string, Coroutine> fadeRoutine in faderRoutines)
                 {
                     StopCoroutine(fadeRoutine.Value);
                 }
                 faderRoutines.Clear();
             }
 
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
             {
-                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                Renderer renderer = renderers[i];
+                string objectReference = renderer.gameObject.GetInstanceID().ToString();
                 if (!originalRendererMaterials.ContainsKey(objectReference))
                 {
                     continue;
@@ -107,9 +109,11 @@ namespace VRTK.Highlighters
         {
             originalSharedRendererMaterials.Clear();
             originalRendererMaterials.Clear();
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
             {
-                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                Renderer renderer = renderers[i];
+                string objectReference = renderer.gameObject.GetInstanceID().ToString();
                 originalSharedRendererMaterials[objectReference] = renderer.sharedMaterials;
                 originalRendererMaterials[objectReference] = renderer.materials;
                 renderer.sharedMaterials = originalSharedRendererMaterials[objectReference];
@@ -118,20 +122,22 @@ namespace VRTK.Highlighters
 
         protected virtual void ChangeToHighlightColor(Color color, float duration = 0f)
         {
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            for (int j = 0; j < renderers.Length; j++)
             {
-                var swapCustomMaterials = new Material[renderer.materials.Length];
+                Renderer renderer = renderers[j];
+                Material[] swapCustomMaterials = new Material[renderer.materials.Length];
 
                 for (int i = 0; i < renderer.materials.Length; i++)
                 {
-                    var material = renderer.materials[i];
-                    if (customMaterial)
+                    Material material = renderer.materials[i];
+                    if (customMaterial != null)
                     {
                         material = customMaterial;
                         swapCustomMaterials[i] = material;
                     }
 
-                    var faderRoutineID = material.GetInstanceID().ToString();
+                    string faderRoutineID = material.GetInstanceID().ToString();
 
                     if (faderRoutines.ContainsKey(faderRoutineID) && faderRoutines[faderRoutineID] != null)
                     {
@@ -163,7 +169,7 @@ namespace VRTK.Highlighters
                     }
                 }
 
-                if (customMaterial)
+                if (customMaterial != null)
                 {
                     renderer.materials = swapCustomMaterials;
                 }
@@ -172,7 +178,7 @@ namespace VRTK.Highlighters
 
         protected virtual IEnumerator CycleColor(Material material, Color startColor, Color endColor, float duration)
         {
-            var elapsedTime = 0f;
+            float elapsedTime = 0f;
             while (elapsedTime <= duration)
             {
                 elapsedTime += Time.deltaTime;

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_MaterialPropertyBlockColorSwapHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_MaterialPropertyBlockColorSwapHighlighter.cs
@@ -48,16 +48,18 @@ namespace VRTK.Highlighters
 
             if (faderRoutines != null)
             {
-                foreach (var fadeRoutine in faderRoutines)
+                foreach (KeyValuePair<string, Coroutine> fadeRoutine in faderRoutines)
                 {
                     StopCoroutine(fadeRoutine.Value);
                 }
                 faderRoutines.Clear();
             }
 
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
             {
-                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                Renderer renderer = renderers[i];
+                string objectReference = renderer.gameObject.GetInstanceID().ToString();
                 if (!originalMaterialPropertyBlocks.ContainsKey(objectReference))
                 {
                     continue;
@@ -71,9 +73,11 @@ namespace VRTK.Highlighters
         {
             originalMaterialPropertyBlocks.Clear();
             highlightMaterialPropertyBlocks.Clear();
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
             {
-                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                Renderer renderer = renderers[i];
+                string objectReference = renderer.gameObject.GetInstanceID().ToString();
                 originalMaterialPropertyBlocks[objectReference] = new MaterialPropertyBlock();
                 renderer.GetPropertyBlock(originalMaterialPropertyBlocks[objectReference]);
                 highlightMaterialPropertyBlocks[objectReference] = new MaterialPropertyBlock();
@@ -82,9 +86,11 @@ namespace VRTK.Highlighters
 
         protected override void ChangeToHighlightColor(Color color, float duration = 0f)
         {
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
+            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
             {
-                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                Renderer renderer = renderers[i];
+                string objectReference = renderer.gameObject.GetInstanceID().ToString();
                 if (!originalMaterialPropertyBlocks.ContainsKey(objectReference))
                 {
                     continue;
@@ -96,7 +102,7 @@ namespace VRTK.Highlighters
                     faderRoutines.Remove(objectReference);
                 }
 
-                var highlightMaterialPropertyBlock = highlightMaterialPropertyBlocks[objectReference];
+                MaterialPropertyBlock highlightMaterialPropertyBlock = highlightMaterialPropertyBlocks[objectReference];
                 renderer.GetPropertyBlock(highlightMaterialPropertyBlock);
                 if (resetMainTexture)
                 {
@@ -118,7 +124,7 @@ namespace VRTK.Highlighters
 
         protected virtual IEnumerator CycleColor(Renderer renderer, MaterialPropertyBlock highlightMaterialPropertyBlock, Color endColor, float duration)
         {
-            var elapsedTime = 0f;
+            float elapsedTime = 0f;
             while (elapsedTime <= duration)
             {
                 elapsedTime += Time.deltaTime;

--- a/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_ControlDirectionGrabAction.cs
+++ b/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_ControlDirectionGrabAction.cs
@@ -107,7 +107,7 @@ namespace VRTK.SecondaryControllerGrabActions
 
         protected virtual IEnumerator RealignOnRelease()
         {
-            var elapsedTime = 0f;
+            float elapsedTime = 0f;
 
             while (elapsedTime < releaseSnapSpeed)
             {

--- a/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAppearance.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_ObjectAppearance.cs
@@ -146,8 +146,10 @@ namespace VRTK
         {
             if (model != null)
             {
-                foreach (Renderer renderer in model.GetComponentsInChildren<Renderer>(true))
+                Renderer[] renderers = model.GetComponentsInChildren<Renderer>(true);
+                for (int i = 0; i < renderers.Length; i++)
                 {
+                    Renderer renderer = renderers[i];
                     if (renderer.gameObject != ignoredModel && (ignoredModel == null || !renderer.transform.IsChildOf(ignoredModel.transform)))
                     {
                         renderer.enabled = true;
@@ -162,8 +164,10 @@ namespace VRTK
         {
             if (model != null)
             {
-                foreach (Renderer renderer in model.GetComponentsInChildren<Renderer>(true))
+                Renderer[] renderers = model.GetComponentsInChildren<Renderer>(true);
+                for (int i = 0; i < renderers.Length; i++)
                 {
+                    Renderer renderer = renderers[i];
                     if (renderer.gameObject != ignoredModel && (ignoredModel == null || !renderer.transform.IsChildOf(ignoredModel.transform)))
                     {
                         renderer.enabled = false;
@@ -230,8 +234,10 @@ namespace VRTK
             if (model != null)
             {
                 alpha = Mathf.Clamp(alpha, 0f, 1f);
-                foreach (Renderer renderer in model.GetComponentsInChildren<Renderer>(true))
+                Renderer[] renderers = model.GetComponentsInChildren<Renderer>(true);
+                for (int i = 0; i < renderers.Length; i++)
                 {
+                    Renderer renderer = renderers[i];
                     if (alpha < 1f)
                     {
                         renderer.material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);

--- a/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -204,6 +204,7 @@ namespace VRTK
         protected List<GameObject> ignoreCollisionsOnGameObjects = new List<GameObject>();
         protected Transform cachedGrabbedObjectTransform = null;
         protected VRTK_InteractableObject cachedGrabbedObject;
+        protected Coroutine restoreCollisionsRoutine;
 
         // Draws a sphere for current standing position and a sphere for current headset position.
         // Set to `true` to view the debug spheres.
@@ -1179,7 +1180,10 @@ namespace VRTK
         {
             if (e.target != null)
             {
-                StopCoroutine("RestoreCollisions");
+                if (restoreCollisionsRoutine != null)
+                {
+                    StopCoroutine(restoreCollisionsRoutine);
+                }
                 IgnoreCollisions(e.target.GetComponentsInChildren<Collider>(), true);
             }
         }
@@ -1188,7 +1192,7 @@ namespace VRTK
         {
             if (gameObject.activeInHierarchy && playArea.gameObject.activeInHierarchy)
             {
-                StartCoroutine(RestoreCollisions(e.target));
+                restoreCollisionsRoutine = StartCoroutine(RestoreCollisions(e.target));
             }
         }
 

--- a/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UICanvas.cs
@@ -46,18 +46,18 @@ namespace VRTK
 
         protected virtual void OnTriggerEnter(Collider collider)
         {
-            var colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
-            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
-            if (pointerCheck && colliderCheck && colliderCheck.objectType == VRTK_PlayerObject.ObjectTypes.Collider)
+            VRTK_PlayerObject colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
+            VRTK_UIPointer pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
+            if (pointerCheck != null && colliderCheck != null && colliderCheck.objectType == VRTK_PlayerObject.ObjectTypes.Collider)
             {
-                pointerCheck.collisionClick = (clickOnPointerCollision ? true : false);
+                pointerCheck.collisionClick = clickOnPointerCollision;
             }
         }
 
         protected virtual void OnTriggerExit(Collider collider)
         {
-            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
-            if (pointerCheck)
+            VRTK_UIPointer pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
+            if (pointerCheck != null)
             {
                 pointerCheck.collisionClick = false;
             }
@@ -65,27 +65,27 @@ namespace VRTK
 
         protected virtual void SetupCanvas()
         {
-            var canvas = GetComponent<Canvas>();
+            Canvas canvas = GetComponent<Canvas>();
 
-            if (!canvas || canvas.renderMode != RenderMode.WorldSpace)
+            if (canvas == null || canvas.renderMode != RenderMode.WorldSpace)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_UICanvas", "Canvas", "the same", " that is set to `Render Mode = World Space`"));
                 return;
             }
 
-            var canvasRectTransform = canvas.GetComponent<RectTransform>();
-            var canvasSize = canvasRectTransform.sizeDelta;
+            RectTransform canvasRectTransform = canvas.GetComponent<RectTransform>();
+            Vector2 canvasSize = canvasRectTransform.sizeDelta;
             //copy public params then disable existing graphic raycaster
-            var defaultRaycaster = canvas.gameObject.GetComponent<GraphicRaycaster>();
-            var customRaycaster = canvas.gameObject.GetComponent<VRTK_UIGraphicRaycaster>();
+            GraphicRaycaster defaultRaycaster = canvas.gameObject.GetComponent<GraphicRaycaster>();
+            VRTK_UIGraphicRaycaster customRaycaster = canvas.gameObject.GetComponent<VRTK_UIGraphicRaycaster>();
 
             //if it doesn't already exist, add the custom raycaster
-            if (!customRaycaster)
+            if (customRaycaster == null)
             {
                 customRaycaster = canvas.gameObject.AddComponent<VRTK_UIGraphicRaycaster>();
             }
 
-            if (defaultRaycaster && defaultRaycaster.enabled)
+            if (defaultRaycaster != null && defaultRaycaster.enabled)
             {
                 customRaycaster.ignoreReversedGraphics = defaultRaycaster.ignoreReversedGraphics;
                 customRaycaster.blockingObjects = defaultRaycaster.blockingObjects;
@@ -93,7 +93,7 @@ namespace VRTK
             }
 
             //add a box collider and background image to ensure the rays always hit
-            if (!canvas.gameObject.GetComponent<BoxCollider>())
+            if (canvas.gameObject.GetComponent<BoxCollider>() == null)
             {
                 Vector2 pivot = canvasRectTransform.pivot;
                 float zSize = 0.1f;
@@ -105,7 +105,7 @@ namespace VRTK
                 canvasBoxCollider.isTrigger = true;
             }
 
-            if (!canvas.gameObject.GetComponent<Rigidbody>())
+            if (canvas.gameObject.GetComponent<Rigidbody>() == null)
             {
                 canvasRigidBody = canvas.gameObject.AddComponent<Rigidbody>();
                 canvasRigidBody.isKinematic = true;
@@ -117,11 +117,11 @@ namespace VRTK
 
         protected virtual IEnumerator CreateDraggablePanel(Canvas canvas, Vector2 canvasSize)
         {
-            if (canvas && !canvas.transform.Find(CANVAS_DRAGGABLE_PANEL))
+            if (canvas != null && !canvas.transform.Find(CANVAS_DRAGGABLE_PANEL))
             {
                 yield return null;
 
-                var draggablePanel = new GameObject(CANVAS_DRAGGABLE_PANEL, typeof(RectTransform));
+                GameObject draggablePanel = new GameObject(CANVAS_DRAGGABLE_PANEL, typeof(RectTransform));
                 draggablePanel.AddComponent<LayoutElement>().ignoreLayout = true;
                 draggablePanel.AddComponent<Image>().color = Color.clear;
                 draggablePanel.AddComponent<EventTrigger>();
@@ -138,20 +138,20 @@ namespace VRTK
         protected virtual void CreateActivator(Canvas canvas, Vector2 canvasSize)
         {
             //if autoActivateWithinDistance is greater than 0 then create the front collider sub object
-            if (autoActivateWithinDistance > 0f && canvas && !canvas.transform.Find(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT))
+            if (autoActivateWithinDistance > 0f && canvas != null && !canvas.transform.Find(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT))
             {
-                var canvasRectTransform = canvas.GetComponent<RectTransform>();
+                RectTransform canvasRectTransform = canvas.GetComponent<RectTransform>();
                 Vector2 pivot = canvasRectTransform.pivot;
 
-                var frontTrigger = new GameObject(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT);
+                GameObject frontTrigger = new GameObject(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT);
                 frontTrigger.transform.SetParent(canvas.transform);
                 frontTrigger.transform.SetAsFirstSibling();
                 frontTrigger.transform.localPosition = new Vector3(canvasSize.x / 2 - canvasSize.x * pivot.x, canvasSize.y / 2 - canvasSize.y * pivot.y);
                 frontTrigger.transform.localRotation = Quaternion.identity;
                 frontTrigger.transform.localScale = Vector3.one;
 
-                var actualActivationDistance = autoActivateWithinDistance / canvasRectTransform.localScale.z;
-                var frontTriggerBoxCollider = frontTrigger.AddComponent<BoxCollider>();
+                float actualActivationDistance = autoActivateWithinDistance / canvasRectTransform.localScale.z;
+                BoxCollider frontTriggerBoxCollider = frontTrigger.AddComponent<BoxCollider>();
                 frontTriggerBoxCollider.isTrigger = true;
                 frontTriggerBoxCollider.size = new Vector3(canvasSize.x, canvasSize.y, actualActivationDistance);
                 frontTriggerBoxCollider.center = new Vector3(0f, 0f, -(actualActivationDistance / 2));
@@ -164,47 +164,51 @@ namespace VRTK
 
         protected virtual void RemoveCanvas()
         {
-            var canvas = GetComponent<Canvas>();
+            Canvas canvas = GetComponent<Canvas>();
 
-            if (!canvas)
+            if (canvas == null)
             {
                 return;
             }
 
-            var defaultRaycaster = canvas.gameObject.GetComponent<GraphicRaycaster>();
-            var customRaycaster = canvas.gameObject.GetComponent<VRTK_UIGraphicRaycaster>();
+            GraphicRaycaster defaultRaycaster = canvas.gameObject.GetComponent<GraphicRaycaster>();
+            VRTK_UIGraphicRaycaster customRaycaster = canvas.gameObject.GetComponent<VRTK_UIGraphicRaycaster>();
             //if a custom raycaster exists then remove it
-            if (customRaycaster)
+            if (customRaycaster != null)
             {
                 Destroy(customRaycaster);
             }
 
             //If the default raycaster is disabled, then re-enable it
-            if (defaultRaycaster && !defaultRaycaster.enabled)
+            if (defaultRaycaster != null && !defaultRaycaster.enabled)
             {
                 defaultRaycaster.enabled = true;
             }
 
             //Check if there is a collider and remove it if there is
-            if (canvasBoxCollider)
+            if (canvasBoxCollider != null)
             {
                 Destroy(canvasBoxCollider);
             }
 
-            if (canvasRigidBody)
+            if (canvasRigidBody != null)
             {
                 Destroy(canvasRigidBody);
             }
 
-            StopCoroutine(draggablePanelCreation);
-            var draggablePanel = canvas.transform.Find(CANVAS_DRAGGABLE_PANEL);
-            if (draggablePanel)
+            if (draggablePanelCreation != null)
+            {
+                StopCoroutine(draggablePanelCreation);
+            }
+
+            Transform draggablePanel = canvas.transform.Find(CANVAS_DRAGGABLE_PANEL);
+            if (draggablePanel != null)
             {
                 Destroy(draggablePanel.gameObject);
             }
 
-            var frontTrigger = canvas.transform.Find(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT);
-            if (frontTrigger)
+            Transform frontTrigger = canvas.transform.Find(ACTIVATOR_FRONT_TRIGGER_GAMEOBJECT);
+            if (frontTrigger != null)
             {
                 Destroy(frontTrigger.gameObject);
             }
@@ -215,9 +219,9 @@ namespace VRTK
     {
         protected virtual void OnTriggerEnter(Collider collider)
         {
-            var colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
-            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
-            if (pointerCheck && colliderCheck && colliderCheck.objectType == VRTK_PlayerObject.ObjectTypes.Collider)
+            VRTK_PlayerObject colliderCheck = collider.GetComponentInParent<VRTK_PlayerObject>();
+            VRTK_UIPointer pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
+            if (pointerCheck != null && colliderCheck != null && colliderCheck.objectType == VRTK_PlayerObject.ObjectTypes.Collider)
             {
                 pointerCheck.autoActivatingCanvas = gameObject;
             }
@@ -225,8 +229,8 @@ namespace VRTK
 
         protected virtual void OnTriggerExit(Collider collider)
         {
-            var pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
-            if (pointerCheck && pointerCheck.autoActivatingCanvas == gameObject)
+            VRTK_UIPointer pointerCheck = collider.GetComponentInParent<VRTK_UIPointer>();
+            if (pointerCheck != null && pointerCheck.autoActivatingCanvas == gameObject)
             {
                 pointerCheck.autoActivatingCanvas = null;
             }


### PR DESCRIPTION
A number of files were not adhering to the coding conventions and
using the `var` keyword or using `foreach` instead of `for`.

Also some coroutines were not being started and stopped correctly
without necessary checking before stopping.