### PR TITLE
feat(Interaction): provide custom highlighter to interactable object

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -3713,6 +3713,7 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
  * **Pointer Activates Use Action:** If this is checked then when a Base Pointer beam (projected from the controller) hits the interactable object, if the object has `Hold Button To Use` unchecked then whilst the pointer is over the object it will run it's `Using` method. If `Hold Button To Use` is unchecked then the `Using` method will be run when the pointer is deactivated. The world pointer will not throw the `Destination Set` event if it is affecting an interactable object with this setting checked as this prevents unwanted teleporting from happening when using an object with a pointer.
  * **Use Override Button:** If this is set to `Undefined` then the global use alias button will use the object, setting it to any other button will ensure the override button is used to use this specific interactable object.
  * **Allowed Use Controllers:** Determines which controller can initiate a use action.
+ * **Object Highlighter:** An optional Highlighter to use when highlighting this Interactable Object. If this is left blank, then the first active highlighter on the same GameObject will be used, if one isn't found then a Material Color Swap Highlighter will be created at runtime.
 
 ### Class Variables
 
@@ -4530,12 +4531,13 @@ As this is an abstract class, it cannot be applied directly to a game object and
 
 ### Class Methods
 
-#### Initialise/2
+#### Initialise/3
 
-  > `public abstract void Initialise(Color? color = null, Dictionary<string, object> options = null);`
+  > `public abstract void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null);`
 
  * Parameters
    * `Color? color` - An optional colour may be passed through at point of initialisation in case the highlighter requires it.
+   * `GameObject affectObject` - An optional GameObject to specify which object to apply the highlighting to.
    * `Dictionary<string, object> options` - An optional dictionary of highlighter specific options that may be differ with highlighter implementations.
  * Returns
    * _none_
@@ -4635,12 +4637,13 @@ This is the default highlighter that is applied to any script that requires a hi
 
 ### Class Methods
 
-#### Initialise/2
+#### Initialise/3
 
-  > `public override void Initialise(Color? color = null, Dictionary<string, object> options = null)`
+  > `public override void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null)`
 
  * Parameters
    * `Color? color` - Not used.
+   * `GameObject affectObject` - An optional GameObject to specify which object to apply the highlighting to.
    * `Dictionary<string, object> options` - A dictionary array containing the highlighter options:
      * `<'resetMainTexture', bool>` - Determines if the default main texture should be cleared on highlight. `true` to reset the main default texture, `false` to not reset it.
  * Returns
@@ -4706,12 +4709,13 @@ The Draw Call Batching will resume on the original material when the item is no 
 
 ### Class Methods
 
-#### Initialise/2
+#### Initialise/3
 
-  > `public override void Initialise(Color? color = null, Dictionary<string, object> options = null)`
+  > `public override void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null)`
 
  * Parameters
    * `Color? color` - Not used.
+   * `GameObject affectObject` - An optional GameObject to specify which object to apply the highlighting to.
    * `Dictionary<string, object> options` - A dictionary array containing the highlighter options:
      * `<'resetMainTexture', bool>` - Determines if the default main texture should be cleared on highlight. `true` to reset the main default texture, `false` to not reset it.
  * Returns
@@ -4749,12 +4753,13 @@ The Outline Object Copy Highlighter works by making a copy of a mesh and adding 
 
 ### Class Methods
 
-#### Initialise/2
+#### Initialise/3
 
-  > `public override void Initialise(Color? color = null, Dictionary<string, object> options = null)`
+  > `public override void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null)`
 
  * Parameters
    * `Color? color` - Not used.
+   * `GameObject affectObject` - An optional GameObject to specify which object to apply the highlighting to.
    * `Dictionary<string, object> options` - A dictionary array containing the highlighter options:
      * `<'thickness', float>` - Same as `thickness` inspector parameter.
      * `<'customOutlineModels', GameObject[]>` - Same as `customOutlineModels` inspector parameter.

--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_BaseHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_BaseHighlighter.cs
@@ -18,13 +18,15 @@ namespace VRTK.Highlighters
         public bool unhighlightOnDisable = true;
 
         protected bool usesClonedObject = false;
+        protected GameObject objectToAffect;
 
         /// <summary>
         /// The Initalise method is used to set up the state of the highlighter.
         /// </summary>
         /// <param name="color">An optional colour may be passed through at point of initialisation in case the highlighter requires it.</param>
+        /// <param name="affectObject">An optional GameObject to specify which object to apply the highlighting to.</param>
         /// <param name="options">An optional dictionary of highlighter specific options that may be differ with highlighter implementations.</param>
-        public abstract void Initialise(Color? color = null, Dictionary<string, object> options = null);
+        public abstract void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null);
 
         /// <summary>
         /// The ResetHighlighter method is used to reset the highlighter if anything on the object has changed. It should be called by any scripts changing object materials or colours.

--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
@@ -37,9 +37,11 @@ namespace VRTK.Highlighters
         /// The Initialise method sets up the highlighter for use.
         /// </summary>
         /// <param name="color">Not used.</param>
+        /// <param name="affectObject">An optional GameObject to specify which object to apply the highlighting to.</param>
         /// <param name="options">A dictionary array containing the highlighter options:\r     * `&lt;'resetMainTexture', bool&gt;` - Determines if the default main texture should be cleared on highlight. `true` to reset the main default texture, `false` to not reset it.</param>
-        public override void Initialise(Color? color = null, Dictionary<string, object> options = null)
+        public override void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null)
         {
+            objectToAffect = (affectObject != null ? affectObject : gameObject);
             originalSharedRendererMaterials = new Dictionary<string, Material[]>();
             originalRendererMaterials = new Dictionary<string, Material[]>();
             faderRoutines = new Dictionary<string, Coroutine>();
@@ -76,7 +78,7 @@ namespace VRTK.Highlighters
         /// <param name="duration">Not used.</param>
         public override void Unhighlight(Color? color = null, float duration = 0f)
         {
-            if (originalRendererMaterials == null)
+            if (originalRendererMaterials == null || objectToAffect == null)
             {
                 return;
             }
@@ -90,7 +92,7 @@ namespace VRTK.Highlighters
                 faderRoutines.Clear();
             }
 
-            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            Renderer[] renderers = objectToAffect.GetComponentsInChildren<Renderer>(true);
             for (int i = 0; i < renderers.Length; i++)
             {
                 Renderer renderer = renderers[i];
@@ -109,7 +111,7 @@ namespace VRTK.Highlighters
         {
             originalSharedRendererMaterials.Clear();
             originalRendererMaterials.Clear();
-            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            Renderer[] renderers = objectToAffect.GetComponentsInChildren<Renderer>(true);
             for (int i = 0; i < renderers.Length; i++)
             {
                 Renderer renderer = renderers[i];
@@ -122,7 +124,7 @@ namespace VRTK.Highlighters
 
         protected virtual void ChangeToHighlightColor(Color color, float duration = 0f)
         {
-            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            Renderer[] renderers = objectToAffect.GetComponentsInChildren<Renderer>(true);
             for (int j = 0; j < renderers.Length; j++)
             {
                 Renderer renderer = renderers[j];

--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialPropertyBlockColorSwapHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialPropertyBlockColorSwapHighlighter.cs
@@ -25,13 +25,15 @@ namespace VRTK.Highlighters
         /// The Initialise method sets up the highlighter for use.
         /// </summary>
         /// <param name="color">Not used.</param>
+        /// <param name="affectObject">An optional GameObject to specify which object to apply the highlighting to.</param>
         /// <param name="options">A dictionary array containing the highlighter options:\r     * `&lt;'resetMainTexture', bool&gt;` - Determines if the default main texture should be cleared on highlight. `true` to reset the main default texture, `false` to not reset it.</param>
-        public override void Initialise(Color? color = null, Dictionary<string, object> options = null)
+        public override void Initialise(Color? color = null, GameObject affectObject = null, Dictionary<string, object> options = null)
         {
+            objectToAffect = (affectObject != null ? affectObject : gameObject);
             originalMaterialPropertyBlocks = new Dictionary<string, MaterialPropertyBlock>();
             highlightMaterialPropertyBlocks = new Dictionary<string, MaterialPropertyBlock>();
             // call to parent highlighter
-            base.Initialise(color, options);
+            base.Initialise(color, affectObject, options);
         }
 
         /// <summary>
@@ -41,7 +43,7 @@ namespace VRTK.Highlighters
         /// <param name="duration">Not used.</param>
         public override void Unhighlight(Color? color = null, float duration = 0f)
         {
-            if (originalMaterialPropertyBlocks == null)
+            if (originalMaterialPropertyBlocks == null || objectToAffect == null)
             {
                 return;
             }
@@ -55,7 +57,7 @@ namespace VRTK.Highlighters
                 faderRoutines.Clear();
             }
 
-            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            Renderer[] renderers = objectToAffect.GetComponentsInChildren<Renderer>(true);
             for (int i = 0; i < renderers.Length; i++)
             {
                 Renderer renderer = renderers[i];
@@ -73,7 +75,7 @@ namespace VRTK.Highlighters
         {
             originalMaterialPropertyBlocks.Clear();
             highlightMaterialPropertyBlocks.Clear();
-            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            Renderer[] renderers = objectToAffect.GetComponentsInChildren<Renderer>(true);
             for (int i = 0; i < renderers.Length; i++)
             {
                 Renderer renderer = renderers[i];
@@ -86,7 +88,7 @@ namespace VRTK.Highlighters
 
         protected override void ChangeToHighlightColor(Color color, float duration = 0f)
         {
-            Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
+            Renderer[] renderers = objectToAffect.GetComponentsInChildren<Renderer>(true);
             for (int i = 0; i < renderers.Length; i++)
             {
                 Renderer renderer = renderers[i];

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_ControllerHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_ControllerHighlighter.cs
@@ -121,7 +121,7 @@ namespace VRTK
 
                 SDK_BaseController.ControllerHand currentHand = VRTK_DeviceFinder.GetControllerHand(actualController);
 
-                objectHighlighter.Initialise(null, highlighterOptions);
+                objectHighlighter.Initialise(null, null, highlighterOptions);
 
                 AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.ButtonOne, currentHand)), objectHighlighter, elementHighlighterOverrides.buttonOne);
                 AddHighlighterToElement(GetElementTransform(VRTK_SDK_Bridge.GetControllerElementPath(SDK_BaseController.ControllerElements.ButtonTwo, currentHand)), objectHighlighter, elementHighlighterOverrides.buttonTwo);
@@ -396,7 +396,7 @@ namespace VRTK
             {
                 VRTK_BaseHighlighter highlighter = (overrideHighlighter != null ? overrideHighlighter : parentHighlighter);
                 VRTK_BaseHighlighter clonedHighlighter = (VRTK_BaseHighlighter)VRTK_SharedMethods.CloneComponent(highlighter, element.gameObject);
-                clonedHighlighter.Initialise(null, highlighterOptions);
+                clonedHighlighter.Initialise(null, null, highlighterOptions);
             }
         }
 


### PR DESCRIPTION
  > **Breaking Changes**

The Interactable Object script now has an additional parameter that
allows injecting a Base Highlighter for the Interactable Object to
use.

This means that the Highlighter does not need to be on the same
GameObject as the Interactable Object and can also be swapped out
at runtime for a different highlighter.

To enable this to work, the Highlighters now can accept new
GameObject parameter in the Initialise method. This GameObject
parameter is the second parameter pushing the `options` parameter
to the 3rd param which will cause a breaking change for anyone
using the existing code.