### PR TITLE
feat(Pointers): match play area cursor rotation to direction indicator - fixes #1499

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -1473,6 +1473,7 @@ The Play Area Cursor is used in conjunction with a Pointer script and displays a
  * **Headset Out Of Bounds Is Collision:** If this is checked then if the user's headset is outside of the play area cursor bounds then it is considered a collision even if the play area isn't colliding with anything.
  * **Display On Invalid Location:** If this is checked then the play area cursor will be displayed when the location is invalid.
  * **Target List Policy:** A specified VRTK_PolicyList to use to determine whether the play area cursor collisions will be acted upon.
+ * **Direction Indicator:** A custom Pointer Direction Indicator to use to determine the rotation of the Play Area Cursor.
  * **Valid Location Object:** A custom GameObject to use for the play area cursor representation for when the location is valid.
  * **Invalid Location Object:** A custom GameObject to use for the play area cursor representation for when the location is invalid.
 

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_InteractGrab.cs
@@ -2,7 +2,6 @@
 namespace VRTK
 {
     using UnityEngine;
-    using System.Collections;
 
     /// <summary>
     /// The Interact Grab script is attached to a Controller object and requires the `VRTK_ControllerEvents` script to be attached as it uses this for listening to the controller button events for grabbing and releasing interactable game objects.

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -44,7 +44,8 @@ namespace VRTK
         public VRTK_PolicyList targetListPolicy;
 
         [Header("Custom Settings")]
-
+        [Tooltip("A custom Pointer Direction Indicator to use to determine the rotation of the Play Area Cursor.")]
+        public VRTK_PointerDirectionIndicator directionIndicator;
         [Tooltip("A custom GameObject to use for the play area cursor representation for when the location is valid.")]
         public GameObject validLocationObject;
         [Tooltip("A custom GameObject to use for the play area cursor representation for when the location is invalid.")]
@@ -186,7 +187,7 @@ namespace VRTK
                         headsetOutOfBounds = false;
                     }
                 }
-
+                playAreaCursor.transform.rotation = (directionIndicator != null ? directionIndicator.transform.rotation : playArea.rotation);
                 playAreaCursor.transform.position = location + offset;
             }
         }


### PR DESCRIPTION
The Play Area Cursor script can now accept a Pointer Direction
Indicator which if provided will be used to amend the rotation of the
Play Area Cursor to match the Pointer Direction Indicator.

If no Pointer Direction Indicator is provided then the rotation will
simply match the Playarea rotation.