### PR TITLE
Feat/radial menu dead zone

### DIFF
--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_IndependentRadialMenuController.cs
@@ -1,4 +1,4 @@
-﻿// Independent Radial Menu Controller|Prefabs|0050
+// Independent Radial Menu Controller|Prefabs|0050
 namespace VRTK
 {
     using UnityEngine;
@@ -290,7 +290,7 @@ namespace VRTK
             }
         }
 
-        protected virtual float CalculateAngle(GameObject interactingObject)
+        protected virtual TouchAngleDeflection CalculateAngle(GameObject interactingObject)
         {
             Vector3 controllerPosition = interactingObject.transform.position;
 
@@ -306,7 +306,7 @@ namespace VRTK
                 angle += 360.0f;
             }
 
-            return angle;
+            return new TouchAngleDeflection(angle, 1);
         }
 
         protected virtual float AngleSigned(Vector3 v1, Vector3 v2, Vector3 n)

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -329,27 +329,28 @@ namespace VRTK
             }
             if (evt == ButtonEvent.click) //Click button if click, and keep track of current press (executes button action)
             {
-                if (buttonID != -1) {
+                if (buttonID != -1)
+                {
                     ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerDownHandler);
-                    currentPress = buttonID;
-                    if (!executeOnUnclick)
-                    {
-                        buttons[buttonID].OnClick.Invoke();
-                        AttempHapticPulse(baseHapticStrength * 2.5f);
-                    }
+                }
+                currentPress = buttonID;
+                if (!executeOnUnclick && buttonID != -1)
+                {
+                    buttons[buttonID].OnClick.Invoke();
+                    AttempHapticPulse(baseHapticStrength * 2.5f);
                 }
             }
             else if (evt == ButtonEvent.unclick) //Clear press id to stop invoking OnHold method (hide menu)
             {
-                if (buttonID != -1) {
+                if (buttonID != -1)
+                {
                     ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerUpHandler);
-                    currentPress = -1;
-
-                    if (executeOnUnclick)
-                    {
-                        AttempHapticPulse(baseHapticStrength * 2.5f);
-                        buttons[buttonID].OnClick.Invoke();
-                    }
+                }
+                currentPress = -1;
+                if (executeOnUnclick && buttonID != -1)
+                {
+                    AttempHapticPulse(baseHapticStrength * 2.5f);
+                    buttons[buttonID].OnClick.Invoke();
                 }
             }
             else if (evt == ButtonEvent.hoverOn && currentHover != buttonID && buttonID != -1) // Show hover UI event (darken button etc). Show menu

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -309,10 +309,9 @@ namespace VRTK
             int buttonID = (int)VRTK_SharedMethods.Mod(((tad.angle + (buttonAngle / 2f)) / buttonAngle), buttons.Count); //Convert angle into ButtonID (This is the magic)
             PointerEventData pointer = new PointerEventData(EventSystem.current); //Create a new EventSystem (UI) Event
 
-            if (tad.deflection <= deadZone) {
-                //currentHover = -1;
-                //currentPress = -1;
-                //return;
+            if (tad.deflection <= deadZone)
+            {
+                //No button selected. Use -1 to represent this
                 buttonID = -1;
             }
 

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -332,7 +332,8 @@ namespace VRTK
                 if (buttonID != -1) {
                     ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerDownHandler);
                     currentPress = buttonID;
-                    if (!executeOnUnclick) {
+                    if (!executeOnUnclick)
+                    {
                         buttons[buttonID].OnClick.Invoke();
                         AttempHapticPulse(baseHapticStrength * 2.5f);
                     }
@@ -344,7 +345,8 @@ namespace VRTK
                     ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerUpHandler);
                     currentPress = -1;
 
-                    if (executeOnUnclick) {
+                    if (executeOnUnclick)
+                    {
                         AttempHapticPulse(baseHapticStrength * 2.5f);
                         buttons[buttonID].OnClick.Invoke();
                     }

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenuController.cs
@@ -20,7 +20,7 @@ namespace VRTK
         public VRTK_ControllerEvents events;
 
         protected VRTK_RadialMenu menu;
-        protected float currentAngle; //Keep track of angle for when we click
+        protected TouchAngleDeflection currentTad; //Keep track of angle and deflection for when we click
         protected bool touchpadTouched;
 
         protected virtual void Awake()
@@ -70,18 +70,18 @@ namespace VRTK
 
         protected virtual void DoClickButton(object sender = null) // The optional argument reduces the need for middleman functions in subclasses whose events likely pass object sender
         {
-            menu.ClickButton(currentAngle);
+            menu.ClickButton(currentTad);
         }
 
         protected virtual void DoUnClickButton(object sender = null)
         {
-            menu.UnClickButton(currentAngle);
+            menu.UnClickButton(currentTad);
         }
 
-        protected virtual void DoShowMenu(float initialAngle, object sender = null)
+        protected virtual void DoShowMenu(TouchAngleDeflection initialTad, object sender = null)
         {
             menu.ShowMenu();
-            DoChangeAngle(initialAngle); // Needed to register initial touch position before the touchpad axis actually changes
+            DoChangeAngle(initialTad); // Needed to register initial touch position before the touchpad axis actually changes
         }
 
         protected virtual void DoHideMenu(bool force, object sender = null)
@@ -90,11 +90,11 @@ namespace VRTK
             menu.HideMenu(force);
         }
 
-        protected virtual void DoChangeAngle(float angle, object sender = null)
+        protected virtual void DoChangeAngle(TouchAngleDeflection tad, object sender = null)
         {
-            currentAngle = angle;
+            currentTad = tad;
 
-            menu.HoverButton(currentAngle);
+            menu.HoverButton(currentTad);
         }
 
         protected virtual void AttemptHapticPulse(float strength)
@@ -136,9 +136,12 @@ namespace VRTK
             }
         }
 
-        protected virtual float CalculateAngle(ControllerInteractionEventArgs e)
+        protected virtual TouchAngleDeflection CalculateAngle(ControllerInteractionEventArgs e)
         {
-            return 360 - e.touchpadAngle;
+            TouchAngleDeflection tad = new TouchAngleDeflection();
+            tad.angle = 360 - e.touchpadAngle;
+            tad.deflection = e.touchpadAxis.magnitude;
+            return tad;
         }
     }
 }


### PR DESCRIPTION
feat(RadialMenu): add dead zone to radial menu

Allow the player to touch the centre of the touchpad without immediately triggering OnHoverEnter event of a button.
