### PR TITLE
feat(Interaction): provide custom highlighter to controller highlighter

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -2995,9 +2995,17 @@ The UnsubscribeToAxisAliasEvent method makes it easier to unsubscribe from axis 
 
 ### Overview
 
-The Controller Highlighter script provides methods to deal with highlighting controller elements.
+Enables highlighting of controller elements.
 
-The highlighting of the controller is defaulted to use the `VRTK_MaterialColorSwapHighlighter` if no other highlighter is applied to the Object.
+**Script Usage:**
+* Place the `VRTK_ControllerHighlighter` script on either:
+* The controller script alias GameObject of the controller to affect (e.g. Right Controller Script Alias).
+* Any other scene GameObject and provide the controller script alias GameObject to the `Controller Alias` parameter of this script.
+* The Model Element Paths will be auto populated at runtime based on the SDK Setup Model Alias being used (except if a custom Model Alias for the SDK Setup is provided).
+* The Highlighter used by the Controller Highlighter will be selected in the following order:
+* The provided Base Highlighter in the `Controller Highlighter` parameter.
+* If the above is not provided, then the first active Base Highlighter found on the actual controller GameObject will be used.
+* If the above is not found, then a Material Color Swap Highlighter will be created on the actual controller GameObject at runtime.
 
 ### Inspector Parameters
 
@@ -3013,8 +3021,9 @@ The highlighting of the controller is defaulted to use the `VRTK_MaterialColorSw
  * **Highlight Start Menu:** The colour to set the start menu highlight colour to.
  * **Model Element Paths:** A collection of strings that determine the path to the controller model sub elements for identifying the model parts at runtime. If the paths are left empty they will default to the model element paths of the selected SDK Bridge.
  * **Element Highlighter Overrides:** A collection of highlighter overrides for each controller model sub element. If no highlighter override is given then highlighter on the Controller game object is used.
- * **Controller Alias:** An optional GameObject to specify which controller to apply the script methods to. If this is left blank then this script is required to be placed on a Controller Alias GameObject and it will use the Actual Controller object linked to the script alias.
- * **Model Container:** An optional GameObject to specifiy where the controller models are. If this is left blank then the Model Alias object will be used.
+ * **Controller Alias:** An optional GameObject to specify which controller to apply the script methods to. If this is left blank then this script is required to be placed on a controller script alias GameObject and it will use the Actual Controller GameObject linked to the controller script alias.
+ * **Model Container:** An optional GameObject to specifiy where the controller models are. If this is left blank then the controller Model Alias object will be used.
+ * **Controller Highlighter:** An optional Highlighter to use when highlighting the controller element. If this is left blank, then the first active highlighter on the same GameObject will be used, if one isn't found then a Material Color Swap Highlighter will be created at runtime.
 
 ### Class Methods
 
@@ -3045,8 +3054,8 @@ The PopulateHighlighters method sets up the highlighters on the controller model
   > `public virtual void HighlightController(Color color, float fadeDuration = 0f)`
 
  * Parameters
-   * `Color color` - The colour to highlight the controller to.
-   * `float fadeDuration` - The duration in time to fade from the initial colour to the target colour.
+   * `Color color` - The Color to highlight the controller to.
+   * `float fadeDuration` - The duration in seconds to fade from the initial color to the target color.
  * Returns
    * _none_
 
@@ -3069,8 +3078,8 @@ The UnhighlightController method attempts to remove the highlight from all sub m
 
  * Parameters
    * `SDK_BaseController.ControllerElements elementType` - The element type on the controller.
-   * `Color color` - The colour to highlight the controller element to.
-   * `float fadeDuration` - The duration in time to fade from the initial colour to the target colour.
+   * `Color color` - The Color to highlight the controller element to.
+   * `float fadeDuration` - The duration in seconds to fade from the initial color to the target color.
  * Returns
    * _none_
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -26,7 +26,7 @@ namespace VRTK.Highlighters
         public bool enableSubmeshHighlight = false;
 
         protected Material stencilOutline;
-        protected GameObject[] highlightModels;
+        protected Renderer[] highlightModels;
         protected string[] copyComponents = new string[] { "UnityEngine.MeshFilter", "UnityEngine.MeshRenderer" };
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace VRTK.Highlighters
         /// <param name="duration">Not used.</param>
         public override void Highlight(Color? color, float duration = 0f)
         {
-            if (highlightModels != null && highlightModels.Length > 0)
+            if (highlightModels != null && highlightModels.Length > 0 && stencilOutline != null)
             {
                 stencilOutline.SetFloat("_Thickness", thickness);
                 stencilOutline.SetColor("_OutlineColor", (Color)color);
@@ -78,7 +78,8 @@ namespace VRTK.Highlighters
                 {
                     if (highlightModels[i] != null)
                     {
-                        highlightModels[i].SetActive(true);
+                        highlightModels[i].gameObject.SetActive(true);
+                        highlightModels[i].material = stencilOutline;
                     }
                 }
             }
@@ -102,7 +103,7 @@ namespace VRTK.Highlighters
                 {
                     if (highlightModels[i] != null)
                     {
-                        highlightModels[i].SetActive(false);
+                        highlightModels[i].gameObject.SetActive(false);
                     }
                 }
             }
@@ -140,7 +141,7 @@ namespace VRTK.Highlighters
         {
             if (customOutlineModels != null && customOutlineModels.Length > 0)
             {
-                highlightModels = new GameObject[customOutlineModels.Length];
+                highlightModels = new Renderer[customOutlineModels.Length];
                 for (int i = 0; i < customOutlineModels.Length; i++)
                 {
                     highlightModels[i] = CreateHighlightModel(customOutlineModels[i], "");
@@ -152,7 +153,7 @@ namespace VRTK.Highlighters
         {
             if (customOutlineModelPaths != null && customOutlineModelPaths.Length > 0)
             {
-                highlightModels = new GameObject[customOutlineModels.Length];
+                highlightModels = new Renderer[customOutlineModels.Length];
                 for (int i = 0; i < customOutlineModelPaths.Length; i++)
                 {
                     highlightModels[i] = CreateHighlightModel(null, customOutlineModelPaths[i]);
@@ -164,7 +165,7 @@ namespace VRTK.Highlighters
         {
             if (highlightModels == null || highlightModels.Length == 0)
             {
-                highlightModels = new GameObject[1];
+                highlightModels = new Renderer[1];
                 highlightModels[0] = CreateHighlightModel(null, "");
             }
         }
@@ -200,10 +201,10 @@ namespace VRTK.Highlighters
                     Destroy(existingHighlighterObjects[i].gameObject);
                 }
             }
-            highlightModels = new GameObject[0];
+            highlightModels = new Renderer[0];
         }
 
-        protected virtual GameObject CreateHighlightModel(GameObject givenOutlineModel, string givenOutlineModelPath)
+        protected virtual Renderer CreateHighlightModel(GameObject givenOutlineModel, string givenOutlineModelPath)
         {
             if (givenOutlineModel != null)
             {
@@ -247,6 +248,7 @@ namespace VRTK.Highlighters
 
             MeshFilter copyMesh = copyModel.GetComponent<MeshFilter>();
             MeshFilter highlightMesh = highlightModel.GetComponent<MeshFilter>();
+            Renderer returnHighlightModel = highlightModel.GetComponent<Renderer>();
             if (highlightMesh != null)
             {
                 if (enableSubmeshHighlight)
@@ -269,14 +271,13 @@ namespace VRTK.Highlighters
                 {
                     highlightMesh.mesh = copyMesh.mesh;
                 }
-
-                highlightModel.GetComponent<Renderer>().material = stencilOutline;
+                returnHighlightModel.material = stencilOutline;
             }
             highlightModel.SetActive(false);
 
             VRTK_PlayerObject.SetPlayerObject(highlightModel, VRTK_PlayerObject.ObjectTypes.Highlighter);
 
-            return highlightModel;
+            return returnHighlightModel;
         }
     }
 }


### PR DESCRIPTION
The Controller Highlighter sript now has an additional parameter that
allows injecting a Base Highlighter for the Controller Highlighter to
use.

There has also been a slight fix to the Outline Highlighter where it
wouldn't set up child materials with the correct colour.