### PR TITLE
feat(Locomotion): add unity event helper for slingshot jump

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -2519,6 +2519,12 @@ Provides the ability for the SDK Camera Rig to be thrown around with a jumping m
 
  * `SlingshotJumped` - Emitted when a slingshot jump occurs
 
+### Unity Events
+
+Adding the `VRTK_SlingshotJump_UnityEvents` component to `VRTK_SlingshotJump` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
 ### Class Methods
 
 #### GetActivationButton/0

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_SlingshotJump_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_SlingshotJump_UnityEvents.cs
@@ -1,0 +1,30 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_SlingshotJump_UnityEvents")]
+    public sealed class VRTK_SlingshotJump_UnityEvents : VRTK_UnityEvents<VRTK_SlingshotJump>
+    {
+        [Serializable]
+        public sealed class SlingshotJumpEvent : UnityEvent<object> { }
+
+        public SlingshotJumpEvent OnSlingshotJumped = new SlingshotJumpEvent();
+
+        protected override void AddListeners(VRTK_SlingshotJump component)
+        {
+            component.SlingshotJumped += SlingshotJumped;
+        }
+
+        protected override void RemoveListeners(VRTK_SlingshotJump component)
+        {
+            component.SlingshotJumped -= SlingshotJumped;
+        }
+
+        private void SlingshotJumped(object o)
+        {
+            OnSlingshotJumped.Invoke(o);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_SlingshotJump_UnityEvents.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_SlingshotJump_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e17028e22ef6f8e4daa050aca24c91d8
+timeCreated: 1506689521
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Slingshot Jumpt script now has a Unity Event Helper script to
allow for unity events to be used in place of C# delegates.