### PR TITLE
fix(UIPointer): fix enter and exit events for ui elements

### DIFF
--- a/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
@@ -134,37 +134,36 @@
                         continue;
                     }
 
+                    // Try to execute the event on an element in the hierarchy of the result
+                    // i.e. a text element in a button will execute on the parent button element instead of the text element
                     var target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.pointerEnterHandler);
-                    if (target != null)
-                    {
-                        var selectable = target.GetComponent<Selectable>();
-                        if (selectable)
-                        {
-                            var noNavigation = new Navigation();
-                            noNavigation.mode = Navigation.Mode.None;
-                            selectable.navigation = noNavigation;
-                        }
 
-                        if (pointer.hoveringElement != null && pointer.hoveringElement != target)
-                        {
-                            pointer.OnUIPointerElementExit(pointer.SetUIPointerEvent(result, null, pointer.hoveringElement));
-                        }
-
-                        pointer.OnUIPointerElementEnter(pointer.SetUIPointerEvent(result, target, pointer.hoveringElement));
-                        pointer.hoveringElement = target;
-                        pointer.pointerEventData.pointerCurrentRaycast = result;
-                        pointer.pointerEventData.pointerEnter = target;
-                        pointer.pointerEventData.hovered.Add(pointer.pointerEventData.pointerEnter);
-                        break;
-                    }
-                    else
+                    // if it did not execute on an element in the result's hierarchy, the result is the target
+                    if (target == null)
                     {
-                        if (result.gameObject != pointer.hoveringElement)
-                        {
-                            pointer.OnUIPointerElementEnter(pointer.SetUIPointerEvent(result, result.gameObject, pointer.hoveringElement));
-                        }
-                        pointer.hoveringElement = result.gameObject;
+                        target = result.gameObject;
                     }
+
+                    var selectable = target.GetComponent<Selectable>();
+                    if (selectable)
+                    {
+                        var noNavigation = new Navigation();
+                        noNavigation.mode = Navigation.Mode.None;
+                        selectable.navigation = noNavigation;
+                    }
+
+                    // fire exit event if switching from the current element directly to another element
+                    if (pointer.hoveringElement != null && pointer.hoveringElement != target)
+                    {
+                        pointer.OnUIPointerElementExit(pointer.SetUIPointerEvent(result, null, pointer.hoveringElement));
+                    }
+
+                    pointer.OnUIPointerElementEnter(pointer.SetUIPointerEvent(result, target, pointer.hoveringElement));
+                    pointer.hoveringElement = target;
+                    pointer.pointerEventData.pointerCurrentRaycast = result;
+                    pointer.pointerEventData.pointerEnter = target;
+                    pointer.pointerEventData.hovered.Add(pointer.pointerEventData.pointerEnter);
+                    break;
                 }
 
                 if (pointer.hoveringElement && results.Count == 0)

--- a/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Scripts/Internal/VRTK_VRInputModule.cs
@@ -145,6 +145,11 @@
                             selectable.navigation = noNavigation;
                         }
 
+                        if (pointer.hoveringElement != null && pointer.hoveringElement != target)
+                        {
+                            pointer.OnUIPointerElementExit(pointer.SetUIPointerEvent(result, null, pointer.hoveringElement));
+                        }
+
                         pointer.OnUIPointerElementEnter(pointer.SetUIPointerEvent(result, target, pointer.hoveringElement));
                         pointer.hoveringElement = target;
                         pointer.pointerEventData.pointerCurrentRaycast = result;


### PR DESCRIPTION
Fixes #1542 

## Steps to reproduce

**First bug (no exit event)**
- Open `034_Controls_InteractingWithUnityUI` example scene
- Using the right controller pointer, hold down the touchpad and hover over keyboard keys
- Open console, look at the event logs coming from `VRTK_ControllerUIPointerEvents_ListenerExample` 
- Notice lack of exit events when going from one key to another (you will get one exit on the last key you let go of the button on)

**Second bug (repetitive enter events)**
- Open `034_Controls_InteractingWithUnityUI` example scene
- Delete all elements except the `Text` element on the `WorldKeyboard` game object (or create a new canvas if you want)
- Center it so it's easy to point at
- Run example, hover over the text field with the right pointer
- Open console, look at the event logs coming from `VRTK_ControllerUIPointerEvents_ListenerExample` 
- Notice the repetitive `Enter` events fired for the `Text` element and the (added at runtime) `VRTK_UICANVAS_DRAGGABLE_PANEL`

**After change**
- Matching `Exit` events for each key as you switch from one element to another
- No repetitive `Enter` events fired, no `VRTK_UICANVAS_DRAGGABLE_PANEL`, just a single `Text` element enter event

## Details
`UIPointer UIPointerElementExit` was not being fired when you would switch the pointer to another UI element. This makes sure to fire `Exit` before firing a new event.

The bug was due to https://github.com/thestonefox/VRTK/pull/1543/files#diff-73ae7845543525150668186d7b88d968L137 finding a new `target` because there were `results` when moving directly from one element to another. 

This fixes it by checking to see if there was any previous `hoveringElement`, and firing `exit` on it before firing `enter` on the next element. 

https://github.com/thestonefox/VRTK/pull/1543/files#diff-73ae7845543525150668186d7b88d968L165
Still handles the case where you move off the edge of the element and don't land on a new one.

Here's a screenshot of me hovering over QWERTY keys with pointer before and after the fix in the `034_Controls_InteractingWithUnityUI` example scene.

**before**
![bug](https://user-images.githubusercontent.com/378038/31289547-162d8de0-aa97-11e7-831b-c06389fc6d3b.JPG)

**after**
![fix](https://user-images.githubusercontent.com/378038/31289553-18873eec-aa97-11e7-8eb9-7601c252a928.JPG)


This PR also fixes a somewhat related issue where `Enter` events were being repetitively fired when hovering over elements that didn't execute their Enter event in their hierarchy. An example of this was a `Text` field on its own, outside of any `Button` or other element's hierarchy. With this change, `Enter` and `Exit` are only fired once each for the text field.
