### PR TITLE
feat(RadialMenu): add dead zone to radial menu

### DIFF
--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_IndependentRadialMenuController.cs
@@ -290,7 +290,7 @@ namespace VRTK
             }
         }
 
-        protected virtual float CalculateAngle(GameObject interactingObject)
+        protected virtual TouchAngleDeflection CalculateAngle(GameObject interactingObject)
         {
             Vector3 controllerPosition = interactingObject.transform.position;
 
@@ -306,7 +306,7 @@ namespace VRTK
                 angle += 360.0f;
             }
 
-            return angle;
+            return new TouchAngleDeflection(angle, 1);
         }
 
         protected virtual float AngleSigned(Vector3 v1, Vector3 v2, Vector3 n)

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_IndependentRadialMenuController.cs
@@ -1,4 +1,4 @@
-// Independent Radial Menu Controller|Prefabs|0050
+﻿// Independent Radial Menu Controller|Prefabs|0050
 namespace VRTK
 {
     using UnityEngine;

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -8,19 +8,19 @@ namespace VRTK
     using UnityEngine.UI;
     using UnityEngine.EventSystems;
 
-    public delegate void HapticPulseEventHandler(float strength);
-
     public struct TouchAngleDeflection
     {
-        public TouchAngleDeflection(float a, float d)
+        public TouchAngleDeflection(float angle, float deflection)
         {
-            angle = a;
-            deflection = d;
+            this.angle = angle;
+            this.deflection = deflection;
         }
 
         public float angle;
         public float deflection;
     }
+
+    public delegate void HapticPulseEventHandler(float strength);
 
     /// <summary>
     /// Provides a UI element into the world space that can be dropped into a Controller GameObject and used to create and use Radial Menus from the touchpad.
@@ -109,10 +109,10 @@ namespace VRTK
         /// <summary>
         /// The HoverButton method is used to set the button hover at a given angle and deflection.
         /// </summary>
-        /// <param name="tad">The angle and deflection on the radial menu.</param>
-        public virtual void HoverButton(TouchAngleDeflection tad)
+        /// <param name="givenTouchAngleDeflection">The angle and deflection on the radial menu.</param>
+        public virtual void HoverButton(TouchAngleDeflection givenTouchAngleDeflection)
         {
-            InteractButton(tad, ButtonEvent.hoverOn);
+            InteractButton(givenTouchAngleDeflection, ButtonEvent.hoverOn);
         }
 
         /// <summary>
@@ -128,10 +128,10 @@ namespace VRTK
         /// <summary>
         /// The ClickButton method is used to set the button click at a given angle and deflection.
         /// </summary>
-        /// <param name="tad">The angle and deflection on the radial menu.</param>
-        public virtual void ClickButton(TouchAngleDeflection tad)
+        /// <param name="givenTouchAngleDeflection">The angle and deflection on the radial menu.</param>
+        public virtual void ClickButton(TouchAngleDeflection givenTouchAngleDeflection)
         {
-            InteractButton(tad, ButtonEvent.click);
+            InteractButton(givenTouchAngleDeflection, ButtonEvent.click);
         }
 
         /// <summary>
@@ -147,10 +147,10 @@ namespace VRTK
         /// <summary>
         /// The UnClickButton method is used to set the button unclick at a given angle and deflection.
         /// </summary>
-        /// <param name="tad">The angle and deflection on the radial menu.</param>
-        public virtual void UnClickButton(TouchAngleDeflection tad)
+        /// <param name="givenTouchAngleDeflection">The angle and deflection on the radial menu.</param>
+        public virtual void UnClickButton(TouchAngleDeflection givenTouchAngleDeflection)
         {
-            InteractButton(tad, ButtonEvent.unclick);
+            InteractButton(givenTouchAngleDeflection, ButtonEvent.unclick);
         }
 
         /// <summary>
@@ -330,16 +330,16 @@ namespace VRTK
         }
 
         //Turns and Angle and Event type into a button action
-        protected virtual void InteractButton(TouchAngleDeflection tad, ButtonEvent evt) //Can't pass ExecuteEvents as parameter? Unity gives error
+        protected virtual void InteractButton(TouchAngleDeflection givenTouchAngleDeflection, ButtonEvent evt) //Can't pass ExecuteEvents as parameter? Unity gives error
         {
             //Get button ID from angle
             float buttonAngle = 360f / buttons.Count; //Each button is an arc with this angle
-            tad.angle = VRTK_SharedMethods.Mod((tad.angle + -offsetRotation), 360f); //Offset the touch coordinate with our offset
+            givenTouchAngleDeflection.angle = VRTK_SharedMethods.Mod((givenTouchAngleDeflection.angle + -offsetRotation), 360f); //Offset the touch coordinate with our offset
 
-            int buttonID = (int)VRTK_SharedMethods.Mod(((tad.angle + (buttonAngle / 2f)) / buttonAngle), buttons.Count); //Convert angle into ButtonID (This is the magic)
+            int buttonID = (int)VRTK_SharedMethods.Mod(((givenTouchAngleDeflection.angle + (buttonAngle / 2f)) / buttonAngle), buttons.Count); //Convert angle into ButtonID (This is the magic)
             PointerEventData pointer = new PointerEventData(EventSystem.current); //Create a new EventSystem (UI) Event
 
-            if (tad.deflection <= deadZone)
+            if (givenTouchAngleDeflection.deflection <= deadZone)
             {
                 //No button selected. Use -1 to represent this
                 buttonID = -1;

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -18,6 +18,11 @@ namespace VRTK
         public float angle;
         public float deflection;
 
+        /// <summary>
+        /// Constructs an object to hold the angle and deflection of the user's touch on the touchpad
+        /// </summary>
+        /// <param name="angle">The angle of the touch on the radial menu.</param>
+        /// <param name="deflection">Deflection of the touch, where 0 is the centre and 1 is the edge.</param>
         public TouchAngleDeflection(float angle, float deflection)
         {
             this.angle = angle;

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -100,7 +100,7 @@ namespace VRTK
         /// The HoverButton method is used to set the button hover at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
-        [System.Obsolete("`VRTK_RadialMenu.HoverButton(float)` has been deprecated, use VRTK_RadialMenu.HoverButton(TouchAngleDeflection) instead")]
+        [System.Obsolete("`VRTK_RadialMenu.HoverButton(float)` has been replaced with `VRTK_RadialMenu.HoverButton(TouchAngleDeflection)`. This method will be removed in a future version of VRTK.")]
         public virtual void HoverButton(float angle)
         {
             HoverButton(new TouchAngleDeflection(angle, 1));
@@ -119,7 +119,7 @@ namespace VRTK
         /// The ClickButton method is used to set the button click at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
-        [System.Obsolete("`VRTK_RadialMenu.ClickButton(float)` has been deprecated, use VRTK_RadialMenu.ClickButton(TouchAngleDeflection) instead")]
+        [System.Obsolete("`VRTK_RadialMenu.ClickButton(float)` has been replaced with `VRTK_RadialMenu.ClickButton(TouchAngleDeflection)`. This method will be removed in a future version of VRTK.")]
         public virtual void ClickButton(float angle)
         {
             ClickButton(new TouchAngleDeflection(angle, 1));
@@ -138,7 +138,7 @@ namespace VRTK
         /// The UnClickButton method is used to set the button unclick at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
-        [System.Obsolete("`VRTK_RadialMenu.UnClickButton(float)` has been deprecated, use VRTK_RadialMenu.UnClickButton(TouchAngleDeflection) instead")]
+        [System.Obsolete("`VRTK_RadialMenu.UnClickButton(float)` has been replaced with `VRTK_RadialMenu.UnClickButton(TouchAngleDeflection)`. This method will be removed in a future version of VRTK.")]
         public virtual void UnClickButton(float angle)
         {
             UnClickButton(new TouchAngleDeflection(angle, 1));

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -8,16 +8,21 @@ namespace VRTK
     using UnityEngine.UI;
     using UnityEngine.EventSystems;
 
+    /// <summary>
+    /// Angle and Deflection of the user's touch on the touchpad
+    /// </summary>
+    /// <param name="angle">The angle of the touch on the radial menu.</param>
+    /// <param name="deflection">Deflection of the touch, where 0 is the centre and 1 is the edge.</param>
     public struct TouchAngleDeflection
     {
+        public float angle;
+        public float deflection;
+
         public TouchAngleDeflection(float angle, float deflection)
         {
             this.angle = angle;
             this.deflection = deflection;
         }
-
-        public float angle;
-        public float deflection;
     }
 
     public delegate void HapticPulseEventHandler(float strength);

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -100,6 +100,16 @@ namespace VRTK
         /// The HoverButton method is used to set the button hover at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
+        [System.Obsolete("`VRTK_RadialMenu.HoverButton(float)` has been deprecated, use VRTK_RadialMenu.HoverButton(TouchAngleDeflection) instead")]
+        public virtual void HoverButton(float angle)
+        {
+            HoverButton(new TouchAngleDeflection(angle, 1));
+        }
+
+        /// <summary>
+        /// The HoverButton method is used to set the button hover at a given angle and deflection.
+        /// </summary>
+        /// <param name="tad">The angle and deflection on the radial menu.</param>
         public virtual void HoverButton(TouchAngleDeflection tad)
         {
             InteractButton(tad, ButtonEvent.hoverOn);
@@ -109,6 +119,16 @@ namespace VRTK
         /// The ClickButton method is used to set the button click at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
+        [System.Obsolete("`VRTK_RadialMenu.ClickButton(float)` has been deprecated, use VRTK_RadialMenu.ClickButton(TouchAngleDeflection) instead")]
+        public virtual void ClickButton(float angle)
+        {
+            ClickButton(new TouchAngleDeflection(angle, 1));
+        }
+
+        /// <summary>
+        /// The ClickButton method is used to set the button click at a given angle and deflection.
+        /// </summary>
+        /// <param name="tad">The angle and deflection on the radial menu.</param>
         public virtual void ClickButton(TouchAngleDeflection tad)
         {
             InteractButton(tad, ButtonEvent.click);
@@ -118,6 +138,16 @@ namespace VRTK
         /// The UnClickButton method is used to set the button unclick at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
+        [System.Obsolete("`VRTK_RadialMenu.UnClickButton(float)` has been deprecated, use VRTK_RadialMenu.UnClickButton(TouchAngleDeflection) instead")]
+        public virtual void UnClickButton(float angle)
+        {
+            UnClickButton(new TouchAngleDeflection(angle, 1));
+        }
+
+        /// <summary>
+        /// The UnClickButton method is used to set the button unclick at a given angle and deflection.
+        /// </summary>
+        /// <param name="tad">The angle and deflection on the radial menu.</param>
         public virtual void UnClickButton(TouchAngleDeflection tad)
         {
             InteractButton(tad, ButtonEvent.unclick);

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -10,6 +10,18 @@ namespace VRTK
 
     public delegate void HapticPulseEventHandler(float strength);
 
+    public struct TouchAngleDeflection
+    {
+        public TouchAngleDeflection(float a, float d)
+        {
+            angle = a;
+            deflection = d;
+        }
+
+        public float angle;
+        public float deflection;
+    }
+
     /// <summary>
     /// Provides a UI element into the world space that can be dropped into a Controller GameObject and used to create and use Radial Menus from the touchpad.
     /// </summary>
@@ -70,6 +82,9 @@ namespace VRTK
         [Tooltip("The base strength of the haptic pulses when the selected button is changed, or a button is pressed. Set to zero to disable.")]
         [Range(0, 1)]
         public float baseHapticStrength;
+        [Tooltip("The dead zone in the middle of the dial where the menu does not consider a button is selected. Set to zero to disable.")]
+        [Range(0, 1)]
+        public float deadZone = 0;
 
         public event HapticPulseEventHandler FireHapticPulse;
 
@@ -85,27 +100,27 @@ namespace VRTK
         /// The HoverButton method is used to set the button hover at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
-        public virtual void HoverButton(float angle)
+        public virtual void HoverButton(TouchAngleDeflection tad)
         {
-            InteractButton(angle, ButtonEvent.hoverOn);
+            InteractButton(tad, ButtonEvent.hoverOn);
         }
 
         /// <summary>
         /// The ClickButton method is used to set the button click at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
-        public virtual void ClickButton(float angle)
+        public virtual void ClickButton(TouchAngleDeflection tad)
         {
-            InteractButton(angle, ButtonEvent.click);
+            InteractButton(tad, ButtonEvent.click);
         }
 
         /// <summary>
         /// The UnClickButton method is used to set the button unclick at a given angle.
         /// </summary>
         /// <param name="angle">The angle on the radial menu.</param>
-        public virtual void UnClickButton(float angle)
+        public virtual void UnClickButton(TouchAngleDeflection tad)
         {
-            InteractButton(angle, ButtonEvent.unclick);
+            InteractButton(tad, ButtonEvent.unclick);
         }
 
         /// <summary>
@@ -285,14 +300,20 @@ namespace VRTK
         }
 
         //Turns and Angle and Event type into a button action
-        protected virtual void InteractButton(float angle, ButtonEvent evt) //Can't pass ExecuteEvents as parameter? Unity gives error
+        protected virtual void InteractButton(TouchAngleDeflection tad, ButtonEvent evt) //Can't pass ExecuteEvents as parameter? Unity gives error
         {
             //Get button ID from angle
             float buttonAngle = 360f / buttons.Count; //Each button is an arc with this angle
-            angle = VRTK_SharedMethods.Mod((angle + -offsetRotation), 360f); //Offset the touch coordinate with our offset
+            tad.angle = VRTK_SharedMethods.Mod((tad.angle + -offsetRotation), 360f); //Offset the touch coordinate with our offset
 
-            int buttonID = (int)VRTK_SharedMethods.Mod(((angle + (buttonAngle / 2f)) / buttonAngle), buttons.Count); //Convert angle into ButtonID (This is the magic)
+            int buttonID = (int)VRTK_SharedMethods.Mod(((tad.angle + (buttonAngle / 2f)) / buttonAngle), buttons.Count); //Convert angle into ButtonID (This is the magic)
             PointerEventData pointer = new PointerEventData(EventSystem.current); //Create a new EventSystem (UI) Event
+
+            if (tad.deflection <= deadZone)
+            {
+                //No button selected. Use -1 to represent this
+                buttonID = -1;
+            }
 
             //If we changed buttons while moving, un-hover and un-click the last button we were on
             if (currentHover != buttonID && currentHover != -1)
@@ -300,7 +321,7 @@ namespace VRTK
                 ExecuteEvents.Execute(menuButtons[currentHover], pointer, ExecuteEvents.pointerUpHandler);
                 ExecuteEvents.Execute(menuButtons[currentHover], pointer, ExecuteEvents.pointerExitHandler);
                 buttons[currentHover].OnHoverExit.Invoke();
-                if (executeOnUnclick && currentPress != -1)
+                if (executeOnUnclick && currentPress != -1 && buttonID != -1)
                 {
                     ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerDownHandler);
                     AttempHapticPulse(baseHapticStrength * 1.666f);
@@ -308,9 +329,12 @@ namespace VRTK
             }
             if (evt == ButtonEvent.click) //Click button if click, and keep track of current press (executes button action)
             {
-                ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerDownHandler);
+                if (buttonID != -1)
+                {
+                    ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerDownHandler);
+                }
                 currentPress = buttonID;
-                if (!executeOnUnclick)
+                if (!executeOnUnclick && buttonID != -1)
                 {
                     buttons[buttonID].OnClick.Invoke();
                     AttempHapticPulse(baseHapticStrength * 2.5f);
@@ -318,16 +342,18 @@ namespace VRTK
             }
             else if (evt == ButtonEvent.unclick) //Clear press id to stop invoking OnHold method (hide menu)
             {
-                ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerUpHandler);
+                if (buttonID != -1)
+                {
+                    ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerUpHandler);
+                }
                 currentPress = -1;
-
-                if (executeOnUnclick)
+                if (executeOnUnclick && buttonID != -1)
                 {
                     AttempHapticPulse(baseHapticStrength * 2.5f);
                     buttons[buttonID].OnClick.Invoke();
                 }
             }
-            else if (evt == ButtonEvent.hoverOn && currentHover != buttonID) // Show hover UI event (darken button etc). Show menu
+            else if (evt == ButtonEvent.hoverOn && currentHover != buttonID && buttonID != -1) // Show hover UI event (darken button etc). Show menu
             {
                 ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerEnterHandler);
                 buttons[buttonID].OnHoverEnter.Invoke();

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenu.cs
@@ -32,18 +32,6 @@ namespace VRTK
 
     public delegate void HapticPulseEventHandler(float strength);
 
-    public struct TouchAngleDeflection
-    {
-        public TouchAngleDeflection(float a, float d)
-        {
-            angle = a;
-            deflection = d;
-        }
-
-        public float angle;
-        public float deflection;
-    }
-
     /// <summary>
     /// Provides a UI element into the world space that can be dropped into a Controller GameObject and used to create and use Radial Menus from the touchpad.
     /// </summary>

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenuController.cs
@@ -20,7 +20,7 @@ namespace VRTK
         public VRTK_ControllerEvents events;
 
         protected VRTK_RadialMenu menu;
-        protected float currentAngle; //Keep track of angle for when we click
+        protected TouchAngleDeflection currentTad; //Keep track of angle and deflection for when we click
         protected bool touchpadTouched;
 
         protected virtual void Awake()
@@ -70,18 +70,18 @@ namespace VRTK
 
         protected virtual void DoClickButton(object sender = null) // The optional argument reduces the need for middleman functions in subclasses whose events likely pass object sender
         {
-            menu.ClickButton(currentAngle);
+            menu.ClickButton(currentTad);
         }
 
         protected virtual void DoUnClickButton(object sender = null)
         {
-            menu.UnClickButton(currentAngle);
+            menu.UnClickButton(currentTad);
         }
 
-        protected virtual void DoShowMenu(float initialAngle, object sender = null)
+        protected virtual void DoShowMenu(TouchAngleDeflection initialTad, object sender = null)
         {
             menu.ShowMenu();
-            DoChangeAngle(initialAngle); // Needed to register initial touch position before the touchpad axis actually changes
+            DoChangeAngle(initialTad); // Needed to register initial touch position before the touchpad axis actually changes
         }
 
         protected virtual void DoHideMenu(bool force, object sender = null)
@@ -90,11 +90,11 @@ namespace VRTK
             menu.HideMenu(force);
         }
 
-        protected virtual void DoChangeAngle(float angle, object sender = null)
+        protected virtual void DoChangeAngle(TouchAngleDeflection tad, object sender = null)
         {
-            currentAngle = angle;
+            currentTad = tad;
 
-            menu.HoverButton(currentAngle);
+            menu.HoverButton(currentTad);
         }
 
         protected virtual void AttemptHapticPulse(float strength)
@@ -136,9 +136,12 @@ namespace VRTK
             }
         }
 
-        protected virtual float CalculateAngle(ControllerInteractionEventArgs e)
+        protected virtual TouchAngleDeflection CalculateAngle(ControllerInteractionEventArgs e)
         {
-            return 360 - e.touchpadAngle;
+            TouchAngleDeflection tad = new TouchAngleDeflection();
+            tad.angle = 360 - e.touchpadAngle;
+            tad.deflection = e.touchpadAxis.magnitude;
+            return tad;
         }
     }
 }

--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_RadialMenuController.cs
@@ -90,9 +90,9 @@ namespace VRTK
             menu.HideMenu(force);
         }
 
-        protected virtual void DoChangeAngle(TouchAngleDeflection tad, object sender = null)
+        protected virtual void DoChangeAngle(TouchAngleDeflection givenTouchAngleDeflection, object sender = null)
         {
-            currentTad = tad;
+            currentTad = givenTouchAngleDeflection;
 
             menu.HoverButton(currentTad);
         }
@@ -138,10 +138,10 @@ namespace VRTK
 
         protected virtual TouchAngleDeflection CalculateAngle(ControllerInteractionEventArgs e)
         {
-            TouchAngleDeflection tad = new TouchAngleDeflection();
-            tad.angle = 360 - e.touchpadAngle;
-            tad.deflection = e.touchpadAxis.magnitude;
-            return tad;
+            TouchAngleDeflection touchAngleDeflection = new TouchAngleDeflection();
+            touchAngleDeflection.angle = 360 - e.touchpadAngle;
+            touchAngleDeflection.deflection = e.touchpadAxis.magnitude;
+            return touchAngleDeflection;
         }
     }
 }


### PR DESCRIPTION
feat(RadialMenu): add dead zone to radial menu

Allow the player to touch the centre of the touchpad without
immediately triggering OnHoverEnter event of a button.
