### PR TITLE
fix(Interaction): ensure valid grab attempt is called

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -515,6 +515,7 @@ namespace VRTK
         protected virtual void PerformGrabAttempt(GameObject objectToGrab)
         {
             IncrementGrabState();
+            IsValidGrabAttempt(objectToGrab);
             undroppableGrabbedObject = GetUndroppableObject();
         }
 


### PR DESCRIPTION
The Interact Grab script requires the `IsValidGrabAttempt` method
to be called to set up state for future method calls.

This was removed during a cleanup that said the line was not being
used, but the variable it was being assigned to wasn't being used,
however, the method call was still required.