### PR TITLE
fix(Simulator): ensure mouse lock behaviour works correctly

### DIFF
--- a/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/SDK/Simulator/SDK_InputSimulator.cs
@@ -33,10 +33,13 @@ namespace VRTK
         public bool hideHandsAtSwitch = false;
         [Tooltip("Reset hand position and rotation when enabling them.")]
         public bool resetHandsAtSwitch = true;
-        [Tooltip("Whether mouse movement always acts as input or requires a button press.")]
-        public MouseInputMode mouseMovementInput = MouseInputMode.Always;
-        [Tooltip("Lock the mouse cursor to the game window when the mouse movement key is pressed.")]
+		
+        [Header("Mouse cursor lock")]
+
+        [Tooltip("Lock the mouse cursor to the game window.")]
         public bool lockMouseToView = true;
+        [Tooltip("Whether the mouse movement always acts as input or requires a button press.")]
+        public MouseInputMode mouseMovementInput = MouseInputMode.Always;
 
         [Header("Adjustments")]
 
@@ -211,6 +214,10 @@ namespace VRTK
                 {
                     oldPos = Input.mousePosition;
                 }
+            }
+            else
+            {
+                Cursor.lockState = lockMouseToView ? CursorLockMode.Locked : CursorLockMode.None;
             }
 
             if (Input.GetKeyDown(handsOnOff))


### PR DESCRIPTION
This fixes the simulator mouse cursor lock to behave as expected with
the "Always" selection of the "Mouse movement input" mode and actually
lock the cursor in the game view.