### PR TITLE
fix(pointers): Custom tracers not cleaned up on destroy.

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_CurveGenerator.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_CurveGenerator.cs
@@ -412,5 +412,11 @@ namespace VRTK
                 }
             }
         }
+
+        protected virtual void OnDisable() {
+            if (tracerLineRenderer != null) {
+                Destroy(tracerLineRenderer);
+            }
+        }
     }
 }


### PR DESCRIPTION
When disabling the BezierPointerRenderer, it doesn't destroy GameObjects created using custom tracers.