### PR TITLE
fix(UI): have UIPointer look for ControllerEvents in parents

### DIFF
--- a/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Scripts/UI/VRTK_UIPointer.cs
@@ -412,7 +412,7 @@ namespace VRTK
         {
             pointerOriginTransform = (originalPointerOriginTransform == null ? VRTK_SDK_Bridge.GenerateControllerPointerOrigin(gameObject) : originalPointerOriginTransform);
 
-            controller = (controller != null ? controller : GetComponent<VRTK_ControllerEvents>());
+            controller = (controller != null ? controller : GetComponentInParent<VRTK_ControllerEvents>());
             ConfigureEventSystem();
             pointerClicked = false;
             lastPointerPressState = false;


### PR DESCRIPTION
Allow the UIPointer to be a child of the object with the controller,
instead of having to be on the same object. Now matches VRTK_Pointer
and several other scripts.