### PR TITLE
fix(SnapDropZone): allow grab remove from unsnappable joints

### DIFF
--- a/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/Internal/Scripts/VRTK_SnapDropZone.cs
@@ -407,12 +407,12 @@ namespace VRTK
                 {
                     ToggleHighlight(interactableObjectCheck, true);
                     interactableObjectCheck.SetSnapDropZoneHover(this, true);
-                    ToggleHighlightColor();
                     if (!willSnap)
                     {
                         OnObjectEnteredSnapDropZone(SetSnapDropZoneEvent(interactableObjectCheck.gameObject));
                     }
                     willSnap = true;
+                    ToggleHighlightColor();
                 }
             }
         }
@@ -446,7 +446,7 @@ namespace VRTK
 
         protected virtual bool ValidUnsnap(VRTK_InteractableObject interactableObjectCheck)
         {
-            return ((snapType != SnapTypes.UseJoint || !float.IsInfinity(GetComponent<Joint>().breakForce)) && interactableObjectCheck.validDrop == VRTK_InteractableObject.ValidDropTypes.DropAnywhere);
+            return (interactableObjectCheck.IsGrabbed() || ((snapType != SnapTypes.UseJoint || !float.IsInfinity(GetComponent<Joint>().breakForce)) && interactableObjectCheck.validDrop == VRTK_InteractableObject.ValidDropTypes.DropAnywhere));
         }
 
         protected virtual void SnapObjectToZone(VRTK_InteractableObject objectToSnap)


### PR DESCRIPTION
A previous commit made it so it was not possible to unsnap objects
from Snap Drop Zones when they left the trigger collider if they were
considered objects that should not be able to be unsnapped.

However, this caused an issue that it was not possible to grab objects
out of snap drop zones either without releasing them and having them
snap straight back into the snap drop zone.

This issue ensures any grabbed object can be removed from a snap drop
zone.