### PR TITLE
fix(UI): prevent crash when no pointer is attached to UI Pointer

### DIFF
--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_VRInputModule.cs
@@ -316,7 +316,7 @@
 
         protected virtual void Scroll(VRTK_UIPointer pointer, List<RaycastResult> results)
         {
-            pointer.pointerEventData.scrollDelta = pointer.controller.GetTouchpadAxis();
+            pointer.pointerEventData.scrollDelta = (pointer.controller != null ? pointer.controller.GetTouchpadAxis() : Vector2.zero);
             bool scrollWheelVisible = false;
             for (int i = 0; i < results.Count; i++)
             {


### PR DESCRIPTION
There was an issue where the VRInputModule would crash if no controller
was attached to the UI Pointer because it was trying to access a
controller to get the touchpad axis data for the scroll amount.

This has been fixed by checking for the existence of a controller.