### PR TITLE
feat(Interaction): add near touch interactions

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -2603,6 +2603,7 @@ A collection of scripts that provide the ability to interact with game objects w
  * [Controller Highlighter](#controller-highlighter-vrtk_controllerhighlighter)
  * [Controller Haptics](#controller-haptics-vrtk_controllerhaptics)
  * [Interact Object Appearance](#interact-object-appearance-vrtk_interactobjectappearance)
+ * [Interact Object Highlighter](#interact-object-highlighter-vrtk_interactobjecthighlighter)
  * [Interact Touch](#interact-touch-vrtk_interacttouch)
  * [Interact Near Touch](#interact-near-touch-vrtk_interactneartouch)
  * [Interact Grab](#interact-grab-vrtk_interactgrab)
@@ -3220,6 +3221,51 @@ Adding the `VRTK_InteractObjectAppearance_UnityEvents` component to `VRTK_Intera
 
 ---
 
+## Interact Object Highlighter (VRTK_InteractObjectHighlighter)
+
+### Overview
+
+The Interact Object Hightlighter script is attached to an Interactable Object component to provide highlighting to the object on various interaction stages.
+
+### Inspector Parameters
+
+ * **Near Touch Highlight:** The colour to highlight the object on the near touch interaction.
+ * **Touch Highlight:** The colour to highlight the object on the touch interaction.
+ * **Grab Highlight:** The colour to highlight the object on the grab interaction.
+ * **Use Highlight:** The colour to highlight the object on the use interaction.
+ * **Object To Affect:** The Interactable Object to affect the highlighter of. If this is left blank, then the Interactable Object will need to be on the current or a parent GameObject.
+
+### Class Events
+
+ * `InteractObjectHighlighterHighlighted` - Emitted when the object is highlighted
+ * `InteractObjectHighlighterUnhighlighted` - Emitted when the object is unhighlighted
+
+### Unity Events
+
+Adding the `VRTK_InteractObjectHighlighter_UnityEvents` component to `VRTK_InteractObjectHighlighter` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `VRTK_InteractableObject affectedObject` - The GameObject that is being highlighted.
+ * `GameObject affectingObject` - The GameObject is initiating the highlight via an interaction.
+
+### Class Methods
+
+#### GetCurrentHighlightColor/0
+
+  > `public virtual Color GetCurrentHighlightColor()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `Color` - The Color that the Interactable Object is being highlighted to.
+
+The GetCurrentHighlightColor returns the colour that the object is currently being highlighted to.
+
+---
+
 ## Interact Touch (VRTK_InteractTouch)
 
 ### Overview
@@ -3671,6 +3717,16 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
 
 ### Class Variables
 
+ * `public enum InteractionType` - The interaction type.
+   * `None` - No interaction is affecting the object.
+   * `NearTouch` - The near touch interaction is affecting the object.
+   * `NearUntouch` - The near untouch interaction stopped affecting the object
+   * `Touch` - The touch interaction is affecting the object.
+   * `Untouch` - The untouch interaction stopped affecting the object
+   * `Grab` - The grab interaction is affecting the object.
+   * `Ungrab` - The ungrab interaction stopped affecting the object
+   * `Use` - The use interaction is affecting the object.
+   * `Unuse` - The unuse interaction stopped affecting the object
  * `public enum AllowedController` - Allowed controller type.
    * `Both` - Both controllers are allowed to interact.
    * `LeftOnly` - Only the left controller is allowed to interact.
@@ -3844,16 +3900,27 @@ The StartUsing method is called automatically when the object is used initially.
 
 The StopUsing method is called automatically when the object has stopped being used.
 
-#### ToggleHighlight/1
+#### Highlight/1
 
-  > `public virtual void ToggleHighlight(bool toggle)`
+  > `public virtual void Highlight(Color highlightColor)`
 
  * Parameters
-   * `bool toggle` - The state to determine whether to activate or deactivate the highlight. `true` will enable the highlight and `false` will remove the highlight.
+   * `Color highlightColor` - The colour to apply to the highlighter.
  * Returns
    * _none_
 
-The ToggleHighlight method is used to turn on or off the colour highlight of the object.
+The Highlight method turns on the highlighter attached to the Interactable Object with the given colour.
+
+#### Unhighlight/0
+
+  > `public virtual void Unhighlight()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * _none_
+
+The Unhighlight method turns off the highlighter attached to the Interactable Object.
 
 #### ResetHighlighter/0
 

--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -2604,6 +2604,7 @@ A collection of scripts that provide the ability to interact with game objects w
  * [Controller Haptics](#controller-haptics-vrtk_controllerhaptics)
  * [Interact Object Appearance](#interact-object-appearance-vrtk_interactobjectappearance)
  * [Interact Touch](#interact-touch-vrtk_interacttouch)
+ * [Interact Near Touch](#interact-near-touch-vrtk_interactneartouch)
  * [Interact Grab](#interact-grab-vrtk_interactgrab)
  * [Interact Use](#interact-use-vrtk_interactuse)
  * [Interactable Object](#interactable-object-vrtk_interactableobject)
@@ -3227,7 +3228,7 @@ The Interact Touch script is usually applied to a Controller and provides a coll
 
 Colliders are created for the controller and by default the selected controller SDK will have a set of colliders for the given default controller of that SDK.
 
-A custom collider can be provided by the Custom Rigidbody Object parameter.
+A custom collider can be provided by the Custom Collider Container parameter.
 
 ### Inspector Parameters
 
@@ -3358,6 +3359,81 @@ The GetControllerType method is a shortcut to retrieve the current controller ty
 ### Example
 
 `VRTK/Examples/005_Controller/BasicObjectGrabbing` demonstrates the highlighting of objects that have the `VRTK_InteractableObject` script added to them to show the ability to highlight interactable objects when they are touched by the controllers.
+
+---
+
+## Interact Near Touch (VRTK_InteractNearTouch)
+
+### Overview
+
+The Interact Near Touch script is usually applied to a Controller and provides a collider to know when the controller is nearly touching something.
+
+Colliders are created for the controller and by default will be a sphere.
+
+A custom collider can be provided by the Custom Collider Container parameter.
+
+### Inspector Parameters
+
+ * **Collider Radius:** The radius of the auto generated collider if a `Custom Collider Container` is not supplied.
+ * **Custom Collider Container:** An optional GameObject that contains the compound colliders to represent the near touching object. If this is empty then the collider will be auto generated at runtime.
+ * **Interact Touch:** The Interact Touch script to associate the near touches with. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
+
+### Class Events
+
+ * `ControllerNearTouchInteractableObject` - Emitted when a valid object is near touched.
+ * `ControllerNearUntouchInteractableObject` - Emitted when a valid object is no longer being near touched.
+
+### Unity Events
+
+Adding the `VRTK_InteractNearTouch_UnityEvents` component to `VRTK_InteractNearTouch` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Class Methods
+
+#### GetNearTouchedObjects/0
+
+  > `public virtual List<GameObject> GetNearTouchedObjects()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `List<GameObject>` - A list of GameObjects that are being near touched.
+
+The GetNearTouchedObjects method returns all of the GameObjects that are currently being near touched.
+
+#### ForceNearTouch/1
+
+  > `public virtual void ForceNearTouch(GameObject obj)`
+
+ * Parameters
+   * `GameObject obj` - The GameObject to attempt to force near touch.
+ * Returns
+   * _none_
+
+The ForceNearTouch method will attempt to force the controller to near touch the given game object.
+
+#### ForceStopNearTouching/1
+
+  > `public virtual void ForceStopNearTouching(GameObject obj = null)`
+
+ * Parameters
+   * `GameObject obj` - An optional GameObject to only include in the force stop. If this is null then all near touched GameObjects will be force stopped.
+ * Returns
+   * _none_
+
+The ForceStopNearTouching method will stop the controller from near touching an object even if the controller is physically touching the object still.
+
+#### GetNearTouchedObjects/0
+
+  > `public virtual List<GameObject> GetNearTouchedObjects()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `List<GameObject>` - A list of GameObjects that are being near touched.
+
+The GetNearTouchedObjects method returns all of the GameObjects that are currently being near touched.
 
 ---
 
@@ -3574,6 +3650,7 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
 ### Inspector Parameters
 
  * **Disable When Idle:** If this is checked then the interactable object script will be disabled when the object is not being interacted with. This will eliminate the potential number of calls the interactable objects make each frame.
+ * **Allowed Near Touch Controllers:** Determines which controller can initiate a near touch action.
  * **Touch Highlight Color:** The colour to highlight the object when it is touched. This colour will override any globally set colour (for instance on the `VRTK_InteractTouch` script).
  * **Allowed Touch Controllers:** Determines which controller can initiate a touch action.
  * **Ignored Colliders:** An array of colliders on the object to ignore when being touched.
@@ -3609,6 +3686,8 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
 
  * `InteractableObjectEnabled` - Emitted when the object script is enabled;
  * `InteractableObjectDisabled` - Emitted when the object script is disabled;
+ * `InteractableObjectNearTouched` - Emitted when another object near touches the current object.
+ * `InteractableObjectNearUntouched` - Emitted when the other object stops near touching the current object.
  * `InteractableObjectTouched` - Emitted when another object touches the current object.
  * `InteractableObjectUntouched` - Emitted when the other object stops touching the current object.
  * `InteractableObjectGrabbed` - Emitted when another object grabs the current object (e.g. a controller).
@@ -3631,6 +3710,17 @@ Adding the `VRTK_InteractableObject_UnityEvents` component to `VRTK_Interactable
  * `GameObject interactingObject` - The object that is initiating the interaction (e.g. a controller).
 
 ### Class Methods
+
+#### IsNearTouched/0
+
+  > `public virtual bool IsNearTouched()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `bool` - Returns `true` if the object is currently being near touched.
+
+The IsNearTouched method is used to determine if the object is currently being near touched.
 
 #### IsTouched/0
 
@@ -3665,6 +3755,28 @@ The IsGrabbed method is used to determine if the object is currently being grabb
 
 The IsUsing method is used to determine if the object is currently being used.
 
+#### StartNearTouching/1
+
+  > `public virtual void StartNearTouching(VRTK_InteractNearTouch currentNearTouchingObject = null)`
+
+ * Parameters
+   * `VRTK_InteractNearTouch currentNearTouchingObject` - The object that is currently nearly touching this object.
+ * Returns
+   * _none_
+
+The StartNearTouching method is called automatically when the object is initially nearly touched.
+
+#### StopNearTouching/1
+
+  > `public virtual void StopNearTouching(VRTK_InteractNearTouch previousNearTouchingObject = null)`
+
+ * Parameters
+   * `VRTK_InteractNearTouch previousNearTouchingObject` - The object that was previously nearly touching this object.
+ * Returns
+   * _none_
+
+The StopNearTouching method is called automatically when the object has stopped being nearly touched.
+
 #### StartTouching/1
 
   > `public virtual void StartTouching(VRTK_InteractTouch currentTouchingObject = null)`
@@ -3674,7 +3786,7 @@ The IsUsing method is used to determine if the object is currently being used.
  * Returns
    * _none_
 
-The StartTouching method is called automatically when the object is touched initially. It is also a virtual method to allow for overriding in inherited classes.
+The StartTouching method is called automatically when the object is touched initially.
 
 #### StopTouching/1
 
@@ -3685,7 +3797,7 @@ The StartTouching method is called automatically when the object is touched init
  * Returns
    * _none_
 
-The StopTouching method is called automatically when the object has stopped being touched. It is also a virtual method to allow for overriding in inherited classes.
+The StopTouching method is called automatically when the object has stopped being touched.
 
 #### Grabbed/1
 
@@ -3696,7 +3808,7 @@ The StopTouching method is called automatically when the object has stopped bein
  * Returns
    * _none_
 
-The Grabbed method is called automatically when the object is grabbed initially. It is also a virtual method to allow for overriding in inherited classes.
+The Grabbed method is called automatically when the object is grabbed initially.
 
 #### Ungrabbed/1
 
@@ -3707,7 +3819,7 @@ The Grabbed method is called automatically when the object is grabbed initially.
  * Returns
    * _none_
 
-The Ungrabbed method is called automatically when the object has stopped being grabbed. It is also a virtual method to allow for overriding in inherited classes.
+The Ungrabbed method is called automatically when the object has stopped being grabbed.
 
 #### StartUsing/1
 
@@ -3718,7 +3830,7 @@ The Ungrabbed method is called automatically when the object has stopped being g
  * Returns
    * _none_
 
-The StartUsing method is called automatically when the object is used initially. It is also a virtual method to allow for overriding in inherited classes.
+The StartUsing method is called automatically when the object is used initially.
 
 #### StopUsing/2
 
@@ -3730,7 +3842,7 @@ The StartUsing method is called automatically when the object is used initially.
  * Returns
    * _none_
 
-The StopUsing method is called automatically when the object has stopped being used. It is also a virtual method to allow for overriding in inherited classes.
+The StopUsing method is called automatically when the object has stopped being used.
 
 #### ToggleHighlight/1
 
@@ -3786,6 +3898,17 @@ The ZeroVelocity method resets the velocity and angular velocity to zero on the 
    * _none_
 
 The SaveCurrentState method stores the existing object parent and the object's rigidbody kinematic setting.
+
+#### GetNearTouchingObjects/0
+
+  > `public virtual List<GameObject> GetNearTouchingObjects()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `List<GameObject>` - A list of game object of that are currently nearly touching the current object.
+
+The GetNearTouchingObjects method is used to return the collecetion of valid game objects that are currently nearly touching this object.
 
 #### GetTouchingObjects/0
 

--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -1176,10 +1176,12 @@ Provides a custom controller hand model with psuedo finger functionality.
  * **Pinky Axis Button:** The button type to listen for axis changes to control the pinky finger.
  * **Three Finger Axis Button:** The button type to listen for axis changes to control the middle, ring and pinky finger.
  * **Thumb State:** The Axis Type to utilise when dealing with the thumb state. Not all controllers support all axis types on all of the available buttons.
+ * **Near Touch Overrides:** Finger axis overrides on an Interact NearTouch event.
  * **Touch Overrides:** Finger axis overrides on an Interact Touch event.
  * **Grab Overrides:** Finger axis overrides on an Interact Grab event.
  * **Use Overrides:** Finger axis overrides on an Interact Use event.
  * **Controller Events:** The controller to listen for the events on. If this is left blank as it will be auto populated by finding the Controller Events script on the parent GameObject.
+ * **Interact Near Touch:** An optional Interact NearTouch to listen for near touch events on. If this is left blank as it will attempt to be auto populated by finding the Interact NearTouch script on the parent GameObject.
  * **Interact Touch:** An optional Interact Touch to listen for touch events on. If this is left blank as it will attempt to be auto populated by finding the Interact Touch script on the parent GameObject.
  * **Interact Grab:** An optional Interact Grab to listen for grab events on. If this is left blank as it will attempt to be auto populated by finding the Interact Grab script on the parent GameObject.
  * **Interact Use:** An optional Interact Use to listen for use events on. If this is left blank as it will attempt to be auto populated by finding the Interact Use script on the parent GameObject.

--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -3163,6 +3163,11 @@ The `Object To Affect` can be the object that is causing the interaction (touch/
  * **Object To Affect:** The GameObject to affect the appearance of. If this is null then then the interacting object will be used (usually the controller).
  * **Game Object Active By Default:** If this is checked then the `Object To Affect` will be an active GameObject when the script is enabled. If it's unchecked then it will be disabled. This only takes effect if `Affect Interacting Object` is unticked.
  * **Renderer Visible By Default:** If this is checked then the `Object To Affect` will have visible renderers when the script is enabled. If it's unchecked then it will have it's renderers disabled. This only takes effect if `Affect Interacting Object` is unticked.
+ * **Game Object Active On Near Touch:** If this is checked then the `Object To Affect` will be an active GameObject when the `Object To Monitor` is near touched. If it's unchecked then it will be disabled on near touch.
+ * **Renderer Visible On Near Touch:** If this is checked then the `Object To Affect` will have visible renderers when the `Object To Monitor` is near touched. If it's unchecked then it will have it's renderers disabled on near touch.
+ * **Near Touch Appearance Delay:** The amount of time to wait before the near touch appearance settings are applied after the near touch event.
+ * **Near Untouch Appearance Delay:** The amount of time to wait before the previous appearance settings are applied after the near untouch event.
+ * **Valid Near Touch Interacting Object:** Determines what type of interacting object will affect the appearance of the `Object To Affect` after the near touch and near untouch event.
  * **Game Object Active On Touch:** If this is checked then the `Object To Affect` will be an active GameObject when the `Object To Monitor` is touched. If it's unchecked then it will be disabled on touch.
  * **Renderer Visible On Touch:** If this is checked then the `Object To Affect` will have visible renderers when the `Object To Monitor` is touched. If it's unchecked then it will have it's renderers disabled on touch.
  * **Touch Appearance Delay:** The amount of time to wait before the touch appearance settings are applied after the touch event.
@@ -3181,14 +3186,6 @@ The `Object To Affect` can be the object that is causing the interaction (touch/
 
 ### Class Variables
 
- * `public enum InteractionType` - The interaction type.
-   * `None` - No interaction has affected the object appearance.
-   * `Touch` - The touch interaction has affected the object appearance.
-   * `Untouch` - The untouch interaction has affected the object appearance.
-   * `Grab` - The grab interaction has affected the object appearance.
-   * `Ungrab` - The ungrab interaction has affected the object appearance.
-   * `Use` - The use interaction has affected the object appearance.
-   * `Unuse` - The unuse interaction has affected the object appearance.
  * `public enum ValidInteractingObject` - The valid interacting object.
    * `Anything` - Any GameObject is considered a valid interacting object.
    * `EitherController` - Only a game controller is considered a valid interacting objcet.
@@ -3213,7 +3210,7 @@ Adding the `VRTK_InteractObjectAppearance_UnityEvents` component to `VRTK_Intera
 
  * `GameObject affectingObject` - The object that is being affected.
  * `VRTK_InteractableObject monitoringObject` - The interactable object that is being monitored.
- * `VRTK_InteractObjectAppearance.InteractionType interactionType` - The type of interaction initiating the event.
+ * `VRTK_InteractableObject.InteractionType interactionType` - The type of interaction initiating the event.
 
 ### Example
 

--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -4342,18 +4342,22 @@ The Interact Haptics script is attached on the same GameObject as an Interactabl
  * **Strength On Near Touch:** Denotes how strong the rumble in the controller will be on near touch.
  * **Duration On Near Touch:** Denotes how long the rumble in the controller will last on near touch.
  * **Interval On Near Touch:** Denotes interval betweens rumble in the controller on near touch.
+ * **Cancel On Near Untouch:** If this is checked then the rumble will be cancelled when the controller is no longer near touching.
  * **Clip On Touch:** Denotes the audio clip to use to rumble the controller on touch.
  * **Strength On Touch:** Denotes how strong the rumble in the controller will be on touch.
  * **Duration On Touch:** Denotes how long the rumble in the controller will last on touch.
  * **Interval On Touch:** Denotes interval betweens rumble in the controller on touch.
+ * **Cancel On Untouch:** If this is checked then the rumble will be cancelled when the controller is no longer touching.
  * **Clip On Grab:** Denotes the audio clip to use to rumble the controller on grab.
  * **Strength On Grab:** Denotes how strong the rumble in the controller will be on grab.
  * **Duration On Grab:** Denotes how long the rumble in the controller will last on grab.
  * **Interval On Grab:** Denotes interval betweens rumble in the controller on grab.
+ * **Cancel On Ungrab:** If this is checked then the rumble will be cancelled when the controller is no longer grabbing.
  * **Clip On Use:** Denotes the audio clip to use to rumble the controller on use.
  * **Strength On Use:** Denotes how strong the rumble in the controller will be on use.
  * **Duration On Use:** Denotes how long the rumble in the controller will last on use.
  * **Interval On Use:** Denotes interval betweens rumble in the controller on use.
+ * **Cancel On Unuse:** If this is checked then the rumble will be cancelled when the controller is no longer using.
  * **Object To Affect:** The Interactable Object to initiate the haptics from. If this is left blank, then the Interactable Object will need to be on the current or a parent GameObject.
 
 ### Class Events

--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -4200,6 +4200,30 @@ The PerformSecondaryAction method returns whether the object has a secondary act
 
 The ResetIgnoredColliders method is used to clear any stored ignored colliders in case the `Ignored Colliders` array parameter is changed at runtime. This needs to be called manually if changes are made at runtime.
 
+#### SubscribeToInteractionEvent/2
+
+  > `public virtual void SubscribeToInteractionEvent(InteractionType givenType, InteractableObjectEventHandler methodCallback)`
+
+ * Parameters
+   * `InteractionType givenType` - The Interaction Type to register the events for.
+   * `InteractableObjectEventHandler methodCallback` - The method to execute when the Interaction Type is initiated.
+ * Returns
+   * _none_
+
+The SubscribeToInteractionEvent method subscribes a given method callback for the given Interaction Type.
+
+#### UnsubscribeFromInteractionEvent/2
+
+  > `public virtual void UnsubscribeFromInteractionEvent(InteractionType givenType, InteractableObjectEventHandler methodCallback)`
+
+ * Parameters
+   * `InteractionType givenType` - The Interaction Type that the previous event subscription was under.
+   * `InteractableObjectEventHandler methodCallback` - The method that was being executed when the Interaction Type was initiated.
+ * Returns
+   * _none_
+
+The UnsubscribeFromInteractionEvent method unsubscribes a previous event subscription for the given Interaction Type.
+
 ### Example
 
 `VRTK/Examples/005_Controller_BasicObjectGrabbing` uses the `VRTK_InteractTouch` and `VRTK_InteractGrab` scripts on the controllers to show how an interactable object can be grabbed and snapped to the controller and thrown around the game world.
@@ -4314,6 +4338,10 @@ The Interact Haptics script is attached on the same GameObject as an Interactabl
 
 ### Inspector Parameters
 
+ * **Clip On Near Touch:** Denotes the audio clip to use to rumble the controller on near touch.
+ * **Strength On Near Touch:** Denotes how strong the rumble in the controller will be on near touch.
+ * **Duration On Near Touch:** Denotes how long the rumble in the controller will last on near touch.
+ * **Interval On Near Touch:** Denotes interval betweens rumble in the controller on near touch.
  * **Clip On Touch:** Denotes the audio clip to use to rumble the controller on touch.
  * **Strength On Touch:** Denotes how strong the rumble in the controller will be on touch.
  * **Duration On Touch:** Denotes how long the rumble in the controller will last on touch.
@@ -4326,9 +4354,11 @@ The Interact Haptics script is attached on the same GameObject as an Interactabl
  * **Strength On Use:** Denotes how strong the rumble in the controller will be on use.
  * **Duration On Use:** Denotes how long the rumble in the controller will last on use.
  * **Interval On Use:** Denotes interval betweens rumble in the controller on use.
+ * **Object To Affect:** The Interactable Object to initiate the haptics from. If this is left blank, then the Interactable Object will need to be on the current or a parent GameObject.
 
 ### Class Events
 
+ * `InteractHapticsNearTouched` - Emitted when the haptics are from a near touch.
  * `InteractHapticsTouched` - Emitted when the haptics are from a touch.
  * `InteractHapticsGrabbed` - Emitted when the haptics are from a grab.
  * `InteractHapticsUsed` - Emitted when the haptics are from a use.
@@ -4344,6 +4374,28 @@ Adding the `VRTK_InteractHaptics_UnityEvents` component to `VRTK_InteractHaptics
  * `VRTK_ControllerReference controllerReference` - The reference to the controller to perform haptics on.
 
 ### Class Methods
+
+#### CancelHaptics/1
+
+  > `public virtual void CancelHaptics(VRTK_ControllerReference controllerReference)`
+
+ * Parameters
+   * `VRTK_ControllerReference controllerReference` -
+ * Returns
+   * _none_
+
+The CancelHaptics method cancels any existing haptic feedback on the given controller.
+
+#### HapticsOnNearTouch/1
+
+  > `public virtual void HapticsOnNearTouch(VRTK_ControllerReference controllerReference)`
+
+ * Parameters
+   * `VRTK_ControllerReference controllerReference` - The reference to the controller to activate the haptic feedback on.
+ * Returns
+   * _none_
+
+The HapticsOnNearTouch method triggers the haptic feedback on the given controller for the settings associated with near touch.
 
 #### HapticsOnTouch/1
 

--- a/Assets/VRTK/Prefabs/AvatarHands/BasicHands/Models/VRTK_BasicHand_AnimationController.controller
+++ b/Assets/VRTK/Prefabs/AvatarHands/BasicHands/Models/VRTK_BasicHand_AnimationController.controller
@@ -8,6 +8,12 @@ AnimatorController:
   m_Name: VRTK_BasicHand_AnimationController
   serializedVersion: 5
   m_AnimatorParameters:
+  - m_Name: NearTouchState
+    m_Type: 1
+    m_DefaultFloat: -1
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: TouchState
     m_Type: 1
     m_DefaultFloat: -1

--- a/Assets/VRTK/Source/Editor/VRTK_InteractHapticsEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_InteractHapticsEditor.cs
@@ -10,21 +10,25 @@
         SerializedProperty strengthOnNearTouch;
         SerializedProperty durationOnNearTouch;
         SerializedProperty intervalOnNearTouch;
+        SerializedProperty cancelOnNearUntouch;
 
         SerializedProperty clipOnTouch;
         SerializedProperty strengthOnTouch;
         SerializedProperty durationOnTouch;
         SerializedProperty intervalOnTouch;
+        SerializedProperty cancelOnUntouch;
 
         SerializedProperty clipOnGrab;
         SerializedProperty strengthOnGrab;
         SerializedProperty durationOnGrab;
         SerializedProperty intervalOnGrab;
+        SerializedProperty cancelOnUngrab;
 
         SerializedProperty clipOnUse;
         SerializedProperty strengthOnUse;
         SerializedProperty durationOnUse;
         SerializedProperty intervalOnUse;
+        SerializedProperty cancelOnUnuse;
 
         SerializedProperty objectToAffect;
 
@@ -34,21 +38,25 @@
             strengthOnNearTouch = serializedObject.FindProperty("strengthOnNearTouch");
             durationOnNearTouch = serializedObject.FindProperty("durationOnNearTouch");
             intervalOnNearTouch = serializedObject.FindProperty("intervalOnNearTouch");
+            cancelOnNearUntouch = serializedObject.FindProperty("cancelOnNearUntouch");
 
             clipOnTouch = serializedObject.FindProperty("clipOnTouch");
             strengthOnTouch = serializedObject.FindProperty("strengthOnTouch");
             durationOnTouch = serializedObject.FindProperty("durationOnTouch");
             intervalOnTouch = serializedObject.FindProperty("intervalOnTouch");
+            cancelOnUntouch = serializedObject.FindProperty("cancelOnUntouch");
 
             clipOnGrab = serializedObject.FindProperty("clipOnGrab");
             strengthOnGrab = serializedObject.FindProperty("strengthOnGrab");
             durationOnGrab = serializedObject.FindProperty("durationOnGrab");
             intervalOnGrab = serializedObject.FindProperty("intervalOnGrab");
+            cancelOnUngrab = serializedObject.FindProperty("cancelOnUngrab");
 
             clipOnUse = serializedObject.FindProperty("clipOnUse");
             strengthOnUse = serializedObject.FindProperty("strengthOnUse");
             durationOnUse = serializedObject.FindProperty("durationOnUse");
             intervalOnUse = serializedObject.FindProperty("intervalOnUse");
+            cancelOnUnuse = serializedObject.FindProperty("cancelOnUnuse");
 
             objectToAffect = serializedObject.FindProperty("objectToAffect");
         }
@@ -67,6 +75,7 @@
                 EditorGUILayout.PropertyField(durationOnNearTouch);
                 EditorGUILayout.PropertyField(intervalOnNearTouch);
             }
+            EditorGUILayout.PropertyField(cancelOnNearUntouch);
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Haptics On Touch Settings", EditorStyles.boldLabel);
@@ -78,6 +87,7 @@
                 EditorGUILayout.PropertyField(durationOnTouch);
                 EditorGUILayout.PropertyField(intervalOnTouch);
             }
+            EditorGUILayout.PropertyField(cancelOnUntouch);
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Haptics On Grab Settings", EditorStyles.boldLabel);
@@ -89,6 +99,7 @@
                 EditorGUILayout.PropertyField(durationOnGrab);
                 EditorGUILayout.PropertyField(intervalOnGrab);
             }
+            EditorGUILayout.PropertyField(cancelOnUngrab);
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Haptics On Use Settings", EditorStyles.boldLabel);
@@ -100,6 +111,7 @@
                 EditorGUILayout.PropertyField(durationOnUse);
                 EditorGUILayout.PropertyField(intervalOnUse);
             }
+            EditorGUILayout.PropertyField(cancelOnUnuse);
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(objectToAffect);

--- a/Assets/VRTK/Source/Editor/VRTK_InteractHapticsEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_InteractHapticsEditor.cs
@@ -6,6 +6,11 @@
     [CustomEditor(typeof(VRTK_InteractHaptics))]
     public class VRTK_InteractHapticsEditor : Editor
     {
+        SerializedProperty clipOnNearTouch;
+        SerializedProperty strengthOnNearTouch;
+        SerializedProperty durationOnNearTouch;
+        SerializedProperty intervalOnNearTouch;
+
         SerializedProperty clipOnTouch;
         SerializedProperty strengthOnTouch;
         SerializedProperty durationOnTouch;
@@ -21,8 +26,15 @@
         SerializedProperty durationOnUse;
         SerializedProperty intervalOnUse;
 
+        SerializedProperty objectToAffect;
+
         private void OnEnable()
         {
+            clipOnNearTouch = serializedObject.FindProperty("clipOnNearTouch");
+            strengthOnNearTouch = serializedObject.FindProperty("strengthOnNearTouch");
+            durationOnNearTouch = serializedObject.FindProperty("durationOnNearTouch");
+            intervalOnNearTouch = serializedObject.FindProperty("intervalOnNearTouch");
+
             clipOnTouch = serializedObject.FindProperty("clipOnTouch");
             strengthOnTouch = serializedObject.FindProperty("strengthOnTouch");
             durationOnTouch = serializedObject.FindProperty("durationOnTouch");
@@ -37,6 +49,8 @@
             strengthOnUse = serializedObject.FindProperty("strengthOnUse");
             durationOnUse = serializedObject.FindProperty("durationOnUse");
             intervalOnUse = serializedObject.FindProperty("intervalOnUse");
+
+            objectToAffect = serializedObject.FindProperty("objectToAffect");
         }
 
         public override void OnInspectorGUI()
@@ -44,7 +58,18 @@
             serializedObject.Update();
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Haptics On Touch", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Haptics On Near Touch Settings", EditorStyles.boldLabel);
+
+            EditorGUILayout.ObjectField(clipOnNearTouch, typeof(AudioClip));
+            if (clipOnNearTouch.objectReferenceValue == null)
+            {
+                EditorGUILayout.PropertyField(strengthOnNearTouch);
+                EditorGUILayout.PropertyField(durationOnNearTouch);
+                EditorGUILayout.PropertyField(intervalOnNearTouch);
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Haptics On Touch Settings", EditorStyles.boldLabel);
 
             EditorGUILayout.ObjectField(clipOnTouch, typeof(AudioClip));
             if (clipOnTouch.objectReferenceValue == null)
@@ -55,7 +80,7 @@
             }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Haptics On Grab", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Haptics On Grab Settings", EditorStyles.boldLabel);
 
             EditorGUILayout.ObjectField(clipOnGrab, typeof(AudioClip));
             if (clipOnGrab.objectReferenceValue == null)
@@ -66,7 +91,7 @@
             }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Haptics On Use", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Haptics On Use Settings", EditorStyles.boldLabel);
 
             EditorGUILayout.ObjectField(clipOnUse, typeof(AudioClip));
             if (clipOnUse.objectReferenceValue == null)
@@ -75,6 +100,9 @@
                 EditorGUILayout.PropertyField(durationOnUse);
                 EditorGUILayout.PropertyField(intervalOnUse);
             }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.PropertyField(objectToAffect);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -499,18 +499,6 @@ namespace VRTK
             return null;
         }
 
-        protected virtual void AttemptHaptics(bool initialGrabAttempt)
-        {
-            if (grabbedObject != null && initialGrabAttempt)
-            {
-                VRTK_InteractHaptics doHaptics = grabbedObject.GetComponentInParent<VRTK_InteractHaptics>();
-                if (doHaptics != null)
-                {
-                    doHaptics.HapticsOnGrab(controllerReference);
-                }
-            }
-        }
-
         protected virtual void AttemptGrabObject()
         {
             GameObject objectToGrab = GetGrabbableObject();
@@ -529,7 +517,6 @@ namespace VRTK
             IncrementGrabState();
             bool initialGrabAttempt = IsValidGrabAttempt(objectToGrab);
             undroppableGrabbedObject = GetUndroppableObject();
-            AttemptHaptics(initialGrabAttempt);
         }
 
         protected virtual bool ScriptValidGrab(VRTK_InteractableObject objectToGrabScript)

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -427,7 +427,6 @@ namespace VRTK
             currentGrabbedObject.SaveCurrentState();
             currentGrabbedObject.Grabbed(this);
             currentGrabbedObject.ZeroVelocity();
-            currentGrabbedObject.ToggleHighlight(false);
             currentGrabbedObject.isKinematic = false;
         }
 
@@ -460,7 +459,6 @@ namespace VRTK
                         grabbedObjectScript.grabAttachMechanicScript.StopGrab(applyGrabbingObjectVelocity);
                     }
                     grabbedObjectScript.Ungrabbed(this);
-                    grabbedObjectScript.ToggleHighlight(false);
                     ToggleControllerVisibility(true);
 
                     OnControllerUngrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -36,6 +36,8 @@ namespace VRTK
         public float durationOnNearTouch = 0f;
         [Tooltip("Denotes interval betweens rumble in the controller on near touch.")]
         public float intervalOnNearTouch = minInterval;
+        [Tooltip("If this is checked then the rumble will be cancelled when the controller is no longer near touching.")]
+        public bool cancelOnNearUntouch = true;
 
         [Header("Haptics On Touch Settings")]
 
@@ -48,6 +50,8 @@ namespace VRTK
         public float durationOnTouch = 0f;
         [Tooltip("Denotes interval betweens rumble in the controller on touch.")]
         public float intervalOnTouch = minInterval;
+        [Tooltip("If this is checked then the rumble will be cancelled when the controller is no longer touching.")]
+        public bool cancelOnUntouch = true;
 
         [Header("Haptics On Grab Settings")]
 
@@ -60,6 +64,8 @@ namespace VRTK
         public float durationOnGrab = 0f;
         [Tooltip("Denotes interval betweens rumble in the controller on grab.")]
         public float intervalOnGrab = minInterval;
+        [Tooltip("If this is checked then the rumble will be cancelled when the controller is no longer grabbing.")]
+        public bool cancelOnUngrab = true;
 
         [Header("Haptics On Use Settings")]
 
@@ -72,6 +78,8 @@ namespace VRTK
         public float durationOnUse = 0f;
         [Tooltip("Denotes interval betweens rumble in the controller on use.")]
         public float intervalOnUse = minInterval;
+        [Tooltip("If this is checked then the rumble will be cancelled when the controller is no longer using.")]
+        public bool cancelOnUnuse = true;
 
         [Header("Custom Settings")]
 
@@ -212,6 +220,11 @@ namespace VRTK
 
             if (objectToAffect != null)
             {
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearUntouch, CancelNearTouchHaptics);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Untouch, CancelTouchHaptics);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Ungrab, CancelGrabHaptics);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Unuse, CancelUseHaptics);
+
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHaptics);
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHaptics);
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHaptics);
@@ -227,6 +240,11 @@ namespace VRTK
         {
             if (objectToAffect != null)
             {
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.NearUntouch, CancelNearTouchHaptics);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Untouch, CancelTouchHaptics);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Ungrab, CancelGrabHaptics);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Unuse, CancelUseHaptics);
+
                 objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHaptics);
                 objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHaptics);
                 objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHaptics);
@@ -279,6 +297,47 @@ namespace VRTK
             if (VRTK_ControllerReference.IsValid(controllerReference))
             {
                 HapticsOnUse(controllerReference);
+            }
+        }
+
+        protected virtual void CancelOn(GameObject givenObject)
+        {
+            VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(givenObject);
+            if (VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                CancelHaptics(controllerReference);
+            }
+        }
+
+        protected virtual void CancelNearTouchHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            if (cancelOnNearUntouch)
+            {
+                CancelOn(e.interactingObject);
+            }
+        }
+
+        protected virtual void CancelTouchHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            if (cancelOnUntouch)
+            {
+                CancelOn(e.interactingObject);
+            }
+        }
+
+        protected virtual void CancelGrabHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            if (cancelOnUngrab)
+            {
+                CancelOn(e.interactingObject);
+            }
+        }
+
+        protected virtual void CancelUseHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            if (cancelOnUnuse)
+            {
+                CancelOn(e.interactingObject);
             }
         }
     }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractHaptics.cs
@@ -25,7 +25,19 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/Interactions/VRTK_InteractHaptics")]
     public class VRTK_InteractHaptics : MonoBehaviour
     {
-        [Header("Haptics On Touch")]
+        [Header("Haptics On Near Touch Settings")]
+
+        [Tooltip("Denotes the audio clip to use to rumble the controller on near touch.")]
+        public AudioClip clipOnNearTouch;
+        [Tooltip("Denotes how strong the rumble in the controller will be on near touch.")]
+        [Range(0, 1)]
+        public float strengthOnNearTouch = 0;
+        [Tooltip("Denotes how long the rumble in the controller will last on near touch.")]
+        public float durationOnNearTouch = 0f;
+        [Tooltip("Denotes interval betweens rumble in the controller on near touch.")]
+        public float intervalOnNearTouch = minInterval;
+
+        [Header("Haptics On Touch Settings")]
 
         [Tooltip("Denotes the audio clip to use to rumble the controller on touch.")]
         public AudioClip clipOnTouch;
@@ -37,7 +49,7 @@ namespace VRTK
         [Tooltip("Denotes interval betweens rumble in the controller on touch.")]
         public float intervalOnTouch = minInterval;
 
-        [Header("Haptics On Grab")]
+        [Header("Haptics On Grab Settings")]
 
         [Tooltip("Denotes the audio clip to use to rumble the controller on grab.")]
         public AudioClip clipOnGrab;
@@ -49,7 +61,7 @@ namespace VRTK
         [Tooltip("Denotes interval betweens rumble in the controller on grab.")]
         public float intervalOnGrab = minInterval;
 
-        [Header("Haptics On Use")]
+        [Header("Haptics On Use Settings")]
 
         [Tooltip("Denotes the audio clip to use to rumble the controller on use.")]
         public AudioClip clipOnUse;
@@ -61,6 +73,15 @@ namespace VRTK
         [Tooltip("Denotes interval betweens rumble in the controller on use.")]
         public float intervalOnUse = minInterval;
 
+        [Header("Custom Settings")]
+
+        [Tooltip("The Interactable Object to initiate the haptics from. If this is left blank, then the Interactable Object will need to be on the current or a parent GameObject.")]
+        public VRTK_InteractableObject objectToAffect;
+
+        /// <summary>
+        /// Emitted when the haptics are from a near touch.
+        /// </summary>
+        public event InteractHapticsEventHandler InteractHapticsNearTouched;
         /// <summary>
         /// Emitted when the haptics are from a touch.
         /// </summary>
@@ -75,6 +96,14 @@ namespace VRTK
         public event InteractHapticsEventHandler InteractHapticsUsed;
 
         protected const float minInterval = 0.05f;
+
+        public virtual void OnInteractHapticsNearTouched(InteractHapticsEventArgs e)
+        {
+            if (InteractHapticsNearTouched != null)
+            {
+                InteractHapticsNearTouched(this, e);
+            }
+        }
 
         public virtual void OnInteractHapticsTouched(InteractHapticsEventArgs e)
         {
@@ -98,6 +127,32 @@ namespace VRTK
             {
                 InteractHapticsUsed(this, e);
             }
+        }
+
+        /// <summary>
+        /// The CancelHaptics method cancels any existing haptic feedback on the given controller.
+        /// </summary>
+        /// <param name="controllerReference"></param>
+        public virtual void CancelHaptics(VRTK_ControllerReference controllerReference)
+        {
+            VRTK_ControllerHaptics.CancelHapticPulse(controllerReference);
+        }
+
+        /// <summary>
+        /// The HapticsOnNearTouch method triggers the haptic feedback on the given controller for the settings associated with near touch.
+        /// </summary>
+        /// <param name="controllerReference">The reference to the controller to activate the haptic feedback on.</param>
+        public virtual void HapticsOnNearTouch(VRTK_ControllerReference controllerReference)
+        {
+            if (clipOnNearTouch != null)
+            {
+                VRTK_ControllerHaptics.TriggerHapticPulse(controllerReference, clipOnNearTouch);
+            }
+            else if (strengthOnNearTouch > 0 && durationOnNearTouch > 0f)
+            {
+                TriggerHapticPulse(controllerReference, strengthOnNearTouch, durationOnNearTouch, intervalOnNearTouch);
+            }
+            OnInteractHapticsNearTouched(SetEventPayload(controllerReference));
         }
 
         /// <summary>
@@ -153,9 +208,29 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            if (!GetComponent<VRTK_InteractableObject>())
+            objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
+
+            if (objectToAffect != null)
             {
-                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_InteractHaptics", "VRTK_InteractableObject", "the same"));
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHaptics);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHaptics);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHaptics);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Use, UseHaptics);
+            }
+            else
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_InteractHaptics", "VRTK_InteractableObject", "the same or parent"));
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (objectToAffect != null)
+            {
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHaptics);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHaptics);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHaptics);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Use, UseHaptics);
             }
         }
 
@@ -169,6 +244,42 @@ namespace VRTK
             InteractHapticsEventArgs e;
             e.controllerReference = givenControllerReference;
             return e;
+        }
+
+        protected virtual void NearTouchHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(e.interactingObject);
+            if (VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                HapticsOnNearTouch(controllerReference);
+            }
+        }
+
+        protected virtual void TouchHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(e.interactingObject);
+            if (VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                HapticsOnTouch(controllerReference);
+            }
+        }
+
+        protected virtual void GrabHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(e.interactingObject);
+            if (VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                HapticsOnGrab(controllerReference);
+            }
+        }
+
+        protected virtual void UseHaptics(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_ControllerReference controllerReference = VRTK_ControllerReference.GetControllerReference(e.interactingObject);
+            if (VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                HapticsOnUse(controllerReference);
+            }
         }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractNearTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractNearTouch.cs
@@ -1,0 +1,258 @@
+﻿// Interact Near Touch|Interactions|30055
+namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The Interact Near Touch script is usually applied to a Controller and provides a collider to know when the controller is nearly touching something.
+    /// </summary>
+    /// <remarks>
+    /// Colliders are created for the controller and by default will be a sphere.
+    ///
+    /// A custom collider can be provided by the Custom Collider Container parameter.
+    /// </remarks>
+    [AddComponentMenu("VRTK/Scripts/Interactions/VRTK_InteractNearTouch")]
+    public class VRTK_InteractNearTouch : MonoBehaviour
+    {
+        [Tooltip("The radius of the auto generated collider if a `Custom Collider Container` is not supplied.")]
+        public float colliderRadius = 0.2f;
+        [Tooltip("An optional GameObject that contains the compound colliders to represent the near touching object. If this is empty then the collider will be auto generated at runtime.")]
+        public GameObject customColliderContainer;
+        [Tooltip("The Interact Touch script to associate the near touches with. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.")]
+        public VRTK_InteractTouch interactTouch;
+
+        protected GameObject neartouchColliderContainer;
+        protected List<GameObject> nearTouchedObjects = new List<GameObject>();
+        protected VRTK_InteractNearTouchCollider interactNearTouchColliderScript;
+
+        /// <summary>
+        /// Emitted when a valid object is near touched.
+        /// </summary>
+        public event ObjectInteractEventHandler ControllerNearTouchInteractableObject;
+        /// <summary>
+        /// Emitted when a valid object is no longer being near touched.
+        /// </summary>
+        public event ObjectInteractEventHandler ControllerNearUntouchInteractableObject;
+
+        public virtual void OnControllerNearTouchInteractableObject(ObjectInteractEventArgs e)
+        {
+            if (!nearTouchedObjects.Contains(e.target))
+            {
+                nearTouchedObjects.Add(e.target);
+            }
+
+            if (ControllerNearTouchInteractableObject != null)
+            {
+                ControllerNearTouchInteractableObject(this, e);
+            }
+        }
+
+        public virtual void OnControllerNearUntouchInteractableObject(ObjectInteractEventArgs e)
+        {
+            if (nearTouchedObjects.Contains(e.target))
+            {
+                nearTouchedObjects.Remove(e.target);
+            }
+
+            if (ControllerNearUntouchInteractableObject != null)
+            {
+                ControllerNearUntouchInteractableObject(this, e);
+            }
+        }
+
+        /// <summary>
+        /// The GetNearTouchedObjects method returns all of the GameObjects that are currently being near touched.
+        /// </summary>
+        /// <returns>A list of GameObjects that are being near touched.</returns>
+        public virtual List<GameObject> GetNearTouchedObjects()
+        {
+            return nearTouchedObjects;
+        }
+
+        /// <summary>
+        /// The ForceNearTouch method will attempt to force the controller to near touch the given game object.
+        /// </summary>
+        /// <param name="obj">The GameObject to attempt to force near touch.</param>
+        public virtual void ForceNearTouch(GameObject obj)
+        {
+            Collider objCollider = (obj != null ? obj.GetComponentInChildren<Collider>() : null);
+            if (objCollider != null)
+            {
+                interactNearTouchColliderScript.StartNearTouch(objCollider);
+            }
+        }
+
+        /// <summary>
+        /// The ForceStopNearTouching method will stop the controller from near touching an object even if the controller is physically touching the object still.
+        /// </summary>
+        /// <param name="obj">An optional GameObject to only include in the force stop. If this is null then all near touched GameObjects will be force stopped.</param>
+        public virtual void ForceStopNearTouching(GameObject obj = null)
+        {
+            if (obj != null)
+            {
+                Collider objCollider = (obj != null ? obj.GetComponentInChildren<Collider>() : null);
+                if (objCollider != null)
+                {
+                    interactNearTouchColliderScript.EndNearTouch(objCollider);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < nearTouchedObjects.Count; i++)
+                {
+                    OnControllerNearUntouchInteractableObject(interactTouch.SetControllerInteractEvent(nearTouchedObjects[i]));
+                }
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            nearTouchedObjects.Clear();
+            interactTouch = (interactTouch != null ? interactTouch : GetComponentInParent<VRTK_InteractTouch>());
+            if (interactTouch != null)
+            {
+                CreateNearTouchCollider();
+                interactTouch.ControllerTouchInteractableObject += ControllerTouchInteractableObject;
+                interactTouch.ControllerUntouchInteractableObject += ControllerUntouchInteractableObject;
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            Destroy(neartouchColliderContainer);
+            if (interactTouch != null)
+            {
+                interactTouch.ControllerTouchInteractableObject -= ControllerTouchInteractableObject;
+                interactTouch.ControllerUntouchInteractableObject -= ControllerUntouchInteractableObject;
+            }
+        }
+
+        protected virtual void ControllerTouchInteractableObject(object sender, ObjectInteractEventArgs e)
+        {
+            ForceStopNearTouching(e.target);
+        }
+
+        protected virtual void ControllerUntouchInteractableObject(object sender, ObjectInteractEventArgs e)
+        {
+            if (interactNearTouchColliderScript.GetNearTouchedObjects().Contains(e.target))
+            {
+                ForceNearTouch(e.target);
+            }
+        }
+
+        protected virtual void CreateNearTouchCollider()
+        {
+            if (customColliderContainer == null)
+            {
+                neartouchColliderContainer = new GameObject();
+                neartouchColliderContainer.transform.SetParent(interactTouch.transform);
+                neartouchColliderContainer.transform.localPosition = Vector3.zero;
+                neartouchColliderContainer.transform.localRotation = Quaternion.identity;
+                neartouchColliderContainer.transform.localScale = interactTouch.transform.localScale;
+            }
+            else
+            {
+                neartouchColliderContainer = Instantiate(customColliderContainer, Vector3.zero, Quaternion.identity, interactTouch.transform);
+            }
+
+            neartouchColliderContainer.name = VRTK_SharedMethods.GenerateVRTKObjectName(true, "Controller", "NearTouch", "CollidersContainer");
+
+            Rigidbody attachedRigidbody = neartouchColliderContainer.GetComponentInChildren<Rigidbody>();
+            if (attachedRigidbody == null)
+            {
+                attachedRigidbody = neartouchColliderContainer.AddComponent<Rigidbody>();
+            }
+
+            attachedRigidbody.isKinematic = true;
+            attachedRigidbody.constraints = RigidbodyConstraints.FreezeRotation;
+
+            Collider attachedCollider = neartouchColliderContainer.GetComponentInChildren<Collider>();
+            if (attachedCollider == null)
+            {
+                SphereCollider attachedSphereCollider = neartouchColliderContainer.AddComponent<SphereCollider>();
+                attachedSphereCollider.isTrigger = true;
+                attachedSphereCollider.radius = colliderRadius;
+            }
+            else
+            {
+                attachedCollider.isTrigger = true;
+            }
+
+            interactNearTouchColliderScript = neartouchColliderContainer.AddComponent<VRTK_InteractNearTouchCollider>();
+            interactNearTouchColliderScript.SetInteractNearTouch(this);
+
+            neartouchColliderContainer.SetActive(true);
+        }
+    }
+
+    public class VRTK_InteractNearTouchCollider : MonoBehaviour
+    {
+        protected VRTK_InteractNearTouch interactNearTouch;
+        protected List<GameObject> nearTouchedObjects = new List<GameObject>();
+
+        public virtual void SetInteractNearTouch(VRTK_InteractNearTouch givenInteractNearTouch)
+        {
+            interactNearTouch = givenInteractNearTouch;
+        }
+
+        public virtual List<GameObject> GetNearTouchedObjects()
+        {
+            return nearTouchedObjects;
+        }
+
+        public virtual void StartNearTouch(Collider collider)
+        {
+            VRTK_InteractableObject checkObject = collider.gameObject.GetComponentInParent<VRTK_InteractableObject>();
+            if (!VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && validObject(checkObject))
+            {
+                if (checkObject != null)
+                {
+                    checkObject.StartNearTouching(interactNearTouch);
+                }
+                interactNearTouch.OnControllerNearTouchInteractableObject(interactNearTouch.interactTouch.SetControllerInteractEvent(collider.gameObject));
+            }
+        }
+
+        public virtual void EndNearTouch(Collider collider)
+        {
+            VRTK_InteractableObject checkObject = collider.gameObject.GetComponentInParent<VRTK_InteractableObject>();
+            if (!VRTK_PlayerObject.IsPlayerObject(collider.gameObject) && validObject(checkObject))
+            {
+                if (checkObject != null)
+                {
+                    checkObject.StopNearTouching(interactNearTouch);
+                }
+                interactNearTouch.OnControllerNearUntouchInteractableObject(interactNearTouch.interactTouch.SetControllerInteractEvent(collider.gameObject));
+            }
+        }
+
+        protected virtual void OnTriggerEnter(Collider collider)
+        {
+            StartNearTouch(collider);
+            if (!nearTouchedObjects.Contains(collider.gameObject))
+            {
+                nearTouchedObjects.Add(collider.gameObject);
+            }
+        }
+
+        protected virtual void OnTriggerExit(Collider collider)
+        {
+            EndNearTouch(collider);
+            if (nearTouchedObjects.Contains(collider.gameObject))
+            {
+                nearTouchedObjects.Remove(collider.gameObject);
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            nearTouchedObjects.Clear();
+        }
+
+        protected virtual bool validObject(VRTK_InteractableObject checkObject)
+        {
+            return (checkObject == null || checkObject.IsValidInteractableController(interactNearTouch.interactTouch.gameObject, checkObject.allowedNearTouchControllers));
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractNearTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractNearTouch.cs
@@ -113,7 +113,7 @@ namespace VRTK
             if (interactTouch != null)
             {
                 CreateNearTouchCollider();
-                interactTouch.ControllerTouchInteractableObject += ControllerTouchInteractableObject;
+                interactTouch.ControllerStartTouchInteractableObject += ControllerStartTouchInteractableObject;
                 interactTouch.ControllerUntouchInteractableObject += ControllerUntouchInteractableObject;
             }
         }
@@ -123,12 +123,12 @@ namespace VRTK
             Destroy(neartouchColliderContainer);
             if (interactTouch != null)
             {
-                interactTouch.ControllerTouchInteractableObject -= ControllerTouchInteractableObject;
+                interactTouch.ControllerStartTouchInteractableObject -= ControllerStartTouchInteractableObject;
                 interactTouch.ControllerUntouchInteractableObject -= ControllerUntouchInteractableObject;
             }
         }
 
-        protected virtual void ControllerTouchInteractableObject(object sender, ObjectInteractEventArgs e)
+        protected virtual void ControllerStartTouchInteractableObject(object sender, ObjectInteractEventArgs e)
         {
             ForceStopNearTouching(e.target);
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractNearTouch.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractNearTouch.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: eda201177cd508f49849386d157bdd39
+timeCreated: 1504769236
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractObjectHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractObjectHighlighter.cs
@@ -85,18 +85,42 @@ namespace VRTK
         {
             objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
 
-            ManageNearTouchSubscriptions(true);
-            ManageTouchSubscriptions(true);
-            ManageGrabSubscriptions(true);
-            ManageUseSubscriptions(true);
+            if (objectToAffect != null)
+            {
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHighlightObject);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearUntouch, NearTouchUnHighlightObject);
+
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHighlightObject);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Untouch, TouchUnHighlightObject);
+
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHighlightObject);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Ungrab, GrabUnHighlightObject);
+
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Use, UseHighlightObject);
+                objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Unuse, UseUnHighlightObject);
+            }
+            else
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_InteractObjectHighlighter", "VRTK_InteractableObject", "the same or parent"));
+            }
         }
 
         protected virtual void OnDisable()
         {
-            ManageNearTouchSubscriptions(false);
-            ManageTouchSubscriptions(false);
-            ManageGrabSubscriptions(false);
-            ManageUseSubscriptions(false);
+            if (objectToAffect != null)
+            {
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHighlightObject);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.NearUntouch, NearTouchUnHighlightObject);
+
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHighlightObject);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Untouch, TouchUnHighlightObject);
+
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHighlightObject);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Ungrab, GrabUnHighlightObject);
+
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Use, UseHighlightObject);
+                objectToAffect.UnsubscribeFromInteractionEvent(VRTK_InteractableObject.InteractionType.Unuse, UseUnHighlightObject);
+            }
         }
 
         protected virtual InteractObjectHighlighterEventArgs SetEventArgs(VRTK_InteractableObject.InteractionType interactionType, GameObject affectingObject)
@@ -107,66 +131,6 @@ namespace VRTK
             e.affectingObject = affectingObject;
             e.highlightColor = currentColour;
             return e;
-        }
-
-        protected virtual void ManageNearTouchSubscriptions(bool register)
-        {
-            if (!register)
-            {
-                objectToAffect.InteractableObjectNearTouched -= NearTouchHighlightObject;
-                objectToAffect.InteractableObjectNearUntouched -= NearTouchUnHighlightObject;
-            }
-
-            if (register)
-            {
-                objectToAffect.InteractableObjectNearTouched += NearTouchHighlightObject;
-                objectToAffect.InteractableObjectNearUntouched += NearTouchUnHighlightObject;
-            }
-        }
-
-        protected virtual void ManageTouchSubscriptions(bool register)
-        {
-            if (!register)
-            {
-                objectToAffect.InteractableObjectTouched -= TouchHighlightObject;
-                objectToAffect.InteractableObjectUntouched -= TouchUnHighlightObject;
-            }
-
-            if (register)
-            {
-                objectToAffect.InteractableObjectTouched += TouchHighlightObject;
-                objectToAffect.InteractableObjectUntouched += TouchUnHighlightObject;
-            }
-        }
-
-        protected virtual void ManageGrabSubscriptions(bool register)
-        {
-            if (!register)
-            {
-                objectToAffect.InteractableObjectGrabbed -= GrabHighlightObject;
-                objectToAffect.InteractableObjectUngrabbed -= GrabUnHighlightObject;
-            }
-
-            if (register)
-            {
-                objectToAffect.InteractableObjectGrabbed += GrabHighlightObject;
-                objectToAffect.InteractableObjectUngrabbed += GrabUnHighlightObject;
-            }
-        }
-
-        protected virtual void ManageUseSubscriptions(bool register)
-        {
-            if (!register)
-            {
-                objectToAffect.InteractableObjectUsed -= UseHighlightObject;
-                objectToAffect.InteractableObjectUnused -= UseUnHighlightObject;
-            }
-
-            if (register)
-            {
-                objectToAffect.InteractableObjectUsed += UseHighlightObject;
-                objectToAffect.InteractableObjectUnused += UseUnHighlightObject;
-            }
         }
 
         protected virtual void NearTouchHighlightObject(object sender, InteractableObjectEventArgs e)

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractObjectHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractObjectHighlighter.cs
@@ -1,0 +1,290 @@
+﻿// Interact Object Highlighter|Interactions|30045
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="affectedObject">The GameObject that is being highlighted.</param>
+    /// /// <param name="affectingObject">The GameObject is initiating the highlight via an interaction.</param>
+    public struct InteractObjectHighlighterEventArgs
+    {
+        public VRTK_InteractableObject.InteractionType interactionType;
+        public Color highlightColor;
+        public VRTK_InteractableObject affectedObject;
+        public GameObject affectingObject;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="InteractObjectHighlighterEventArgs"/></param>
+    public delegate void InteractObjectHighlighterEventHandler(object sender, InteractObjectHighlighterEventArgs e);
+
+    /// <summary>
+    /// The Interact Object Hightlighter script is attached to an Interactable Object component to provide highlighting to the object on various interaction stages.
+    /// </summary>
+    [AddComponentMenu("VRTK/Scripts/Interactions/VRTK_InteractObjectHighlighter")]
+    public class VRTK_InteractObjectHighlighter : MonoBehaviour
+    {
+        [Header("Object Interaction Settings")]
+
+        [Tooltip("The colour to highlight the object on the near touch interaction.")]
+        public Color nearTouchHighlight = Color.clear;
+        [Tooltip("The colour to highlight the object on the touch interaction.")]
+        public Color touchHighlight = Color.clear;
+        [Tooltip("The colour to highlight the object on the grab interaction.")]
+        public Color grabHighlight = Color.clear;
+        [Tooltip("The colour to highlight the object on the use interaction.")]
+        public Color useHighlight = Color.clear;
+
+        [Header("Custom Settings")]
+
+        [Tooltip("The Interactable Object to affect the highlighter of. If this is left blank, then the Interactable Object will need to be on the current or a parent GameObject.")]
+        public VRTK_InteractableObject objectToAffect;
+
+        protected Color currentColour = Color.clear;
+
+        /// <summary>
+        /// Emitted when the object is highlighted
+        /// </summary>
+        public event InteractObjectHighlighterEventHandler InteractObjectHighlighterHighlighted;
+        /// <summary>
+        /// Emitted when the object is unhighlighted
+        /// </summary>
+        public event InteractObjectHighlighterEventHandler InteractObjectHighlighterUnhighlighted;
+
+        public virtual void OnInteractObjectHighlighterHighlighted(InteractObjectHighlighterEventArgs e)
+        {
+            if (InteractObjectHighlighterHighlighted != null)
+            {
+                InteractObjectHighlighterHighlighted(this, e);
+            }
+        }
+
+        public virtual void OnInteractObjectHighlighterUnhighlighted(InteractObjectHighlighterEventArgs e)
+        {
+            if (InteractObjectHighlighterUnhighlighted != null)
+            {
+                InteractObjectHighlighterUnhighlighted(this, e);
+            }
+        }
+
+        /// <summary>
+        /// The GetCurrentHighlightColor returns the colour that the object is currently being highlighted to.
+        /// </summary>
+        /// <returns>The Color that the Interactable Object is being highlighted to.</returns>
+        public virtual Color GetCurrentHighlightColor()
+        {
+            return currentColour;
+        }
+
+        protected virtual void OnEnable()
+        {
+            objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
+
+            ManageNearTouchSubscriptions(true);
+            ManageTouchSubscriptions(true);
+            ManageGrabSubscriptions(true);
+            ManageUseSubscriptions(true);
+        }
+
+        protected virtual void OnDisable()
+        {
+            ManageNearTouchSubscriptions(false);
+            ManageTouchSubscriptions(false);
+            ManageGrabSubscriptions(false);
+            ManageUseSubscriptions(false);
+        }
+
+        protected virtual InteractObjectHighlighterEventArgs SetEventArgs(VRTK_InteractableObject.InteractionType interactionType, GameObject affectingObject)
+        {
+            InteractObjectHighlighterEventArgs e;
+            e.interactionType = interactionType;
+            e.affectedObject = objectToAffect;
+            e.affectingObject = affectingObject;
+            e.highlightColor = currentColour;
+            return e;
+        }
+
+        protected virtual void ManageNearTouchSubscriptions(bool register)
+        {
+            if (!register)
+            {
+                objectToAffect.InteractableObjectNearTouched -= NearTouchHighlightObject;
+                objectToAffect.InteractableObjectNearUntouched -= NearTouchUnHighlightObject;
+            }
+
+            if (register)
+            {
+                objectToAffect.InteractableObjectNearTouched += NearTouchHighlightObject;
+                objectToAffect.InteractableObjectNearUntouched += NearTouchUnHighlightObject;
+            }
+        }
+
+        protected virtual void ManageTouchSubscriptions(bool register)
+        {
+            if (!register)
+            {
+                objectToAffect.InteractableObjectTouched -= TouchHighlightObject;
+                objectToAffect.InteractableObjectUntouched -= TouchUnHighlightObject;
+            }
+
+            if (register)
+            {
+                objectToAffect.InteractableObjectTouched += TouchHighlightObject;
+                objectToAffect.InteractableObjectUntouched += TouchUnHighlightObject;
+            }
+        }
+
+        protected virtual void ManageGrabSubscriptions(bool register)
+        {
+            if (!register)
+            {
+                objectToAffect.InteractableObjectGrabbed -= GrabHighlightObject;
+                objectToAffect.InteractableObjectUngrabbed -= GrabUnHighlightObject;
+            }
+
+            if (register)
+            {
+                objectToAffect.InteractableObjectGrabbed += GrabHighlightObject;
+                objectToAffect.InteractableObjectUngrabbed += GrabUnHighlightObject;
+            }
+        }
+
+        protected virtual void ManageUseSubscriptions(bool register)
+        {
+            if (!register)
+            {
+                objectToAffect.InteractableObjectUsed -= UseHighlightObject;
+                objectToAffect.InteractableObjectUnused -= UseUnHighlightObject;
+            }
+
+            if (register)
+            {
+                objectToAffect.InteractableObjectUsed += UseHighlightObject;
+                objectToAffect.InteractableObjectUnused += UseUnHighlightObject;
+            }
+        }
+
+        protected virtual void NearTouchHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            Highlight(interactableObject, nearTouchHighlight);
+            OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.NearTouch, e.interactingObject));
+        }
+
+        protected virtual void NearTouchUnHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            if (!interactableObject.IsTouched())
+            {
+                Unhighlight(interactableObject);
+                OnInteractObjectHighlighterUnhighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.NearUntouch, e.interactingObject));
+            }
+        }
+
+        protected virtual void TouchHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            Highlight(interactableObject, touchHighlight);
+            OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Touch, e.interactingObject));
+        }
+
+        protected virtual void TouchUnHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            if (interactableObject.IsNearTouched())
+            {
+                Highlight(sender as VRTK_InteractableObject, nearTouchHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.NearTouch, e.interactingObject));
+            }
+            else
+            {
+                Unhighlight(interactableObject);
+                OnInteractObjectHighlighterUnhighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Untouch, e.interactingObject));
+            }
+        }
+
+        protected virtual void GrabHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            if (!interactableObject.IsUsing())
+            {
+                Highlight(interactableObject, grabHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Grab, e.interactingObject));
+            }
+        }
+
+        protected virtual void GrabUnHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            if (interactableObject.IsTouched())
+            {
+                Highlight(interactableObject, touchHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Touch, e.interactingObject));
+            }
+            else if (interactableObject.IsNearTouched())
+            {
+                Highlight(sender as VRTK_InteractableObject, nearTouchHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.NearTouch, e.interactingObject));
+            }
+            else
+            {
+                Unhighlight(interactableObject);
+                OnInteractObjectHighlighterUnhighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Ungrab, e.interactingObject));
+            }
+        }
+
+        protected virtual void UseHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            Highlight(interactableObject, useHighlight);
+            OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Use, e.interactingObject));
+        }
+
+        protected virtual void UseUnHighlightObject(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject interactableObject = sender as VRTK_InteractableObject;
+            if (interactableObject.IsGrabbed())
+            {
+                Highlight(sender as VRTK_InteractableObject, grabHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Grab, e.interactingObject));
+            }
+            else if (interactableObject.IsTouched())
+            {
+                Highlight(interactableObject, touchHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Touch, e.interactingObject));
+            }
+            else if (interactableObject.IsNearTouched())
+            {
+                Highlight(sender as VRTK_InteractableObject, nearTouchHighlight);
+                OnInteractObjectHighlighterHighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.NearTouch, e.interactingObject));
+            }
+            else
+            {
+                Unhighlight(interactableObject);
+                OnInteractObjectHighlighterUnhighlighted(SetEventArgs(VRTK_InteractableObject.InteractionType.Unuse, e.interactingObject));
+            }
+        }
+
+        protected virtual void Highlight(VRTK_InteractableObject interactableObject, Color highlightColor)
+        {
+            if (interactableObject != null)
+            {
+                interactableObject.Highlight(highlightColor);
+                currentColour = highlightColor;
+            }
+        }
+
+        protected virtual void Unhighlight(VRTK_InteractableObject interactableObject)
+        {
+            if (interactableObject != null)
+            {
+                interactableObject.Unhighlight();
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractObjectHighlighter.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractObjectHighlighter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: abc4b5dd2be1cea4aaea2850b910d3f9
+timeCreated: 1504777683
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -68,7 +68,6 @@ namespace VRTK
         protected List<Collider> touchedObjectColliders = new List<Collider>();
         protected List<Collider> touchedObjectActiveColliders = new List<Collider>();
         protected GameObject controllerCollisionDetector;
-        protected bool triggerRumble;
         protected bool destroyColliderOnDisable;
         protected bool triggerIsColliding = false;
         protected bool triggerWasColliding = false;
@@ -260,7 +259,6 @@ namespace VRTK
         {
             destroyColliderOnDisable = false;
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
-            triggerRumble = false;
             CreateTouchRigidBody();
             trackedController = GetComponentInParent<VRTK_TrackedController>();
             if (trackedController != null)
@@ -291,8 +289,6 @@ namespace VRTK
             //If the new collider is not part of the existing touched object (and the object isn't being grabbed) then start touching the new object
             if (touchedObject != null && colliderInteractableObject != null && touchedObject != colliderInteractableObject && touchedObjectScript != null && !touchedObjectScript.IsGrabbed())
             {
-                CancelInvoke("ResetTriggerRumble");
-                ResetTriggerRumble();
                 ForceStopTouching();
                 triggerIsColliding = true;
             }
@@ -330,7 +326,6 @@ namespace VRTK
                 StoreTouchedObjectColliders(collider);
 
                 ToggleControllerVisibility(false);
-                CheckRumbleController(touchedObjectScript);
                 touchedObjectScript.StartTouching(this);
 
                 OnControllerTouchInteractableObject(SetControllerInteractEvent(touchedObject));
@@ -406,20 +401,6 @@ namespace VRTK
             }
         }
 
-        protected virtual void CheckRumbleController(VRTK_InteractableObject touchedObjectScript)
-        {
-            if (!triggerRumble)
-            {
-                VRTK_InteractHaptics doHaptics = touchedObject.GetComponentInParent<VRTK_InteractHaptics>();
-                if (doHaptics != null)
-                {
-                    triggerRumble = true;
-                    doHaptics.HapticsOnTouch(controllerReference);
-                    Invoke("ResetTriggerRumble", doHaptics.durationOnTouch);
-                }
-            }
-        }
-
         protected virtual void CheckStopTouching()
         {
             if (touchedObject != null)
@@ -453,11 +434,6 @@ namespace VRTK
                 return true;
             }
             return false;
-        }
-
-        protected virtual void ResetTriggerRumble()
-        {
-            triggerRumble = false;
         }
 
         protected virtual void StopTouching(GameObject untouched)

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -28,7 +28,7 @@ namespace VRTK
     /// <remarks>
     /// Colliders are created for the controller and by default the selected controller SDK will have a set of colliders for the given default controller of that SDK.
     ///
-    /// A custom collider can be provided by the Custom Rigidbody Object parameter.
+    /// A custom collider can be provided by the Custom Collider Container parameter.
     /// </remarks>
     /// <example>
     /// `VRTK/Examples/005_Controller/BasicObjectGrabbing` demonstrates the highlighting of objects that have the `VRTK_InteractableObject` script added to them to show the ability to highlight interactable objects when they are touched by the controllers.

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractTouch.cs
@@ -329,7 +329,6 @@ namespace VRTK
                 OnControllerStartTouchInteractableObject(SetControllerInteractEvent(touchedObject));
                 StoreTouchedObjectColliders(collider);
 
-                touchedObjectScript.ToggleHighlight(true);
                 ToggleControllerVisibility(false);
                 CheckRumbleController(touchedObjectScript);
                 touchedObjectScript.StartTouching(this);
@@ -470,10 +469,6 @@ namespace VRTK
                 if (untouchedObjectScript != null)
                 {
                     untouchedObjectScript.StopTouching(this);
-                    if (!untouchedObjectScript.IsTouched())
-                    {
-                        untouchedObjectScript.ToggleHighlight(false);
-                    }
                 }
             }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractUse.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractUse.cs
@@ -298,18 +298,6 @@ namespace VRTK
             }
         }
 
-        protected virtual void AttemptHaptics()
-        {
-            if (usingObject != null)
-            {
-                VRTK_InteractHaptics doHaptics = usingObject.GetComponentInParent<VRTK_InteractHaptics>();
-                if (doHaptics != null)
-                {
-                    doHaptics.HapticsOnUse(controllerReference);
-                }
-            }
-        }
-
         protected virtual void ToggleControllerVisibility(bool visible)
         {
             if (usingObject != null)
@@ -343,7 +331,6 @@ namespace VRTK
 
                     usingObjectScript.StartUsing(this);
                     ToggleControllerVisibility(false);
-                    AttemptHaptics();
                     OnControllerUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
                 }
             }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractableObject.cs
@@ -960,6 +960,26 @@ namespace VRTK
             currentIgnoredColliders.Clear();
         }
 
+        /// <summary>
+        /// The SubscribeToInteractionEvent method subscribes a given method callback for the given Interaction Type.
+        /// </summary>
+        /// <param name="givenType">The Interaction Type to register the events for.</param>
+        /// <param name="methodCallback">The method to execute when the Interaction Type is initiated.</param>
+        public virtual void SubscribeToInteractionEvent(InteractionType givenType, InteractableObjectEventHandler methodCallback)
+        {
+            ManageInteractionEvent(givenType, true, methodCallback);
+        }
+
+        /// <summary>
+        /// The UnsubscribeFromInteractionEvent method unsubscribes a previous event subscription for the given Interaction Type.
+        /// </summary>
+        /// <param name="givenType">The Interaction Type that the previous event subscription was under.</param>
+        /// <param name="methodCallback">The method that was being executed when the Interaction Type was initiated.</param>
+        public virtual void UnsubscribeFromInteractionEvent(InteractionType givenType, InteractableObjectEventHandler methodCallback)
+        {
+            ManageInteractionEvent(givenType, false, methodCallback);
+        }
+
         protected virtual void Awake()
         {
             interactableRigidbody = GetComponent<Rigidbody>();
@@ -1404,6 +1424,141 @@ namespace VRTK
                 {
                     usingObjectScript.ForceResetUsing();
                 }
+            }
+        }
+
+        protected virtual void ManageInteractionEvent(InteractionType givenType, bool state, InteractableObjectEventHandler methodCallback)
+        {
+            switch (givenType)
+            {
+                case InteractionType.NearTouch:
+                    ManageNearTouchSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.Touch:
+                    ManageTouchSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.Grab:
+                    ManageGrabSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.Use:
+                    ManageUseSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.NearUntouch:
+                    ManageNearUntouchSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.Untouch:
+                    ManageUntouchSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.Ungrab:
+                    ManageUngrabSubscriptions(state, methodCallback);
+                    break;
+                case InteractionType.Unuse:
+                    ManageUnuseSubscriptions(state, methodCallback);
+                    break;
+            }
+        }
+
+        protected virtual void ManageNearTouchSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectNearTouched -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectNearTouched += methodCallback;
+            }
+        }
+
+        protected virtual void ManageTouchSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectTouched -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectTouched += methodCallback;
+            }
+        }
+
+        protected virtual void ManageGrabSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectGrabbed -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectGrabbed += methodCallback;
+            }
+        }
+
+        protected virtual void ManageUseSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectUsed -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectUsed += methodCallback;
+            }
+        }
+
+        protected virtual void ManageNearUntouchSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectNearUntouched -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectNearUntouched += methodCallback;
+            }
+        }
+
+        protected virtual void ManageUntouchSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectUntouched -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectUntouched += methodCallback;
+            }
+        }
+
+        protected virtual void ManageUngrabSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectUngrabbed -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectUngrabbed += methodCallback;
+            }
+        }
+
+        protected virtual void ManageUnuseSubscriptions(bool register, InteractableObjectEventHandler methodCallback)
+        {
+            if (!register)
+            {
+                InteractableObjectUnused -= methodCallback;
+            }
+
+            if (register)
+            {
+                InteractableObjectUnused += methodCallback;
             }
         }
     }

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractHaptics_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractHaptics_UnityEvents.cs
@@ -10,12 +10,14 @@
         [Serializable]
         public sealed class InteractHapticsEvent : UnityEvent<object, InteractHapticsEventArgs> { }
 
+        public InteractHapticsEvent OnInteractHapticsNearTouched = new InteractHapticsEvent();
         public InteractHapticsEvent OnInteractHapticsTouched = new InteractHapticsEvent();
         public InteractHapticsEvent OnInteractHapticsGrabbed = new InteractHapticsEvent();
         public InteractHapticsEvent OnInteractHapticsUsed = new InteractHapticsEvent();
 
         protected override void AddListeners(VRTK_InteractHaptics component)
         {
+            component.InteractHapticsNearTouched += InteractHapticsNearTouched;
             component.InteractHapticsTouched += InteractHapticsTouched;
             component.InteractHapticsGrabbed += InteractHapticsGrabbed;
             component.InteractHapticsUsed += InteractHapticsUsed;
@@ -23,9 +25,15 @@
 
         protected override void RemoveListeners(VRTK_InteractHaptics component)
         {
+            component.InteractHapticsNearTouched -= InteractHapticsNearTouched;
             component.InteractHapticsTouched -= InteractHapticsTouched;
             component.InteractHapticsGrabbed -= InteractHapticsGrabbed;
             component.InteractHapticsUsed -= InteractHapticsUsed;
+        }
+
+        private void InteractHapticsNearTouched(object o, InteractHapticsEventArgs e)
+        {
+            OnInteractHapticsNearTouched.Invoke(o, e);
         }
 
         private void InteractHapticsTouched(object o, InteractHapticsEventArgs e)

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractNearTouch_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractNearTouch_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_InteractNearTouch_UnityEvents")]
+    public sealed class VRTK_InteractNearTouch_UnityEvents : VRTK_UnityEvents<VRTK_InteractNearTouch>
+    {
+        [Serializable]
+        public sealed class ObjectInteractEvent : UnityEvent<object, ObjectInteractEventArgs> { }
+
+        public ObjectInteractEvent OnControllerNearTouchInteractableObject = new ObjectInteractEvent();
+        public ObjectInteractEvent OnControllerNearUntouchInteractableObject = new ObjectInteractEvent();
+
+        protected override void AddListeners(VRTK_InteractNearTouch component)
+        {
+            component.ControllerNearTouchInteractableObject += ControllerNearTouchInteractableObject;
+            component.ControllerNearUntouchInteractableObject += ControllerNearUntouchInteractableObject;
+        }
+
+        protected override void RemoveListeners(VRTK_InteractNearTouch component)
+        {
+            component.ControllerNearTouchInteractableObject -= ControllerNearTouchInteractableObject;
+            component.ControllerNearUntouchInteractableObject -= ControllerNearUntouchInteractableObject;
+        }
+
+        private void ControllerNearTouchInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerNearTouchInteractableObject.Invoke(o, e);
+        }
+
+        private void ControllerNearUntouchInteractableObject(object o, ObjectInteractEventArgs e)
+        {
+            OnControllerNearUntouchInteractableObject.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractNearTouch_UnityEvents.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractNearTouch_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: aa487b4b54750e341b5a98dd7357189d
+timeCreated: 1504775100
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractObjectHighlighter_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractObjectHighlighter_UnityEvents.cs
@@ -1,0 +1,38 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_InteractObjectHighlighter_UnityEvents")]
+    public sealed class VRTK_InteractObjectHighlighter_UnityEvents : VRTK_UnityEvents<VRTK_InteractObjectHighlighter>
+    {
+        [Serializable]
+        public sealed class InteractObjectHighlighterEvent : UnityEvent<object, InteractObjectHighlighterEventArgs> { }
+
+        public InteractObjectHighlighterEvent OnInteractObjectHighlighterHighlighted = new InteractObjectHighlighterEvent();
+        public InteractObjectHighlighterEvent OnInteractObjectHighlighterUnhighlighted = new InteractObjectHighlighterEvent();
+
+        protected override void AddListeners(VRTK_InteractObjectHighlighter component)
+        {
+            component.InteractObjectHighlighterHighlighted += InteractObjectHighlighterHighlighted;
+            component.InteractObjectHighlighterUnhighlighted += InteractObjectHighlighterUnhighlighted;
+        }
+
+        protected override void RemoveListeners(VRTK_InteractObjectHighlighter component)
+        {
+            component.InteractObjectHighlighterHighlighted -= InteractObjectHighlighterHighlighted;
+            component.InteractObjectHighlighterUnhighlighted -= InteractObjectHighlighterUnhighlighted;
+        }
+
+        private void InteractObjectHighlighterHighlighted(object o, InteractObjectHighlighterEventArgs e)
+        {
+            OnInteractObjectHighlighterHighlighted.Invoke(o, e);
+        }
+
+        private void InteractObjectHighlighterUnhighlighted(object o, InteractObjectHighlighterEventArgs e)
+        {
+            OnInteractObjectHighlighterUnhighlighted.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractObjectHighlighter_UnityEvents.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractObjectHighlighter_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7ea41090e3ad98340ab97efc65e676a4
+timeCreated: 1504950857
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -13,6 +13,9 @@
         public InteractableObjectEvent OnObjectEnable = new InteractableObjectEvent();
         public InteractableObjectEvent OnObjectDisable = new InteractableObjectEvent();
 
+        public InteractableObjectEvent OnNearTouch = new InteractableObjectEvent();
+        public InteractableObjectEvent OnNearUntouch = new InteractableObjectEvent();
+
         public InteractableObjectEvent OnTouch = new InteractableObjectEvent();
         public InteractableObjectEvent OnUntouch = new InteractableObjectEvent();
 
@@ -31,6 +34,9 @@
         {
             component.InteractableObjectEnabled += Enable;
             component.InteractableObjectDisabled += Disable;
+
+            component.InteractableObjectNearTouched += NearTouch;
+            component.InteractableObjectNearUntouched += NearUnTouch;
 
             component.InteractableObjectTouched += Touch;
             component.InteractableObjectUntouched += UnTouch;
@@ -51,6 +57,9 @@
         {
             component.InteractableObjectEnabled -= Enable;
             component.InteractableObjectDisabled -= Disable;
+
+            component.InteractableObjectNearTouched -= NearTouch;
+            component.InteractableObjectNearUntouched -= NearUnTouch;
 
             component.InteractableObjectTouched -= Touch;
             component.InteractableObjectUntouched -= UnTouch;
@@ -75,6 +84,16 @@
         private void Disable(object o, InteractableObjectEventArgs e)
         {
             OnObjectDisable.Invoke(o, e);
+        }
+
+        private void NearTouch(object o, InteractableObjectEventArgs e)
+        {
+            OnNearTouch.Invoke(o, e);
+        }
+
+        private void NearUnTouch(object o, InteractableObjectEventArgs e)
+        {
+            OnNearUntouch.Invoke(o, e);
         }
 
         private void Touch(object o, InteractableObjectEventArgs e)


### PR DESCRIPTION
The Interact Near Touch script generates a collider around the
controller that should be larger than the controller collider and
then when the controller is near something it will emit a near
touch event.

This can be useful for knowing what the controllers are near.