### PR TITLE
refactor(Structure): apply coding conventions to scripts

### DIFF
--- a/Assets/VRTK/Prefabs/Resources/SubPrefabs/RadialMenuButton/UICircle.cs
+++ b/Assets/VRTK/Prefabs/Resources/SubPrefabs/RadialMenuButton/UICircle.cs
@@ -52,7 +52,7 @@ namespace VRTK
             UIVertex[] vbo = new UIVertex[4];
             for (int i = 0; i < vertices.Length; i++)
             {
-                var vert = UIVertex.simpleVert;
+                UIVertex vert = UIVertex.simpleVert;
                 vert.color = color;
                 vert.position = vertices[i];
                 vert.uv0 = uvs[i];

--- a/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/SDK/Base/SDK_BaseHeadset.cs
@@ -74,7 +74,7 @@ namespace VRTK
 
         protected Transform GetSDKManagerHeadset()
         {
-            var sdkManager = VRTK_SDKManager.instance;
+            VRTK_SDKManager sdkManager = VRTK_SDKManager.instance;
             if (sdkManager != null && sdkManager.loadedSetup != null && sdkManager.loadedSetup.actualHeadset != null)
             {
                 cachedHeadset = (sdkManager.loadedSetup.actualHeadset ? sdkManager.loadedSetup.actualHeadset.transform : null);

--- a/Assets/VRTK/SDK/Oculus/SDK_OculusBoundaries.cs
+++ b/Assets/VRTK/SDK/Oculus/SDK_OculusBoundaries.cs
@@ -37,8 +37,8 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                var ovrManager = VRTK_SharedMethods.FindEvenInactiveComponent<OVRManager>();
-                if (ovrManager)
+                OVRManager ovrManager = VRTK_SharedMethods.FindEvenInactiveComponent<OVRManager>();
+                if (ovrManager != null)
                 {
                     cachedPlayArea = ovrManager.transform;
                 }
@@ -53,13 +53,13 @@ namespace VRTK
         /// <returns>A Vector3 array of the points in the scene that represent the play area boundaries.</returns>
         public override Vector3[] GetPlayAreaVertices()
         {
-            var area = new OVRBoundary();
+            OVRBoundary area = new OVRBoundary();
             if (area.GetConfigured())
             {
-                var outerBoundary = area.GetDimensions(OVRBoundary.BoundaryType.OuterBoundary);
-                var thickness = 0.1f;
+                Vector3 outerBoundary = area.GetDimensions(OVRBoundary.BoundaryType.OuterBoundary);
+                float thickness = 0.1f;
 
-                var vertices = new Vector3[8];
+                Vector3[] vertices = new Vector3[8];
 
                 vertices[0] = new Vector3(outerBoundary.x - thickness, 0f, outerBoundary.z - thickness);
                 vertices[1] = new Vector3(0f + thickness, 0f, outerBoundary.z - thickness);
@@ -125,7 +125,7 @@ namespace VRTK
                 avatarContainer = VRTK_SharedMethods.FindEvenInactiveComponent<OvrAvatar>();
                 if (avatarContainer != null && avatarContainer.GetComponent<VRTK_TransformFollow>() == null)
                 {
-                    var objectFollow = avatarContainer.gameObject.AddComponent<VRTK_TransformFollow>();
+                    VRTK_TransformFollow objectFollow = avatarContainer.gameObject.AddComponent<VRTK_TransformFollow>();
                     objectFollow.gameObjectToFollow = GetPlayArea().gameObject;
                 }
             }

--- a/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
@@ -166,7 +166,7 @@ namespace VRTK
             leftController.selected = false;
             destroyed = false;
 
-            var controllerSDK = VRTK_SDK_Bridge.GetControllerSDK() as SDK_SimController;
+            SDK_SimController controllerSDK = VRTK_SDK_Bridge.GetControllerSDK() as SDK_SimController;
             if (controllerSDK != null)
             {
                 Dictionary<string, KeyCode> keyMappings = new Dictionary<string, KeyCode>()
@@ -289,7 +289,7 @@ namespace VRTK
             if (Physics.Raycast(screenRay, out hit))
             {
                 VRTK_InteractableObject io = hit.collider.gameObject.GetComponent<VRTK_InteractableObject>();
-                if (io)
+                if (io != null)
                 {
                     GameObject hand;
                     if (rightHand)

--- a/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -44,11 +44,11 @@ namespace VRTK
             if (cachedHeadset == null)
             {
 #if (UNITY_5_4_OR_NEWER)
-                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
+                SteamVR_Camera foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
 #else
-                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_GameView>();
+                SteamVR_GameView foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_GameView>();
 #endif
-                if (foundCamera)
+                if (foundCamera != null)
                 {
                     cachedHeadset = foundCamera.transform;
                 }
@@ -65,8 +65,8 @@ namespace VRTK
             cachedHeadsetCamera = GetSDKManagerHeadset();
             if (cachedHeadsetCamera == null)
             {
-                var foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
-                if (foundCamera)
+                SteamVR_Camera foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
+                if (foundCamera != null)
                 {
                     cachedHeadsetCamera = foundCamera.transform;
                 }
@@ -110,7 +110,7 @@ namespace VRTK
         /// <returns>Returns true if the headset has fade functionality on it.</returns>
         public override bool HasHeadsetFade(Transform obj)
         {
-            if (obj.GetComponentInChildren<SteamVR_Fade>())
+            if (obj.GetComponentInChildren<SteamVR_Fade>() != null)
             {
                 return true;
             }
@@ -123,7 +123,7 @@ namespace VRTK
         /// <param name="camera">The Transform to with the camera on to add the fade functionality to.</param>
         public override void AddHeadsetFade(Transform camera)
         {
-            if (camera && !camera.GetComponent<SteamVR_Fade>())
+            if (camera != null && camera.GetComponent<SteamVR_Fade>() == null)
             {
                 camera.gameObject.AddComponent<SteamVR_Fade>();
             }

--- a/Assets/VRTK/Scripts/Controls/3D/Utilities/VRTK_ContentHandler.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/Utilities/VRTK_ContentHandler.cs
@@ -27,11 +27,13 @@ namespace VRTK
             if (contentInteractableObject == null)
             {
                 // treat as parent and assign to all children
-                foreach (var childIo in GetComponentsInChildren<VRTK_InteractableObject>())
+                VRTK_InteractableObject[] foundObjects = GetComponentsInChildren<VRTK_InteractableObject>();
+                for (int i = 0; i < foundObjects.Length; i++)
                 {
-                    if (childIo.GetComponent<VRTK_ContentHandler>() == null)
+                    VRTK_InteractableObject foundIO = foundObjects[i];
+                    if (foundIO.GetComponent<VRTK_ContentHandler>() == null)
                     {
-                        VRTK_ContentHandler childContentHandler = childIo.gameObject.AddComponent<VRTK_ContentHandler>();
+                        VRTK_ContentHandler childContentHandler = foundIO.gameObject.AddComponent<VRTK_ContentHandler>();
                         childContentHandler.control = control;
                         childContentHandler.inside = inside;
                         childContentHandler.outside = outside;

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Control.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Control.cs
@@ -239,9 +239,10 @@ namespace VRTK
             }
 
             // do not cache objects since otherwise they would still be made inactive once taken out of the content
-            foreach (var io in controlContent.GetComponentsInChildren<VRTK_InteractableObject>(true))
+            VRTK_InteractableObject[] foundInteractableObjects = controlContent.GetComponentsInChildren<VRTK_InteractableObject>(true);
+            for (int i = 0; i < foundInteractableObjects.Length; i++)
             {
-                io.enabled = value > MIN_OPENING_DISTANCE;
+                foundInteractableObjects[i].enabled = value > MIN_OPENING_DISTANCE;
             }
         }
     }

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Slider.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Slider.cs
@@ -65,7 +65,7 @@ namespace VRTK
         {
             if (sliderJointCreated)
             {
-                if (connectedTo)
+                if (connectedTo != null)
                 {
                     sliderJoint.connectedBody = connectedTo.GetComponent<Rigidbody>();
                 }
@@ -157,9 +157,9 @@ namespace VRTK
 
         protected virtual Vector3 CalculateDiff(Vector3 initialPosition, Vector3 givenDirection, float scaleValue, float diffMultiplier, bool addition)
         {
-            var additionDiff = givenDirection * diffMultiplier;
+            Vector3 additionDiff = givenDirection * diffMultiplier;
 
-            var limitDiff = givenDirection * (scaleValue / 2f);
+            Vector3 limitDiff = givenDirection * (scaleValue / 2f);
             if (addition)
             {
                 limitDiff = initialPosition + limitDiff;
@@ -169,7 +169,7 @@ namespace VRTK
                 limitDiff = initialPosition - limitDiff;
             }
 
-            var answer = initialPosition - limitDiff;
+            Vector3 answer = initialPosition - limitDiff;
 
             if (addition)
             {
@@ -195,7 +195,7 @@ namespace VRTK
             sliderRigidbody.constraints = RigidbodyConstraints.FreezeRotation;
             sliderRigidbody.drag = releasedFriction;
 
-            if (connectedTo)
+            if (connectedTo != null)
             {
                 Rigidbody connectedToRigidbody = connectedTo.GetComponent<Rigidbody>();
                 if (connectedToRigidbody == null)

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Wheel.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Wheel.cs
@@ -141,9 +141,9 @@ namespace VRTK
 
         protected virtual void SetupHingeRestrictions()
         {
-            var minJointLimit = 0f;
-            var maxJointLimit = maxAngle;
-            var limitOffset = maxAngle - 180f;
+            float minJointLimit = 0f;
+            float maxJointLimit = maxAngle;
+            float limitOffset = maxAngle - 180f;
 
             if (limitOffset > 0f)
             {

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseJointGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_BaseJointGrabAttach.cs
@@ -66,9 +66,9 @@ namespace VRTK.GrabAttachMechanics
 
         protected override Rigidbody ReleaseFromController(bool applyGrabbingObjectVelocity)
         {
-            if (controllerAttachJoint)
+            if (controllerAttachJoint != null)
             {
-                var jointRigidbody = controllerAttachJoint.GetComponent<Rigidbody>();
+                Rigidbody jointRigidbody = controllerAttachJoint.GetComponent<Rigidbody>();
                 DestroyJoint(destroyImmediatelyOnThrow, applyGrabbingObjectVelocity);
                 controllerAttachJoint = null;
 

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
@@ -30,13 +30,13 @@ namespace VRTK.GrabAttachMechanics
 
         protected override void CreateJoint(GameObject obj)
         {
-            if (!jointHolder)
+            if (jointHolder == null)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, "VRTK_CustomJointGrabAttach", "Joint", "customJoint", "the same"));
                 return;
             }
-            var storedJoint = jointHolder.GetComponent<Joint>();
-            var storeName = gameObject.name;
+            Joint storedJoint = jointHolder.GetComponent<Joint>();
+            string storeName = gameObject.name;
             VRTK_SharedMethods.CloneComponent(storedJoint, obj, true);
             gameObject.name = storeName;
             givenJoint = obj.GetComponent(storedJoint.GetType()) as Joint;
@@ -51,7 +51,7 @@ namespace VRTK.GrabAttachMechanics
 
         protected virtual void CopyCustomJoint()
         {
-            if (customJoint)
+            if (customJoint != null)
             {
                 jointHolder = new GameObject();
                 jointHolder.transform.SetParent(transform);

--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_RotatorTrackGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_RotatorTrackGrabAttach.cs
@@ -30,7 +30,7 @@ namespace VRTK.GrabAttachMechanics
         /// </summary>
         public override void ProcessFixedUpdate()
         {
-            var rotateForce = trackPoint.position - initialAttachPoint.position;
+            Vector3 rotateForce = trackPoint.position - initialAttachPoint.position;
             grabbedObjectRigidBody.AddForceAtPosition(rotateForce, initialAttachPoint.position, ForceMode.VelocityChange);
         }
 

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_BaseHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_BaseHighlighter.cs
@@ -78,11 +78,13 @@ namespace VRTK.Highlighters
         public static VRTK_BaseHighlighter GetActiveHighlighter(GameObject obj)
         {
             VRTK_BaseHighlighter objectHighlighter = null;
-            foreach (var tmpHighlighter in obj.GetComponents<VRTK_BaseHighlighter>())
+            VRTK_BaseHighlighter[] foundHighlighters = obj.GetComponents<VRTK_BaseHighlighter>();
+            for (int i = 0; i < foundHighlighters.Length; i++)
             {
-                if (tmpHighlighter.active)
+                VRTK_BaseHighlighter foundHighlighter = foundHighlighters[i];
+                if (foundHighlighter.active)
                 {
-                    objectHighlighter = tmpHighlighter;
+                    objectHighlighter = foundHighlighter;
                     break;
                 }
             }

--- a/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -74,7 +74,7 @@ namespace VRTK.Highlighters
 
                 for (int i = 0; i < highlightModels.Length; i++)
                 {
-                    if (highlightModels[i])
+                    if (highlightModels[i] != null)
                     {
                         highlightModels[i].SetActive(true);
                     }
@@ -93,7 +93,7 @@ namespace VRTK.Highlighters
             {
                 for (int i = 0; i < highlightModels.Length; i++)
                 {
-                    if (highlightModels[i])
+                    if (highlightModels[i] != null)
                     {
                         highlightModels[i].SetActive(false);
                     }
@@ -120,7 +120,7 @@ namespace VRTK.Highlighters
             {
                 for (int i = 0; i < highlightModels.Length; i++)
                 {
-                    if (highlightModels[i])
+                    if (highlightModels[i] != null)
                     {
                         Destroy(highlightModels[i]);
                     }
@@ -164,19 +164,19 @@ namespace VRTK.Highlighters
 
         protected virtual void SetOptions(Dictionary<string, object> options = null)
         {
-            var tmpThickness = GetOption<float>(options, "thickness");
+            float tmpThickness = GetOption<float>(options, "thickness");
             if (tmpThickness > 0f)
             {
                 thickness = tmpThickness;
             }
 
-            var tmpCustomModels = GetOption<GameObject[]>(options, "customOutlineModels");
+            GameObject[] tmpCustomModels = GetOption<GameObject[]>(options, "customOutlineModels");
             if (tmpCustomModels != null)
             {
                 customOutlineModels = tmpCustomModels;
             }
 
-            var tmpCustomModelPaths = GetOption<string[]>(options, "customOutlineModelPaths");
+            string[] tmpCustomModelPaths = GetOption<string[]>(options, "customOutlineModelPaths");
             if (tmpCustomModelPaths != null)
             {
                 customOutlineModelPaths = tmpCustomModelPaths;
@@ -185,7 +185,7 @@ namespace VRTK.Highlighters
 
         protected virtual void DeleteExistingHighlightModels()
         {
-            var existingHighlighterObjects = GetComponentsInChildren<VRTK_PlayerObject>(true);
+            VRTK_PlayerObject[] existingHighlighterObjects = GetComponentsInChildren<VRTK_PlayerObject>(true);
             for (int i = 0; i < existingHighlighterObjects.Length; i++)
             {
                 if (existingHighlighterObjects[i].objectType == VRTK_PlayerObject.ObjectTypes.Highlighter)
@@ -203,7 +203,7 @@ namespace VRTK.Highlighters
             }
             else if (givenOutlineModelPath != "")
             {
-                var getChildModel = transform.Find(givenOutlineModelPath);
+                Transform getChildModel = transform.Find(givenOutlineModelPath);
                 givenOutlineModel = (getChildModel ? getChildModel.gameObject : null);
             }
 
@@ -226,17 +226,19 @@ namespace VRTK.Highlighters
             highlightModel.transform.localScale = copyModel.transform.localScale;
             highlightModel.transform.SetParent(transform);
 
-            foreach (var component in copyModel.GetComponents<Component>())
+            Component[] copyModelComponents = copyModel.GetComponents<Component>();
+            for (int i = 0; i < copyModelComponents.Length; i++)
             {
-                if (Array.IndexOf(copyComponents, component.GetType().ToString()) >= 0)
+                Component copyModelComponent = copyModelComponents[i];
+                if (Array.IndexOf(copyComponents, copyModelComponent.GetType().ToString()) >= 0)
                 {
-                    VRTK_SharedMethods.CloneComponent(component, highlightModel);
+                    VRTK_SharedMethods.CloneComponent(copyModelComponent, highlightModel);
                 }
             }
 
-            var copyMesh = copyModel.GetComponent<MeshFilter>();
-            var highlightMesh = highlightModel.GetComponent<MeshFilter>();
-            if (highlightMesh)
+            MeshFilter copyMesh = copyModel.GetComponent<MeshFilter>();
+            MeshFilter highlightMesh = highlightModel.GetComponent<MeshFilter>();
+            if (highlightMesh != null)
             {
                 if (enableSubmeshHighlight)
                 {

--- a/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
+++ b/Assets/VRTK/Scripts/Interactions/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
@@ -95,7 +95,7 @@ namespace VRTK.SecondaryControllerGrabActions
             float newScaleY = CalculateAxisScale(initialRotatedPosition.y, initialSecondGrabRotatedPosition.y, currentSecondGrabRotatedPosition.y);
             float newScaleZ = CalculateAxisScale(initialRotatedPosition.z, initialSecondGrabRotatedPosition.z, currentSecondGrabRotatedPosition.z);
 
-            var newScale = new Vector3(newScaleX, newScaleY, newScaleZ) + initialScale;
+            Vector3 newScale = new Vector3(newScaleX, newScaleY, newScaleZ) + initialScale;
             ApplyScale(newScale);
         }
 
@@ -104,7 +104,7 @@ namespace VRTK.SecondaryControllerGrabActions
             float adjustedLength = (grabbedObject.transform.position - secondaryGrabbingObject.transform.position).magnitude;
             float adjustedScale = initialScaleFactor * adjustedLength;
 
-            var newScale = new Vector3(adjustedScale, adjustedScale, adjustedScale);
+            Vector3 newScale = new Vector3(adjustedScale, adjustedScale, adjustedScale);
             ApplyScale(newScale);
         }
 

--- a/Assets/VRTK/Scripts/Internal/VRTK_PlayerObject.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_PlayerObject.cs
@@ -30,7 +30,7 @@ namespace VRTK
         /// <param name="objType">The type of player object that is to be assigned.</param>
         public static void SetPlayerObject(GameObject obj, ObjectTypes objType)
         {
-            var currentPlayerObject = obj.GetComponent<VRTK_PlayerObject>();
+            VRTK_PlayerObject currentPlayerObject = obj.GetComponent<VRTK_PlayerObject>();
             if (currentPlayerObject == null)
             {
                 currentPlayerObject = obj.AddComponent<VRTK_PlayerObject>();
@@ -46,9 +46,10 @@ namespace VRTK
         /// <returns>Returns true if the object is a player object with the optional given type.</returns>
         public static bool IsPlayerObject(GameObject obj, ObjectTypes ofType = ObjectTypes.Null)
         {
-            foreach (var playerObject in obj.GetComponentsInParent<VRTK_PlayerObject>(true))
+            VRTK_PlayerObject[] playerObjects = obj.GetComponentsInParent<VRTK_PlayerObject>(true);
+            for (int i = 0; i < playerObjects.Length; i++)
             {
-                if (ofType == ObjectTypes.Null || ofType == playerObject.objectType)
+                if (ofType == ObjectTypes.Null || ofType == playerObjects[i].objectType)
                 {
                     return true;
                 }

--- a/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
@@ -56,24 +56,24 @@
                 return;
             }
 
-            var vertices = VRTK_SDK_Bridge.GetPlayAreaVertices();
+            Vector3[] vertices = VRTK_SDK_Bridge.GetPlayAreaVertices();
             if (vertices == null || vertices.Length == 0)
             {
                 return;
             }
 
-            var btmRight = 4;
-            var btmLeft = 5;
-            var topLeft = 6;
-            var topRight = 7;
+            int btmRight = 4;
+            int btmLeft = 5;
+            int topLeft = 6;
+            int topRight = 7;
 
-            var btmRightVertex = vertices[btmRight] * roomExtender.additionalMovementMultiplier;
-            var btmLeftVertex = vertices[btmLeft] * roomExtender.additionalMovementMultiplier;
-            var topLeftVertex = vertices[topLeft] * roomExtender.additionalMovementMultiplier;
-            var topRightVertex = vertices[topRight] * roomExtender.additionalMovementMultiplier;
+            Vector3 btmRightVertex = vertices[btmRight] * roomExtender.additionalMovementMultiplier;
+            Vector3 btmLeftVertex = vertices[btmLeft] * roomExtender.additionalMovementMultiplier;
+            Vector3 topLeftVertex = vertices[topLeft] * roomExtender.additionalMovementMultiplier;
+            Vector3 topRightVertex = vertices[topRight] * roomExtender.additionalMovementMultiplier;
 
-            var btmOffset = new Vector3(0f, roomExtender.transform.localPosition.y, 0f);
-            var topOffset = btmOffset + playArea.TransformVector(Vector3.up * wireframeHeight);
+            Vector3 btmOffset = new Vector3(0f, roomExtender.transform.localPosition.y, 0f);
+            Vector3 topOffset = btmOffset + playArea.TransformVector(Vector3.up * wireframeHeight);
             Gizmos.color = color;
             //bottom rectangle
             Gizmos.DrawLine(btmRightVertex + btmOffset, btmLeftVertex + btmOffset);

--- a/Assets/VRTK/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -30,7 +30,7 @@
                 return;
             }
 
-            var ray = new Ray(eventData.pointerCurrentRaycast.worldPosition, eventData.pointerCurrentRaycast.worldNormal);
+            Ray ray = new Ray(eventData.pointerCurrentRaycast.worldPosition, eventData.pointerCurrentRaycast.worldNormal);
             Raycast(canvas, eventCamera, ray, ref s_RaycastResults);
             SetNearestRaycast(ref eventData, ref resultAppendList, ref s_RaycastResults);
             s_RaycastResults.Clear();
@@ -40,7 +40,7 @@
         protected virtual void SetNearestRaycast(ref PointerEventData eventData, ref List<RaycastResult> resultAppendList, ref List<RaycastResult> raycastResults)
         {
             RaycastResult? nearestRaycast = null;
-            for (var index = 0; index < raycastResults.Count; index++)
+            for (int index = 0; index < raycastResults.Count; index++)
             {
                 RaycastResult castResult = raycastResults[index];
                 castResult.index = resultAppendList.Count;
@@ -63,11 +63,11 @@
         //[Pure]
         protected virtual float GetHitDistance(Ray ray)
         {
-            var hitDistance = float.MaxValue;
+            float hitDistance = float.MaxValue;
 
             if (canvas.renderMode != RenderMode.ScreenSpaceOverlay && blockingObjects != BlockingObjects.None)
             {
-                var maxDistance = Vector3.Distance(ray.origin, canvas.transform.position);
+                float maxDistance = Vector3.Distance(ray.origin, canvas.transform.position);
 
                 if (blockingObjects == BlockingObjects.ThreeD || blockingObjects == BlockingObjects.All)
                 {
@@ -95,18 +95,18 @@
         //[Pure]
         protected virtual void Raycast(Canvas canvas, Camera eventCamera, Ray ray, ref List<RaycastResult> results)
         {
-            var hitDistance = GetHitDistance(ray);
-            var canvasGraphics = GraphicRegistry.GetGraphicsForCanvas(canvas);
+            float hitDistance = GetHitDistance(ray);
+            IList<Graphic> canvasGraphics = GraphicRegistry.GetGraphicsForCanvas(canvas);
             for (int i = 0; i < canvasGraphics.Count; ++i)
             {
-                var graphic = canvasGraphics[i];
+                Graphic graphic = canvasGraphics[i];
 
                 if (graphic.depth == -1 || !graphic.raycastTarget)
                 {
                     continue;
                 }
 
-                var graphicTransform = graphic.transform;
+                Transform graphicTransform = graphic.transform;
                 Vector3 graphicForward = graphicTransform.forward;
                 float distance = Vector3.Dot(graphicForward, graphicTransform.position - ray.origin) / Vector3.Dot(graphicForward, ray.direction);
 
@@ -131,7 +131,7 @@
 
                 if (graphic.Raycast(pointerPosition, eventCamera))
                 {
-                    var result = new RaycastResult()
+                    RaycastResult result = new RaycastResult()
                     {
                         gameObject = graphic.gameObject,
                         module = this,

--- a/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
@@ -44,7 +44,7 @@
 
         protected virtual List<RaycastResult> CheckRaycasts(VRTK_UIPointer pointer)
         {
-            var raycastResult = new RaycastResult();
+            RaycastResult raycastResult = new RaycastResult();
             raycastResult.worldPosition = pointer.GetOriginPosition();
             raycastResult.worldNormal = pointer.GetOriginForward();
 
@@ -77,9 +77,10 @@
 
         protected virtual bool IsHovering(VRTK_UIPointer pointer)
         {
-            foreach (var hoveredObject in pointer.pointerEventData.hovered)
+            for (int i = 0; i < pointer.pointerEventData.hovered.Count; i++)
             {
-                if (pointer.pointerEventData.pointerEnter && hoveredObject && CheckTransformTree(hoveredObject.transform, pointer.pointerEventData.pointerEnter.transform))
+                GameObject hoveredObject = pointer.pointerEventData.hovered[i];
+                if (pointer.pointerEventData.pointerEnter != null && hoveredObject != null && CheckTransformTree(hoveredObject.transform, pointer.pointerEventData.pointerEnter.transform))
                 {
                     return true;
                 }
@@ -89,8 +90,8 @@
 
         protected virtual bool ValidElement(GameObject obj)
         {
-            var canvasCheck = obj.GetComponentInParent<VRTK_UICanvas>();
-            return (canvasCheck && canvasCheck.enabled ? true : false);
+            VRTK_UICanvas canvasCheck = obj.GetComponentInParent<VRTK_UICanvas>();
+            return (canvasCheck != null && canvasCheck.enabled ? true : false);
         }
 
         protected virtual void CheckPointerHoverClick(VRTK_UIPointer pointer, List<RaycastResult> results)
@@ -109,7 +110,7 @@
 
         protected virtual void Hover(VRTK_UIPointer pointer, List<RaycastResult> results)
         {
-            if (pointer.pointerEventData.pointerEnter)
+            if (pointer.pointerEventData.pointerEnter != null)
             {
                 CheckPointerHoverClick(pointer, results);
                 if (!ValidElement(pointer.pointerEventData.pointerEnter))
@@ -127,20 +128,21 @@
             }
             else
             {
-                foreach (var result in results)
+                for (int i = 0; i < results.Count; i++)
                 {
+                    RaycastResult result = results[i];
                     if (!ValidElement(result.gameObject))
                     {
                         continue;
                     }
 
-                    var target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.pointerEnterHandler);
+                    GameObject target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.pointerEnterHandler);
                     if (target != null)
                     {
-                        var selectable = target.GetComponent<Selectable>();
-                        if (selectable)
+                        Selectable selectable = target.GetComponent<Selectable>();
+                        if (selectable != null)
                         {
-                            var noNavigation = new Navigation();
+                            Navigation noNavigation = new Navigation();
                             noNavigation.mode = Navigation.Mode.None;
                             selectable.navigation = noNavigation;
                         }
@@ -208,14 +210,15 @@
         {
             if (pointer.pointerEventData.eligibleForClick)
             {
-                foreach (var result in results)
+                for (int i = 0; i < results.Count; i++)
                 {
+                    RaycastResult result = results[i];
                     if (!ValidElement(result.gameObject))
                     {
                         continue;
                     }
 
-                    var target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.pointerDownHandler);
+                    GameObject target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.pointerDownHandler);
                     if (target != null)
                     {
                         pointer.pointerEventData.pressPosition = pointer.pointerEventData.position;
@@ -282,17 +285,18 @@
                 {
                     ExecuteEvents.ExecuteHierarchy(pointer.pointerEventData.pointerDrag, pointer.pointerEventData, ExecuteEvents.dragHandler);
                     ExecuteEvents.ExecuteHierarchy(pointer.pointerEventData.pointerDrag, pointer.pointerEventData, ExecuteEvents.endDragHandler);
-                    foreach (RaycastResult raycast in results)
+                    for (int i = 0; i < results.Count; i++)
                     {
-                        ExecuteEvents.ExecuteHierarchy(raycast.gameObject, pointer.pointerEventData, ExecuteEvents.dropHandler);
+                        ExecuteEvents.ExecuteHierarchy(results[i].gameObject, pointer.pointerEventData, ExecuteEvents.dropHandler);
                     }
                     pointer.pointerEventData.pointerDrag = null;
                 }
             }
             else if (pointer.pointerEventData.dragging)
             {
-                foreach (var result in results)
+                for (int i = 0; i < results.Count; i++)
                 {
+                    RaycastResult result = results[i];
                     if (!ValidElement(result.gameObject))
                     {
                         continue;
@@ -300,7 +304,7 @@
 
                     ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.initializePotentialDrag);
                     ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.beginDragHandler);
-                    var target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.dragHandler);
+                    GameObject target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.dragHandler);
                     if (target != null)
                     {
                         pointer.pointerEventData.pointerDrag = target;
@@ -313,20 +317,20 @@
         protected virtual void Scroll(VRTK_UIPointer pointer, List<RaycastResult> results)
         {
             pointer.pointerEventData.scrollDelta = pointer.controller.GetTouchpadAxis();
-            var scrollWheelVisible = false;
-            foreach (RaycastResult result in results)
+            bool scrollWheelVisible = false;
+            for (int i = 0; i < results.Count; i++)
             {
                 if (pointer.pointerEventData.scrollDelta != Vector2.zero)
                 {
-                    var target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.scrollHandler);
-                    if (target)
+                    GameObject target = ExecuteEvents.ExecuteHierarchy(results[i].gameObject, pointer.pointerEventData, ExecuteEvents.scrollHandler);
+                    if (target != null)
                     {
                         scrollWheelVisible = true;
                     }
                 }
             }
 
-            if (pointer.controllerRenderModel)
+            if (pointer.controllerRenderModel != null)
             {
                 VRTK_SDK_Bridge.SetControllerRenderModelWheel(pointer.controllerRenderModel, scrollWheelVisible);
             }

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_PlayerClimb.cs
@@ -188,27 +188,27 @@ namespace VRTK
         {
             if (usePlayerScale)
             {
-                return playArea.localRotation * Vector3.Scale(objTransform.localPosition, playArea.localScale);
+                return (playArea.localRotation * Vector3.Scale(objTransform.localPosition, playArea.localScale));
             }
 
-            return playArea.localRotation * objTransform.localPosition;
+            return (playArea.localRotation * objTransform.localPosition);
         }
 
         protected virtual void OnGrabObject(object sender, ObjectInteractEventArgs e)
         {
             if (IsClimbableObject(e.target))
             {
-                var controller = ((VRTK_InteractGrab)sender).gameObject;
-                var actualController = VRTK_DeviceFinder.GetActualController(controller);
+                GameObject controller = ((VRTK_InteractGrab)sender).gameObject;
+                GameObject actualController = VRTK_DeviceFinder.GetActualController(controller);
                 Grab(actualController, e.controllerReference, e.target);
             }
         }
 
         protected virtual void OnUngrabObject(object sender, ObjectInteractEventArgs e)
         {
-            var controller = ((VRTK_InteractGrab)sender).gameObject;
-            var actualController = VRTK_DeviceFinder.GetActualController(controller);
-            if (e.target && IsClimbableObject(e.target) && IsActiveClimbingController(actualController))
+            GameObject controller = ((VRTK_InteractGrab)sender).gameObject;
+            GameObject actualController = VRTK_DeviceFinder.GetActualController(controller);
+            if (e.target != null && IsClimbableObject(e.target) && IsActiveClimbingController(actualController))
             {
                 Ungrab(true, e.controllerReference, e.target);
             }
@@ -280,16 +280,16 @@ namespace VRTK
 
         protected virtual bool IsClimbableObject(GameObject obj)
         {
-            var interactObject = obj.GetComponent<VRTK_InteractableObject>();
-            return (interactObject && interactObject.grabAttachMechanicScript && interactObject.grabAttachMechanicScript.IsClimbable());
+            VRTK_InteractableObject interactObject = obj.GetComponent<VRTK_InteractableObject>();
+            return (interactObject != null && interactObject.grabAttachMechanicScript && interactObject.grabAttachMechanicScript.IsClimbable());
         }
 
         protected virtual void InitControllerListeners(GameObject controller, bool state)
         {
-            if (controller)
+            if (controller != null)
             {
-                var grabScript = controller.GetComponent<VRTK_InteractGrab>();
-                if (grabScript)
+                VRTK_InteractGrab grabScript = controller.GetComponent<VRTK_InteractGrab>();
+                if (grabScript != null)
                 {
                     if (state)
                     {

--- a/Assets/VRTK/Scripts/Locomotion/VRTK_RoomExtender.cs
+++ b/Assets/VRTK/Scripts/Locomotion/VRTK_RoomExtender.cs
@@ -64,7 +64,7 @@ namespace VRTK
             }
             playArea = VRTK_DeviceFinder.PlayAreaTransform();
             additionalMovementEnabled = !additionalMovementEnabledOnButtonPress;
-            if (debugTransform)
+            if (debugTransform != null)
             {
                 debugTransform.localScale = new Vector3(headZoneRadius * 2, 0.01f, headZoneRadius * 2);
             }
@@ -95,7 +95,7 @@ namespace VRTK
         protected virtual void Move(Vector3 movement)
         {
             headCirclePosition += movement;
-            if (debugTransform)
+            if (debugTransform != null)
             {
                 debugTransform.localPosition = new Vector3(headCirclePosition.x, debugTransform.localPosition.y, headCirclePosition.z);
             }
@@ -109,7 +109,7 @@ namespace VRTK
         protected virtual void MoveHeadCircle()
         {
             //Get the movement of the head relative to the headCircle.
-            var circleCenterToHead = new Vector3(movementTransform.localPosition.x - headCirclePosition.x, 0, movementTransform.localPosition.z - headCirclePosition.z);
+            Vector3 circleCenterToHead = new Vector3(movementTransform.localPosition.x - headCirclePosition.x, 0, movementTransform.localPosition.z - headCirclePosition.z);
 
             //Get the direction of the head movement.
             UpdateLastMovement();
@@ -124,10 +124,10 @@ namespace VRTK
 
         protected virtual void MoveHeadCircleNonLinearDrift()
         {
-            var movement = new Vector3(movementTransform.localPosition.x - headCirclePosition.x, 0, movementTransform.localPosition.z - headCirclePosition.z);
+            Vector3 movement = new Vector3(movementTransform.localPosition.x - headCirclePosition.x, 0, movementTransform.localPosition.z - headCirclePosition.z);
             if (movement.sqrMagnitude > headZoneRadius * headZoneRadius)
             {
-                var deltaMovement = movement.normalized * (movement.magnitude - headZoneRadius);
+                Vector3 deltaMovement = movement.normalized * (movement.magnitude - headZoneRadius);
                 Move(deltaMovement);
             }
         }

--- a/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -164,11 +164,11 @@ namespace VRTK
         /// <param name="location">The location where to draw the play area cursor.</param>
         public virtual void SetPlayAreaCursorTransform(Vector3 location)
         {
-            var offset = Vector3.zero;
+            Vector3 offset = Vector3.zero;
             if (headsetPositionCompensation)
             {
-                var playAreaPos = new Vector3(playArea.transform.position.x, 0f, playArea.transform.position.z);
-                var headsetPos = new Vector3(headset.position.x, 0f, headset.position.z);
+                Vector3 playAreaPos = new Vector3(playArea.transform.position.x, 0f, playArea.transform.position.z);
+                Vector3 headsetPos = new Vector3(headset.position.x, 0f, headset.position.z);
                 offset = playAreaPos - headsetPos;
             }
 
@@ -176,7 +176,7 @@ namespace VRTK
             {
                 if (playAreaCursor.activeInHierarchy && handlePlayAreaCursorCollisions && headsetOutOfBoundsIsCollision)
                 {
-                    var checkPoint = new Vector3(location.x, playAreaCursor.transform.position.y + (playAreaCursor.transform.localScale.y * 2), location.z);
+                    Vector3 checkPoint = new Vector3(location.x, playAreaCursor.transform.position.y + (playAreaCursor.transform.localScale.y * 2), location.z);
                     if (!playAreaCursorCollider.bounds.Contains(checkPoint))
                     {
                         headsetOutOfBounds = true;
@@ -346,13 +346,13 @@ namespace VRTK
 
         protected virtual void SetCursorColor(GameObject cursorObject, Color color)
         {
-            Renderer paRenderer = cursorObject.GetComponentInChildren<Renderer>();
+            Renderer playareaRenderer = cursorObject.GetComponentInChildren<Renderer>();
 
-            if (paRenderer && paRenderer.material && paRenderer.material.HasProperty("_Color"))
+            if (playareaRenderer != null && playareaRenderer.material && playareaRenderer.material.HasProperty("_Color"))
             {
-                paRenderer.material.color = color;
-                paRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
-                paRenderer.receiveShadows = false;
+                playareaRenderer.material.color = color;
+                playareaRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                playareaRenderer.receiveShadows = false;
             }
         }
 
@@ -411,7 +411,7 @@ namespace VRTK
         {
             if (playAreaCursorDimensions != Vector2.zero)
             {
-                var customAreaPadding = VRTK_SDK_Bridge.GetPlayAreaBorderThickness();
+                float customAreaPadding = VRTK_SDK_Bridge.GetPlayAreaBorderThickness();
 
                 cursorDrawVertices[btmRightOuter] = new Vector3(playAreaCursorDimensions.x / 2, 0f, (playAreaCursorDimensions.y / 2) * -1);
                 cursorDrawVertices[btmLeftOuter] = new Vector3((playAreaCursorDimensions.x / 2) * -1, 0f, (playAreaCursorDimensions.y / 2) * -1);
@@ -472,9 +472,9 @@ namespace VRTK
 
         protected virtual void UpdateCollider()
         {
-            var playAreaHeightAdjustment = 1f;
-            var newBCYSize = (headset.transform.position.y - playArea.transform.position.y) * 100f;
-            var newBCYCenter = (newBCYSize != 0 ? (newBCYSize / 2) + playAreaHeightAdjustment : 0);
+            float playAreaHeightAdjustment = 1f;
+            float newBCYSize = (headset.transform.position.y - playArea.transform.position.y) * 100f;
+            float newBCYCenter = (newBCYSize != 0 ? (newBCYSize / 2) + playAreaHeightAdjustment : 0);
 
             playAreaCursorCollider.size = new Vector3(playAreaCursorCollider.size.x, newBCYSize, playAreaCursorCollider.size.z);
             playAreaCursorCollider.center = new Vector3(playAreaCursorCollider.center.x, newBCYCenter, playAreaCursorCollider.center.z);

--- a/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
+++ b/Assets/VRTK/Scripts/Presence/VRTK_HeadsetControllerAware.cs
@@ -194,9 +194,9 @@ namespace VRTK
         protected virtual void RayCastToController(GameObject controller, Transform customDestination, ref bool obscured, ref bool lastState)
         {
             obscured = false;
-            if (controller && controller.gameObject.activeInHierarchy)
+            if (controller != null && controller.gameObject.activeInHierarchy)
             {
-                var destination = (customDestination ? customDestination.position : controller.transform.position);
+                Vector3 destination = (customDestination ? customDestination.position : controller.transform.position);
                 RaycastHit hitInfo;
                 if (VRTK_CustomRaycast.Linecast(customRaycast, headset.position, destination, out hitInfo, Physics.IgnoreRaycastLayer, QueryTriggerInteraction.Ignore))
                 {
@@ -228,11 +228,11 @@ namespace VRTK
         protected virtual void CheckHeadsetView(GameObject controller, Transform customDestination, ref bool controllerGlance, ref bool controllerGlanceLastState)
         {
             controllerGlance = false;
-            if (controller && controller.gameObject.activeInHierarchy)
+            if (controller != null && controller.gameObject.activeInHierarchy)
             {
-                var controllerPosition = (customDestination ? customDestination.position : controller.transform.position);
-                var distanceFromHeadsetToController = Vector3.Distance(headset.position, controllerPosition);
-                var lookPoint = headset.position + (headset.forward * distanceFromHeadsetToController);
+                Vector3 controllerPosition = (customDestination ? customDestination.position : controller.transform.position);
+                float distanceFromHeadsetToController = Vector3.Distance(headset.position, controllerPosition);
+                Vector3 lookPoint = headset.position + (headset.forward * distanceFromHeadsetToController);
 
                 if (Vector3.Distance(controllerPosition, lookPoint) <= controllerGlanceRadius)
                 {

--- a/Assets/VRTK/Scripts/UI/VRTK_UIDropZone.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIDropZone.cs
@@ -20,10 +20,10 @@ namespace VRTK
 
         public virtual void OnPointerEnter(PointerEventData eventData)
         {
-            if (eventData.pointerDrag)
+            if (eventData.pointerDrag != null)
             {
-                var dragItem = eventData.pointerDrag.GetComponent<VRTK_UIDraggableItem>();
-                if (dragItem && dragItem.restrictToDropZone)
+                VRTK_UIDraggableItem dragItem = eventData.pointerDrag.GetComponent<VRTK_UIDraggableItem>();
+                if (dragItem != null && dragItem.restrictToDropZone)
                 {
                     dragItem.validDropZone = gameObject;
                     droppableItem = dragItem;
@@ -33,7 +33,7 @@ namespace VRTK
 
         public virtual void OnPointerExit(PointerEventData eventData)
         {
-            if (droppableItem)
+            if (droppableItem != null)
             {
                 droppableItem.validDropZone = null;
             }

--- a/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
@@ -284,7 +284,7 @@ namespace VRTK
         /// <returns>A custom input module that is used to detect input from VR pointers.</returns>
         public virtual VRTK_VRInputModule SetEventSystem(EventSystem eventSystem)
         {
-            if (!eventSystem)
+            if (eventSystem == null)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "VRTK_UIPointer", "EventSystem"));
                 return null;
@@ -303,9 +303,9 @@ namespace VRTK
         /// </summary>
         public virtual void RemoveEventSystem()
         {
-            var vrtkEventSystem = FindObjectOfType<VRTK_EventSystem>();
+            VRTK_EventSystem vrtkEventSystem = FindObjectOfType<VRTK_EventSystem>();
 
-            if (!vrtkEventSystem)
+            if (vrtkEventSystem == null)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "VRTK_UIPointer", "EventSystem"));
                 return;
@@ -372,8 +372,8 @@ namespace VRTK
         /// <returns>Returns true if the UI Click button is in a valid state to action a click, returns false if it is not in a valid state.</returns>
         public virtual bool ValidClick(bool checkLastClick, bool lastClickState = false)
         {
-            var controllerClicked = (collisionClick ? collisionClick : IsSelectionButtonPressed());
-            var result = (checkLastClick ? controllerClicked && lastPointerClickState == lastClickState : controllerClicked);
+            bool controllerClicked = (collisionClick ? collisionClick : IsSelectionButtonPressed());
+            bool result = (checkLastClick ? controllerClicked && lastPointerClickState == lastClickState : controllerClicked);
             lastPointerClickState = controllerClicked;
             return result;
         }
@@ -483,17 +483,17 @@ namespace VRTK
 
         protected virtual void ConfigureEventSystem()
         {
-            if (!cachedEventSystem)
+            if (cachedEventSystem == null)
             {
                 cachedEventSystem = FindObjectOfType<EventSystem>();
             }
 
-            if (!cachedVRInputModule)
+            if (cachedVRInputModule == null)
             {
                 cachedVRInputModule = SetEventSystem(cachedEventSystem);
             }
 
-            if (cachedEventSystem && cachedVRInputModule)
+            if (cachedEventSystem != null && cachedVRInputModule != null)
             {
                 if (pointerEventData == null)
                 {

--- a/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
+++ b/Assets/VRTK/Scripts/Utilities/ObjectFollow/VRTK_ObjectFollow.cs
@@ -104,12 +104,12 @@ namespace VRTK
 
         protected virtual void FollowPosition()
         {
-            var positionToFollow = GetPositionToFollow();
+            Vector3 positionToFollow = GetPositionToFollow();
             Vector3 newPosition;
 
             if (smoothsPosition)
             {
-                var alpha = Mathf.Clamp01(Vector3.Distance(targetPosition, positionToFollow) / maxAllowedPerFrameDistanceDifference);
+                float alpha = Mathf.Clamp01(Vector3.Distance(targetPosition, positionToFollow) / maxAllowedPerFrameDistanceDifference);
                 newPosition = Vector3.Lerp(targetPosition, positionToFollow, alpha);
             }
             else
@@ -123,12 +123,12 @@ namespace VRTK
 
         protected virtual void FollowRotation()
         {
-            var rotationToFollow = GetRotationToFollow();
+            Quaternion rotationToFollow = GetRotationToFollow();
             Quaternion newRotation;
 
             if (smoothsRotation)
             {
-                var alpha = Mathf.Clamp01(Quaternion.Angle(targetRotation, rotationToFollow) / maxAllowedPerFrameAngleDifference);
+                float alpha = Mathf.Clamp01(Quaternion.Angle(targetRotation, rotationToFollow) / maxAllowedPerFrameAngleDifference);
                 newRotation = Quaternion.Lerp(targetRotation, rotationToFollow, alpha);
             }
             else
@@ -142,12 +142,12 @@ namespace VRTK
 
         protected virtual void FollowScale()
         {
-            var scaleToFollow = GetScaleToFollow();
+            Vector3 scaleToFollow = GetScaleToFollow();
             Vector3 newScale;
 
             if (smoothsScale)
             {
-                var alpha = Mathf.Clamp01(Vector3.Distance(targetScale, scaleToFollow) / maxAllowedPerFrameSizeDifference);
+                float alpha = Mathf.Clamp01(Vector3.Distance(targetScale, scaleToFollow) / maxAllowedPerFrameSizeDifference);
                 newScale = Vector3.Lerp(targetScale, scaleToFollow, alpha);
             }
             else

--- a/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -244,14 +244,14 @@ namespace VRTK
         /// </returns>
         public override string ToString()
         {
-            var stringBuilder = new StringBuilder("Adaptive Quality\n");
+            StringBuilder stringBuilder = new StringBuilder("Adaptive Quality\n");
             stringBuilder.AppendLine("Render Scale:");
             stringBuilder.AppendLine("Level - Resolution - Multiplier");
 
             for (int index = 0; index < allRenderScales.Count; index++)
             {
                 float renderScale = allRenderScales[index];
-                var renderTargetResolution = RenderTargetResolutionForRenderScale(renderScale);
+                Vector2 renderTargetResolution = RenderTargetResolutionForRenderScale(renderScale);
 
                 stringBuilder.AppendFormat(
                     "{0, 3} {1, 5}x{2, -5} {3, -8}",
@@ -371,7 +371,7 @@ namespace VRTK
                 return;
             }
 
-            var commandLineArguments = Environment.GetCommandLineArgs();
+            string[] commandLineArguments = Environment.GetCommandLineArgs();
 
             for (int index = 0; index < commandLineArguments.Length; index++)
             {
@@ -672,7 +672,7 @@ namespace VRTK
 
             if (enabled && drawDebugVisualization && debugVisualizationQuad == null)
             {
-                var mesh = new Mesh
+                Mesh mesh = new Mesh
                 {
                     vertices =
                         new[]

--- a/Assets/VRTK/Scripts/Utilities/VRTK_PolicyList.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_PolicyList.cs
@@ -125,7 +125,7 @@ namespace VRTK
 
         protected virtual bool TypeCheck(GameObject obj, bool returnState)
         {
-            var selection = 0;
+            int selection = 0;
 
             if (((int)checkType & (int)CheckTypes.Tag) != 0)
             {

--- a/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -27,7 +27,7 @@ namespace VRTK
         public static Bounds GetBounds(Transform transform, Transform excludeRotation = null, Transform excludeTransform = null)
         {
             Quaternion oldRotation = Quaternion.identity;
-            if (excludeRotation)
+            if (excludeRotation != null)
             {
                 oldRotation = excludeRotation.rotation;
                 excludeRotation.rotation = Quaternion.identity;
@@ -37,8 +37,9 @@ namespace VRTK
             Bounds bounds = new Bounds(transform.position, Vector3.zero);
 
             Renderer[] renderers = transform.GetComponentsInChildren<Renderer>();
-            foreach (Renderer renderer in renderers)
+            for (int i = 0; i < renderers.Length; i++)
             {
+                Renderer renderer = renderers[i];
                 if (excludeTransform != null && renderer.transform.IsChildOf(excludeTransform))
                 {
                     continue;
@@ -57,8 +58,9 @@ namespace VRTK
             {
                 // do second pass as there were no renderers, this time with colliders
                 BoxCollider[] colliders = transform.GetComponentsInChildren<BoxCollider>();
-                foreach (BoxCollider collider in colliders)
+                for (int i = 0; i < colliders.Length; i++)
                 {
+                    BoxCollider collider = colliders[i];
                     if (excludeTransform != null && collider.transform.IsChildOf(excludeTransform))
                     {
                         continue;
@@ -74,7 +76,7 @@ namespace VRTK
                 }
             }
 
-            if (excludeRotation)
+            if (excludeRotation != null)
             {
                 excludeRotation.rotation = oldRotation;
             }
@@ -90,9 +92,9 @@ namespace VRTK
         /// <returns>Returns true if the value is lower than all numbers in the given array, returns false if it is not the lowest.</returns>
         public static bool IsLowest(float value, float[] others)
         {
-            foreach (float o in others)
+            for (int i = 0; i < others.Length; i++)
             {
-                if (o <= value)
+                if (others[i] <= value)
                 {
                     return false;
                 }
@@ -106,7 +108,7 @@ namespace VRTK
         /// <returns>The transform of the headset camera.</returns>
         public static Transform AddCameraFade()
         {
-            var camera = VRTK_DeviceFinder.HeadsetCamera();
+            Transform camera = VRTK_DeviceFinder.HeadsetCamera();
             VRTK_SDK_Bridge.AddHeadsetFade(camera);
             return camera;
         }
@@ -118,9 +120,10 @@ namespace VRTK
         public static void CreateColliders(GameObject obj)
         {
             Renderer[] renderers = obj.GetComponentsInChildren<Renderer>();
-            foreach (Renderer renderer in renderers)
+            for (int i = 0; i < renderers.Length; i++)
             {
-                if (!renderer.gameObject.GetComponent<Collider>())
+                Renderer renderer = renderers[i];
+                if (renderer.gameObject.GetComponent<Collider>() == null)
                 {
                     renderer.gameObject.AddComponent<BoxCollider>();
                 }
@@ -139,18 +142,22 @@ namespace VRTK
             Component tmpComponent = destination.gameObject.AddComponent(source.GetType());
             if (copyProperties)
             {
-                foreach (PropertyInfo p in source.GetType().GetProperties())
+                PropertyInfo[] foundProperties = source.GetType().GetProperties();
+                for (int i = 0; i < foundProperties.Length; i++)
                 {
-                    if (p.CanWrite)
+                    PropertyInfo foundProperty = foundProperties[i];
+                    if (foundProperty.CanWrite)
                     {
-                        p.SetValue(tmpComponent, p.GetValue(source, null), null);
+                        foundProperty.SetValue(tmpComponent, foundProperty.GetValue(source, null), null);
                     }
                 }
             }
 
-            foreach (FieldInfo f in source.GetType().GetFields())
+            FieldInfo[] foundFields = source.GetType().GetFields();
+            for (int i = 0; i < foundFields.Length; i++)
             {
-                f.SetValue(tmpComponent, f.GetValue(source));
+                FieldInfo foundField = foundFields[i];
+                foundField.SetValue(tmpComponent, foundField.GetValue(source));
             }
             return tmpComponent;
         }
@@ -307,11 +314,7 @@ namespace VRTK
         {
 #if UNITY_5_6_OR_NEWER
             float gpuTimeLastFrame;
-            if (VRStats.TryGetGPUTimeLastFrame(out gpuTimeLastFrame))
-            {
-                return gpuTimeLastFrame;
-            }
-            return 0f;
+            return (VRStats.TryGetGPUTimeLastFrame(out gpuTimeLastFrame) ? gpuTimeLastFrame : 0f);
 #else
             return VRStats.gpuTimeLastFrame;
 #endif
@@ -326,7 +329,7 @@ namespace VRTK
         /// <returns>Returns true if the given Vector2 objects match based on the given fidelity.</returns>
         public static bool Vector2ShallowCompare(Vector2 vectorA, Vector2 vectorB, int compareFidelity)
         {
-            var distanceVector = vectorA - vectorB;
+            Vector2 distanceVector = vectorA - vectorB;
             return (Math.Round(Mathf.Abs(distanceVector.x), compareFidelity, MidpointRounding.AwayFromZero) < float.Epsilon &&
                     Math.Round(Mathf.Abs(distanceVector.y), compareFidelity, MidpointRounding.AwayFromZero) < float.Epsilon);
         }
@@ -366,9 +369,10 @@ namespace VRTK
             {
                 return type;
             }
-            foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
+            Assembly[] foundAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < foundAssemblies.Length; i++)
             {
-                type = a.GetType(typeName);
+                type = foundAssemblies[i].GetType(typeName);
                 if (type != null)
                 {
                     return type;


### PR DESCRIPTION
The coding conventions about not using `var` and preferring `for`
over `foreach` has been applied to more code.