### PR TITLE
chore(Structure): support new XR naming convention in 2017.2

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -7381,6 +7381,28 @@ The SetGlobalScale method is used to set a transform scale based on a global sca
 
 The GetTypeUnknownAssembly method is used to find a Type without knowing the exact assembly it is in.
 
+#### GetEyeTextureResolutionScale/0
+
+  > `public static float GetEyeTextureResolutionScale()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `float` - Returns a float with the render scale for the resolution.
+
+The GetEyeTextureResolutionScale method returns the render scale for the resolution.
+
+#### SetEyeTextureResolutionScale/1
+
+  > `public static void SetEyeTextureResolutionScale(float value)`
+
+ * Parameters
+   * `float value` - The value to set the render scale to.
+ * Returns
+   * _none_
+
+The SetEyeTextureResolutionScale method sets the render scale for the resolution.
+
 ---
 
 ## Policy List (VRTK_PolicyList)

--- a/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
@@ -2,7 +2,11 @@
 {
     using UnityEngine;
     using UnityEngine.SceneManagement;
-    using UnityEngine.VR;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
+    using XRSettings = UnityEngine.VR.VRSettings;
+#endif
     using UnityEditor;
     using UnityEditor.SceneManagement;
     using System;
@@ -342,7 +346,7 @@
                     VRTK_SDKManager.AvailableControllerSDKInfos
                 }
                 .SelectMany(infos => infos.Select(sdkInfo => sdkInfo.description.vrDeviceName))
-                .Concat(VRSettings.supportedDevices)
+                .Concat(XRSettings.supportedDevices)
                 .Concat(new[] { "None" })
                 .Distinct()
                 .Select(deviceName => GUI.skin.label.CalcSize(new GUIContent(deviceName)).x)

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityCameraRig.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityCameraRig.cs
@@ -2,7 +2,11 @@
 namespace VRTK
 {
     using UnityEngine;
-    using UnityEngine.VR;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
+    using XRDevice = UnityEngine.VR.VRDevice;
+#endif
 
     /// <summary>
     /// The `[UnityBase_CameraRig]` prefab is a default camera rig set up for use with the Unity SDK support.
@@ -19,7 +23,7 @@ namespace VRTK
         {
             if (lockPhysicsUpdateRateToRenderFrequency && Time.timeScale > 0.0f)
             {
-                Time.fixedDeltaTime = Time.timeScale / VRDevice.refreshRate;
+                Time.fixedDeltaTime = Time.timeScale / XRDevice.refreshRate;
             }
         }
     }

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityControllerTracker.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityControllerTracker.cs
@@ -2,7 +2,12 @@
 namespace VRTK
 {
     using UnityEngine;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
     using UnityEngine.VR;
+    using XRNode = UnityEngine.VR.VRNode;
+#endif
 
     /// <summary>
     /// The Controller Tracker enables the GameObject to track it's position/rotation to the available connected VR Controller via the `UnityEngine.VR` library.
@@ -13,7 +18,7 @@ namespace VRTK
     public class SDK_UnityControllerTracker : MonoBehaviour
     {
         [Tooltip("The Unity VRNode to track.")]
-        public VRNode nodeType;
+        public XRNode nodeType;
         [Tooltip("The unique index to assign to the controller.")]
         public uint index;
         [Tooltip("The Unity Input name for the trigger axis.")]

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -14,7 +14,12 @@ namespace VRTK
     using System.Linq;
     using System.Text;
     using UnityEngine;
-    using UnityEngine.VR;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
+    using XRSettings = UnityEngine.VR.VRSettings;
+    using XRDevice = UnityEngine.VR.VRDevice;
+#endif
 
     /// <summary>
     /// Adaptive Quality dynamically changes rendering settings to maintain VR framerate while maximizing GPU utilization.
@@ -145,7 +150,7 @@ namespace VRTK
         /// </remarks>
         public static float CurrentRenderScale
         {
-            get { return VRSettings.renderScale * VRSettings.renderViewportScale; }
+            get { return VRTK_SharedMethods.GetEyeTextureResolutionScale() * XRSettings.renderViewportScale; }
         }
 
         /// <summary>
@@ -210,8 +215,8 @@ namespace VRTK
         /// </returns>
         public static Vector2 RenderTargetResolutionForRenderScale(float renderScale)
         {
-            return new Vector2((int)(VRSettings.eyeTextureWidth / VRSettings.renderScale * renderScale),
-                               (int)(VRSettings.eyeTextureHeight / VRSettings.renderScale * renderScale));
+            return new Vector2((int)(XRSettings.eyeTextureWidth / VRTK_SharedMethods.GetEyeTextureResolutionScale() * renderScale),
+                               (int)(XRSettings.eyeTextureHeight / VRTK_SharedMethods.GetEyeTextureResolutionScale() * renderScale));
         }
 
         /// <summary>
@@ -223,15 +228,15 @@ namespace VRTK
         /// </returns>
         public float BiggestAllowedMaximumRenderScale()
         {
-            if (VRSettings.eyeTextureWidth == 0 || VRSettings.eyeTextureHeight == 0)
+            if (XRSettings.eyeTextureWidth == 0 || XRSettings.eyeTextureHeight == 0)
             {
                 return maximumRenderScale;
             }
 
-            float maximumHorizontalRenderScale = maximumRenderTargetDimension * VRSettings.renderScale
-                                                 / VRSettings.eyeTextureWidth;
-            float maximumVerticalRenderScale = maximumRenderTargetDimension * VRSettings.renderScale
-                                               / VRSettings.eyeTextureHeight;
+            float maximumHorizontalRenderScale = maximumRenderTargetDimension * VRTK_SharedMethods.GetEyeTextureResolutionScale()
+                                                 / XRSettings.eyeTextureWidth;
+            float maximumVerticalRenderScale = maximumRenderTargetDimension * VRTK_SharedMethods.GetEyeTextureResolutionScale()
+                                               / XRSettings.eyeTextureHeight;
             return Mathf.Min(maximumHorizontalRenderScale, maximumVerticalRenderScale);
         }
 
@@ -300,8 +305,8 @@ namespace VRTK
             Camera.onPreCull += OnCameraPreCull;
 
             hmdDisplayIsOnDesktop = VRTK_SDK_Bridge.IsDisplayOnDesktop();
-            singleFrameDurationInMilliseconds = VRDevice.refreshRate > 0.0f
-                                                ? 1000.0f / VRDevice.refreshRate
+            singleFrameDurationInMilliseconds = XRDevice.refreshRate > 0.0f
+                                                ? 1000.0f / XRDevice.refreshRate
                                                 : DefaultFrameDurationInMilliseconds;
 
             HandleCommandLineArguments();
@@ -644,13 +649,13 @@ namespace VRTK
 
         private static void SetRenderScale(float renderScale, float renderViewportScale)
         {
-            if (Mathf.Abs(VRSettings.renderScale - renderScale) > float.Epsilon)
+            if (Mathf.Abs(VRTK_SharedMethods.GetEyeTextureResolutionScale() - renderScale) > float.Epsilon)
             {
-                VRSettings.renderScale = renderScale;
+                VRTK_SharedMethods.SetEyeTextureResolutionScale(renderScale);
             }
-            if (Mathf.Abs(VRSettings.renderViewportScale - renderViewportScale) > float.Epsilon)
+            if (Mathf.Abs(XRSettings.renderViewportScale - renderViewportScale) > float.Epsilon)
             {
-                VRSettings.renderViewportScale = renderViewportScale;
+                XRSettings.renderViewportScale = renderViewportScale;
             }
         }
 

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -2,7 +2,11 @@
 namespace VRTK
 {
     using UnityEngine;
-    using UnityEngine.VR;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
+    using XRDevice = UnityEngine.VR.VRDevice;
+#endif
 
     /// <summary>
     /// The Device Finder offers a collection of static methods that can be called to find common game devices such as the headset or controllers, or used to determine key information about the connected devices.
@@ -369,7 +373,7 @@ namespace VRTK
         public static Headsets GetHeadsetType(bool summary = false)
         {
             Headsets returnValue = Headsets.Unknown;
-            cachedHeadsetType = (cachedHeadsetType == "" ? VRDevice.model.Replace(" ", "").Replace(".", "").ToLowerInvariant() : cachedHeadsetType);
+            cachedHeadsetType = (cachedHeadsetType == "" ? XRDevice.model.Replace(" ", "").Replace(".", "").ToLowerInvariant() : cachedHeadsetType);
             switch (cachedHeadsetType)
             {
                 case "oculusriftcv1":

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -10,7 +10,12 @@ namespace VRTK
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using UnityEngine.VR;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
+    using XRSettings = UnityEngine.VR.VRSettings;
+    using XRStats = UnityEngine.VR.VRStats;
+#endif
 
     /// <summary>
     /// The Shared Methods script is a collection of reusable static methods that are used across a range of different scripts.
@@ -314,7 +319,7 @@ namespace VRTK
         {
 #if UNITY_5_6_OR_NEWER
             float gpuTimeLastFrame;
-            return (VRStats.TryGetGPUTimeLastFrame(out gpuTimeLastFrame) ? gpuTimeLastFrame : 0f);
+            return (XRStats.TryGetGPUTimeLastFrame(out gpuTimeLastFrame) ? gpuTimeLastFrame : 0f);
 #else
             return VRStats.gpuTimeLastFrame;
 #endif
@@ -379,6 +384,32 @@ namespace VRTK
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// The GetEyeTextureResolutionScale method returns the render scale for the resolution.
+        /// </summary>
+        /// <returns>Returns a float with the render scale for the resolution.</returns>
+        public static float GetEyeTextureResolutionScale()
+        {
+#if UNITY_2017_2_OR_NEWER
+            return XRSettings.eyeTextureResolutionScale;
+#else
+            return XRSettings.renderScale;
+#endif
+        }
+
+        /// <summary>
+        /// The SetEyeTextureResolutionScale method sets the render scale for the resolution.
+        /// </summary>
+        /// <param name="value">The value to set the render scale to.</param>
+        public static void SetEyeTextureResolutionScale(float value)
+        {
+#if UNITY_2017_2_OR_NEWER
+            XRSettings.eyeTextureResolutionScale = value;
+#else
+            XRSettings.renderScale = value;
+#endif
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
Unity 2017.2 has changed all of the VR packages and VR class names
and renamed them to XR. To ensure future proofing, all of the
references to VR classes have been updated XR and then script
define symbols for any Unity version older than 2017.2 create
class aliases from the old VR convention to the new XR convention.

The VRSettings.renderScale method has been completely renamed so
it's not possible to alias it. In this case a new helper method
has been created in SharedMethods that allows the retrieval of
the renderScale and another method which sets it.