### PR TITLE
fix(DeviceFinder): support Oculus Rift ES07

### DIFF
--- a/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -386,6 +386,8 @@ namespace VRTK
             switch (cachedHeadsetType)
             {
                 case "oculusriftcv1":
+                case "oculusriftes07":
+                    // The ES07 model seems to be an obscure model and it's hard to find documentation about it. Treat it like a CV1.
                     returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftCV1);
                     break;
                 case "vivemv":


### PR DESCRIPTION
This model is an obscure one, with pretty much no information about it
publicly available. For some reason, I ended up with a device with this
model, and treating it like a CV1 works just fine.

----

Hi @thestonefox. I somehow ended up with a device with this weird Oculus Rift ES07 model, and I don't know why. Without supporting this model, the `GetHeadsetType` method spews a warning over and over again, since the method is used in a loop. This slows down Unity projects with way too much logging.

The other option would have been to not log as often, but that's a more invasive change. It's up to you if you'd like to accept this change or not, but I'll need something of this sort locally to avoid slowing down my project.