### PR TITLE
feat(Locomotion): add tunnel overlay camera effect for comfort options - fixes #222

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -1965,6 +1965,7 @@ A collection of scripts that provide varying methods of moving the user around t
  * [Player Climb](#player-climb-vrtk_playerclimb)
  * [Slingshot Jump](#slingshot-jump-vrtk_slingshotjump)
  * [Step Multiplier](#step-multiplier-vrtk_stepmultiplier)
+ * [Tunnel Overlay](#tunnel-overlay-vrtk_tunneloverlay)
 
 ---
 
@@ -2610,6 +2611,31 @@ Multiplies each real world step within the play area to enable further distances
 ### Example
 
 `VRTK/Examples/028_CameraRig_RoomExtender` shows how the Step Multiplier can be used to move around the scene with multiplied steps.
+
+---
+
+## Tunnel Overlay (VRTK_TunnelOverlay)
+
+### Overview
+
+Applys a tunnel overlay effect to the active VR camera when the play area is moving or rotating to reduce potential nausea caused by simulation sickness.
+
+**Script Usage:**
+ * Place the `VRTK_TunnelOverlay` script on any active scene GameObject.
+
+  > This implementation is based on a project made by SixWays at https://github.com/SixWays/UnityVrTunnelling
+
+### Inspector Parameters
+
+ * **Minimum Rotation:** Minimum rotation speed for the effect to activate (degrees per second).
+ * **Maximum Rotation:** Maximum rotation speed for the effect have its max settings applied (degrees per second).
+ * **Minimum Speed:** Minimum movement speed for the effect to activate.
+ * **Maximum Speed:** Maximum movement speed where the effect will have its max settings applied.
+ * **Effect Color:** The color to use for the tunnel effect.
+ * **Initial Effect Size:** The initial amount of screen coverage the tunnel to consume without any movement.
+ * **Maximum Effect Size:** Screen coverage at the maximum tracked values.
+ * **Feather Size:** Feather effect size around the cut-off as fraction of screen.
+ * **Smoothing Time:** Smooth out radius over time.
 
 ---
 

--- a/Assets/VRTK/Internal/Materials/Resources/TunnelOverlay.mat
+++ b/Assets/VRTK/Internal/Materials/Resources/TunnelOverlay.mat
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: TunnelOverlay
+  m_Shader: {fileID: 4800000, guid: 9a0d8a7c6bde1d64cb8f6c2f81f3d5d5, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AngularVelocity: 0
+    - _FeatherSize: 0.1
+    m_Colors:
+    - _Color: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/VRTK/Internal/Materials/Resources/TunnelOverlay.mat.meta
+++ b/Assets/VRTK/Internal/Materials/Resources/TunnelOverlay.mat.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 441b55e210b1bfb498ace8bae36e0941
+timeCreated: 1507117382
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/Shaders/VRTK_TunnelEffect.shader
+++ b/Assets/VRTK/Source/Scripts/Internal/Shaders/VRTK_TunnelEffect.shader
@@ -1,0 +1,66 @@
+﻿Shader "VRTK/VRTK_TunnelEffect"
+{
+    Properties
+    {
+        _Color("Color Tint", Color) = (0,0,0,1)
+        _MainTex ("Texture", 2D) = "white" {}
+        _AngularVelocity ("Angular Velocity", Float) = 0
+        _FeatherSize ("FeatherSize", Float) = 0.1
+    }
+
+    SubShader
+    {
+        // No culling or depth
+        Cull Off ZWrite Off ZTest Always
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float _AngularVelocity;
+            float _FeatherSize;
+            half4 _Color;
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = UnityStereoScreenSpaceUVAdjust(i.uv, _MainTex_ST);
+                fixed4 col = tex2D(_MainTex, uv);
+
+                float2 coords = (i.uv - 0.5) * 2;
+                float radius = length(coords) / 1.414214;
+                float avMin = (1 - _AngularVelocity) - _FeatherSize;
+                float avMax = (1 - _AngularVelocity) + _FeatherSize;
+                float t = saturate((radius - avMin) / (avMax - avMin));
+                return lerp(col, _Color, t);
+            }
+
+            ENDCG
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/Shaders/VRTK_TunnelEffect.shader.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/Shaders/VRTK_TunnelEffect.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9a0d8a7c6bde1d64cb8f6c2f81f3d5d5
+timeCreated: 1507116836
+licenseType: Free
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_TunnelEffect.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_TunnelEffect.cs
@@ -1,0 +1,19 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public class VRTK_TunnelEffect : MonoBehaviour
+    {
+        protected Material material;
+
+        public virtual void SetMaterial(Material material)
+        {
+            this.material = material;
+        }
+
+        protected virtual void OnRenderImage(RenderTexture src, RenderTexture dest)
+        {
+            Graphics.Blit(src, dest, material);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_TunnelEffect.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_TunnelEffect.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: af8ec391cfe418e4589d1b634150da7b
+timeCreated: 1507116883
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TunnelOverlay.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TunnelOverlay.cs
@@ -1,0 +1,142 @@
+﻿// Tunnel Overlay|Locomotion|20140
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Applys a tunnel overlay effect to the active VR camera when the play area is moving or rotating to reduce potential nausea caused by simulation sickness.
+    /// </summary>
+    /// <remarks>
+    /// **Script Usage:**
+    ///  * Place the `VRTK_TunnelOverlay` script on any active scene GameObject.
+    ///
+    ///   > This implementation is based on a project made by SixWays at https://github.com/SixWays/UnityVrTunnelling
+    /// </remarks>
+    [AddComponentMenu("VRTK/Scripts/Locomotion/VRTK_TunnelOverlay")]
+    public class VRTK_TunnelOverlay : MonoBehaviour
+    {
+        [Header("Movement Settings")]
+
+        [Tooltip("Minimum rotation speed for the effect to activate (degrees per second).")]
+        public float minimumRotation = 0f;
+        [Tooltip("Maximum rotation speed for the effect have its max settings applied (degrees per second).")]
+        public float maximumRotation = 45f;
+        [Tooltip("Minimum movement speed for the effect to activate.")]
+        public float minimumSpeed = 0f;
+        [Tooltip("Maximum movement speed where the effect will have its max settings applied.")]
+        public float maximumSpeed = 1f;
+
+        [Header("Effect Settings")]
+
+        [Tooltip("The color to use for the tunnel effect.")]
+        public Color effectColor = Color.black;
+        [Tooltip("The initial amount of screen coverage the tunnel to consume without any movement.")]
+        [Range(0f, 1f)]
+        public float initialEffectSize = 0f;
+        [Tooltip("Screen coverage at the maximum tracked values.")]
+        [Range(0f, 1f)]
+        public float maximumEffectSize = 0.65f;
+        [Tooltip("Feather effect size around the cut-off as fraction of screen.")]
+        [Range(0f, 0.5f)]
+        public float featherSize = 0.1f;
+        [Tooltip("Smooth out radius over time.")]
+        public float smoothingTime = 0.15f;
+
+        protected Transform headset;
+        protected Transform playarea;
+        protected VRTK_TunnelEffect cameraEffect;
+        protected float angularVelocity;
+        protected float angularVelocitySlew;
+        protected Vector3 lastForward;
+        protected Vector3 lastPosition;
+        protected Material matCameraEffect;
+        protected int shaderPropertyColor;
+        protected int shaderPropertyAV;
+        protected int shaderPropertyFeather;
+        protected Color originalColor;
+        protected float originalAngularVelocity;
+        protected float originalFeatherSize;
+        protected float maximumEffectCoverage = 1.15f;
+
+        protected virtual void Awake()
+        {
+            matCameraEffect = Resources.Load<Material>("TunnelOverlay");
+            shaderPropertyColor = Shader.PropertyToID("_Color");
+            shaderPropertyAV = Shader.PropertyToID("_AngularVelocity");
+            shaderPropertyFeather = Shader.PropertyToID("_FeatherSize");
+            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+        }
+
+        protected virtual void OnEnable()
+        {
+            headset = VRTK_DeviceFinder.HeadsetCamera();
+            playarea = VRTK_DeviceFinder.PlayAreaTransform();
+            cameraEffect = headset.GetComponent<VRTK_TunnelEffect>();
+            originalAngularVelocity = matCameraEffect.GetFloat(shaderPropertyAV);
+            originalFeatherSize = matCameraEffect.GetFloat(shaderPropertyFeather);
+            originalColor = matCameraEffect.GetColor(shaderPropertyColor);
+
+            if (cameraEffect == null)
+            {
+                cameraEffect = headset.gameObject.AddComponent<VRTK_TunnelEffect>();
+                cameraEffect.SetMaterial(matCameraEffect);
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            headset = null;
+            playarea = null;
+
+            if (cameraEffect != null)
+            {
+                SetShaderFeather(originalColor, originalAngularVelocity, originalFeatherSize);
+                matCameraEffect.SetColor(shaderPropertyColor, originalColor);
+                Destroy(cameraEffect);
+            }
+        }
+
+        protected virtual void OnDestroy()
+        {
+            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            Vector3 fwd = playarea.forward;
+            Vector3 pos = playarea.position;
+
+            float newAngularVelocity = Vector3.Angle(lastForward, fwd) / Time.fixedDeltaTime;
+            newAngularVelocity = (newAngularVelocity - minimumRotation) / (maximumRotation - minimumRotation);
+
+            if (maximumSpeed > 0)
+            {
+                float speed = (pos - lastPosition).magnitude / Time.fixedDeltaTime;
+                speed = (speed - minimumSpeed) / (maximumSpeed - minimumSpeed);
+
+                if (speed > newAngularVelocity)
+                {
+                    newAngularVelocity = speed;
+                }
+            }
+
+            float actualInitialSize = (initialEffectSize * maximumEffectCoverage);
+            float actualMaxSize = (maximumEffectSize * maximumEffectCoverage) - actualInitialSize;
+
+            newAngularVelocity = Mathf.Clamp01(newAngularVelocity) * actualMaxSize;
+            angularVelocity = Mathf.SmoothDamp(angularVelocity, newAngularVelocity, ref angularVelocitySlew, smoothingTime);
+
+            SetShaderFeather(effectColor, angularVelocity + actualInitialSize, featherSize);
+
+            lastForward = fwd;
+            lastPosition = pos;
+        }
+
+        protected virtual void SetShaderFeather(Color givenTunnelColor, float givenAngularVelocity, float givenFeatherSize)
+        {
+            matCameraEffect.SetColor(shaderPropertyColor, givenTunnelColor);
+            matCameraEffect.SetFloat(shaderPropertyAV, givenAngularVelocity);
+            matCameraEffect.SetFloat(shaderPropertyFeather, givenFeatherSize);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TunnelOverlay.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TunnelOverlay.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 11ae14e46824f384b98d6ea1aae82798
+timeCreated: 1507118816
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Tunnel Overlay script creates a texture overlay that can increase
in it's radius towards the centre of the screen to reduce the perceived
field of view.

This can be triggered based on the movement and rotation of the play
area to reduce nausea with artificial locomotion. The tunnel effect
can also be applied when stationary to simulate effects such as damage
being taken.

Thanks to @reznovVR for the original port of the excellent
UnityVRTunnelling repo by @sixways:

https://github.com/SixWays/UnityVrTunnelling