### PR TITLE
fix(SnapDropZone): prevent unwanted unsnap on leaving trigger collider

### DIFF
--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_SnapDropZone.cs
@@ -419,7 +419,7 @@ namespace VRTK
 
         protected virtual void CheckCanUnsnap(VRTK_InteractableObject interactableObjectCheck)
         {
-            if (interactableObjectCheck != null && currentValidSnapInteractableObjects.Contains(interactableObjectCheck))
+            if (interactableObjectCheck != null && currentValidSnapInteractableObjects.Contains(interactableObjectCheck) && ValidUnsnap(interactableObjectCheck))
             {
                 if (isSnapped && currentSnappedObject == interactableObjectCheck)
                 {
@@ -442,6 +442,11 @@ namespace VRTK
                     OnObjectExitedSnapDropZone(SetSnapDropZoneEvent(interactableObjectCheck.gameObject));
                 }
             }
+        }
+
+        protected virtual bool ValidUnsnap(VRTK_InteractableObject interactableObjectCheck)
+        {
+            return ((snapType != SnapTypes.UseJoint || !float.IsInfinity(GetComponent<Joint>().breakForce)) && interactableObjectCheck.validDrop == VRTK_InteractableObject.ValidDropTypes.DropAnywhere);
         }
 
         protected virtual void SnapObjectToZone(VRTK_InteractableObject objectToSnap)


### PR DESCRIPTION
The Snap Drop Zone will automatically unsnap an object if it leaves the
trigger collider of the snap drop zone. However, this isn't always the
correct result. If the snap drop zone is using a joint snap and the
joint is set to infinity, then it would never be expected to break the
joint. Also, if the interactable object can only be dropped in snap
drop zones then forcing it out of the snap drop zone when it leaves
the trigger collider is also incorrect.