### PR TITLE
fix(Interaction): prevent null exception when getting touch colliders - fixes #1478

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -244,7 +244,7 @@ namespace VRTK
         /// <returns>An array of colliders that are associated with the controller.</returns>
         public virtual Collider[] ControllerColliders()
         {
-            return (controllerCollisionDetector != null && controllerCollisionDetector.GetComponents<Collider>().Length > 0 ? controllerCollisionDetector.GetComponents<Collider>() : controllerCollisionDetector.GetComponentsInChildren<Collider>());
+            return (controllerCollisionDetector != null ? controllerCollisionDetector.GetComponentsInChildren<Collider>() : new Collider[0]);
         }
 
         protected virtual void Awake()


### PR DESCRIPTION
The Interact Touch script could potentially return a null exception
error when calling the `ControllerColliders` method because if the
condition was false it would still try and perform a `GetComponent`
on a null object.

It was also not necessary to do the GetComponents or
GetComponentsInChildren check as the latter will also get components
in the current object as well as the children.