### PR TITLE
fix(DeviceFinder): add oculus headset type for rare es07

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -7477,6 +7477,7 @@ The Device Finder offers a collection of static methods that can be called to fi
    * `Vive` - A summary of all HTC Vive headset versions.
    * `ViveMV` - A specific version of the HTC Vive headset, the first consumer version.
    * `ViveDVT` - A specific version of the HTC Vive headset, the first consumer version.
+   * `OculusRiftES07` - A specific version of the Oculus Rift headset, the rare ES07.
 
 ### Class Methods
 
@@ -7740,7 +7741,7 @@ The ResetHeadsetTypeCache resets the cache holding the current headset type valu
   > `public static Headsets GetHeadsetType(bool summary = false)`
 
  * Parameters
-   * `bool summary` - If this is true, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).
+   * `bool summary` - If this is `true`, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).
  * Returns
    * `Headsets` - The Headset type that is connected.
 

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -60,7 +60,11 @@ namespace VRTK
             /// <summary>
             /// A specific version of the HTC Vive headset, the first consumer version.
             /// </summary>
-            ViveDVT
+            ViveDVT,
+            /// <summary>
+            /// A specific version of the Oculus Rift headset, the rare ES07.
+            /// </summary>
+            OculusRiftES07
         }
 
         private static string cachedHeadsetType = "";
@@ -368,7 +372,7 @@ namespace VRTK
         /// <summary>
         /// The GetHeadsetType method returns the type of headset connected to the computer.
         /// </summary>
-        /// <param name="summary">If this is true, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).</param>
+        /// <param name="summary">If this is `true`, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).</param>
         /// <returns>The Headset type that is connected.</returns>
         public static Headsets GetHeadsetType(bool summary = false)
         {
@@ -378,6 +382,9 @@ namespace VRTK
             {
                 case "oculusriftcv1":
                     returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftCV1);
+                    break;
+                case "oculusriftes07":
+                    returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftES07);
                     break;
                 case "vivemv":
                     returnValue = (summary ? Headsets.Vive : Headsets.ViveMV);


### PR DESCRIPTION
The Oculus Rift headset can have a rare reported type of es07 which
is now being caught and returned correctly.

Thanks to @avik-das for identifying the issue.