### PR TITLE
fix(Utilities): ensure controller ready event happens on sdk switch

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -7846,6 +7846,39 @@ The GetControllerLeftHand method retrieves the game object for the left hand con
 
 The GetControllerRightHand method retrieves the game object for the right hand controller.
 
+#### GetControllerReferenceLeftHand/0
+
+  > `public static VRTK_ControllerReference GetControllerReferenceLeftHand()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `VRTK_ControllerReference` - The Controller Reference for the left hand controller.
+
+The GetControllerReferenceLeftHand returns a Controller Reference for the left hand controller.
+
+#### GetControllerReferenceRightHand/0
+
+  > `public static VRTK_ControllerReference GetControllerReferenceRightHand()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `VRTK_ControllerReference` - The Controller Reference for the right hand controller.
+
+The GetControllerReferenceRightHand returns a Controller Reference for the right hand controller.
+
+#### GetControllerReferenceForHand/1
+
+  > `public static VRTK_ControllerReference GetControllerReferenceForHand(SDK_BaseController.ControllerHand hand)`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `VRTK_ControllerReference` - The Controller Reference for the given hand controller.
+
+The GetControllerReferenceForHand returns a Controller Reference for the given hand controller.
+
 #### IsControllerOfHand/2
 
   > `public static bool IsControllerOfHand(GameObject checkController, SDK_BaseController.ControllerHand hand)`
@@ -8714,6 +8747,7 @@ The GameObject that the SDK Object Alias script is applied to will become a chil
 ---
 
 ## SDK Transform Modify (VRTK_SDKTransformModify)
+ > extends VRTK_SDKControllerReady
 
 ### Overview
 
@@ -8726,8 +8760,9 @@ The SDK Transform Modify can be used to change a transform orientation at runtim
  * **Position:** The new local position to change the transform to.
  * **Rotation:** The new local rotation in eular angles to change the transform to.
  * **Scale:** The new local scale to change the transform to.
- * **Target:** The target transform to modify on enable. If this is left blank then the transform the script is attached to will be used.
- * **Sdk Overrides:** A collection of SDK Transform overrides to change the given target transform for each specified SDK.
+ * **Target:** The target Transform to modify on enable. If this is left blank then the Transform the script is attached to will be used.
+ * **Reset On Disable:** If this is checked then the target Transform will be reset to the original orientation when this script is disabled.
+ * **Sdk Overrides:** A collection of SDK Transform overrides to change the given target Transform for each specified SDK.
 
 ### Class Methods
 
@@ -8742,9 +8777,21 @@ The SDK Transform Modify can be used to change a transform orientation at runtim
 
 The UpdateTransform method updates the Transform data on the current GameObject for the specified settings.
 
+#### SetOrigins/0
+
+  > `public virtual void SetOrigins()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * _none_
+
+The SetOrigins method sets the original position, rotation, scale of the target Transform.
+
 ---
 
 ## SDK Object State (VRTK_SDKObjectState)
+ > extends VRTK_SDKControllerReady
 
 ### Overview
 

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs
@@ -1,0 +1,121 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public abstract class VRTK_SDKControllerReady : MonoBehaviour
+    {
+        protected VRTK_SDKManager sdkManager;
+        protected SDK_BaseController previousControllerSDK;
+
+        protected virtual void OnEnable()
+        {
+            sdkManager = VRTK_SDKManager.instance;
+            if (sdkManager != null)
+            {
+                sdkManager.LoadedSetupChanged += LoadedSetupChanged;
+            }
+            CheckControllersReady();
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (sdkManager != null)
+            {
+                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
+                UnregisterPreviousLeftController();
+                UnregisterPreviousRightController();
+            }
+        }
+
+        protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
+        {
+            RegisterLeftControllerReady();
+            RegisterRightControllerReady();
+            CheckControllersReady();
+            previousControllerSDK = VRTK_SDK_Bridge.GetControllerSDK();
+        }
+
+        protected virtual void CheckControllersReady()
+        {
+            VRTK_ControllerReference leftRef = VRTK_DeviceFinder.GetControllerReferenceLeftHand();
+            VRTK_ControllerReference rightRef = VRTK_DeviceFinder.GetControllerReferenceRightHand();
+
+            if (VRTK_ControllerReference.IsValid(leftRef))
+            {
+                RegisterLeftControllerReady();
+                ControllerReady(leftRef);
+            }
+
+            if (VRTK_ControllerReference.IsValid(rightRef))
+            {
+                RegisterRightControllerReady();
+                ControllerReady(rightRef);
+            }
+        }
+
+        protected virtual void UnregisterPreviousLeftController()
+        {
+            try
+            {
+                previousControllerSDK.LeftControllerReady -= LeftControllerReady;
+            }
+            catch (System.Exception)
+            {
+            }
+        }
+
+        protected virtual void UnregisterPreviousRightController()
+        {
+            try
+            {
+                previousControllerSDK.RightControllerReady -= RightControllerReady;
+            }
+            catch (System.Exception)
+            {
+            }
+        }
+
+        protected virtual void RegisterLeftControllerReady()
+        {
+            UnregisterPreviousLeftController();
+            try
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().LeftControllerReady -= LeftControllerReady;
+                VRTK_SDK_Bridge.GetControllerSDK().LeftControllerReady += LeftControllerReady;
+            }
+            catch (System.Exception)
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().LeftControllerReady += LeftControllerReady;
+            }
+        }
+
+        protected virtual void RegisterRightControllerReady()
+        {
+            UnregisterPreviousRightController();
+
+            try
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().RightControllerReady -= RightControllerReady;
+                VRTK_SDK_Bridge.GetControllerSDK().RightControllerReady += RightControllerReady;
+            }
+            catch (System.Exception)
+            {
+                VRTK_SDK_Bridge.GetControllerSDK().RightControllerReady += RightControllerReady;
+            }
+        }
+
+        protected virtual void RightControllerReady(object sender, VRTKSDKBaseControllerEventArgs e)
+        {
+            ControllerReady(e.controllerReference);
+        }
+
+        protected virtual void LeftControllerReady(object sender, VRTKSDKBaseControllerEventArgs e)
+        {
+            ControllerReady(e.controllerReference);
+        }
+
+        protected virtual void ControllerReady(VRTK_ControllerReference controllerReference)
+        {
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0b903a4a6ded86c4c88729b6d1e67a47
+timeCreated: 1507370362
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -189,6 +189,33 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetControllerReferenceLeftHand returns a Controller Reference for the left hand controller.
+        /// </summary>
+        /// <returns>The Controller Reference for the left hand controller.</returns>
+        public static VRTK_ControllerReference GetControllerReferenceLeftHand()
+        {
+            return VRTK_ControllerReference.GetControllerReference(SDK_BaseController.ControllerHand.Left);
+        }
+
+        /// <summary>
+        /// The GetControllerReferenceRightHand returns a Controller Reference for the right hand controller.
+        /// </summary>
+        /// <returns>The Controller Reference for the right hand controller.</returns>
+        public static VRTK_ControllerReference GetControllerReferenceRightHand()
+        {
+            return VRTK_ControllerReference.GetControllerReference(SDK_BaseController.ControllerHand.Right);
+        }
+
+        /// <summary>
+        /// The GetControllerReferenceForHand returns a Controller Reference for the given hand controller.
+        /// </summary>
+        /// <returns>The Controller Reference for the given hand controller.</returns>
+        public static VRTK_ControllerReference GetControllerReferenceForHand(SDK_BaseController.ControllerHand hand)
+        {
+            return VRTK_ControllerReference.GetControllerReference(hand);
+        }
+
+        /// <summary>
         /// The IsControllerOfHand method is used to check if a given controller game object is of the hand type provided.
         /// </summary>
         /// <param name="checkController">The actual controller object that is being checked.</param>

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
@@ -15,7 +15,7 @@ namespace VRTK
     ///  * The current attached Controller type.
     /// </remarks>
     [AddComponentMenu("VRTK/Scripts/Utilities/VRTK_SDKObjectState")]
-    public class VRTK_SDKObjectState : MonoBehaviour
+    public class VRTK_SDKObjectState : VRTK_SDKControllerReady
     {
         [Header("Target Settings")]
 
@@ -30,7 +30,6 @@ namespace VRTK
         [Tooltip("If the current controller type matches the selected controller type then the `Target` state will be set to the desired `Object State`.")]
         public SDK_BaseController.ControllerType controllerType = SDK_BaseController.ControllerType.Undefined;
 
-        protected VRTK_SDKManager sdkManager;
         protected Coroutine checkToggleRoutine;
 
         /// <summary>
@@ -49,34 +48,25 @@ namespace VRTK
             }
         }
 
-        protected virtual void OnEnable()
+        protected override void OnEnable()
         {
-            sdkManager = VRTK_SDKManager.instance;
             target = (target != null ? target : gameObject);
-            sdkManager.LoadedSetupChanged += LoadedSetupChanged;
+            base.OnEnable();
             checkToggleRoutine = StartCoroutine(CheckToggleAtEndOfFrame());
-
-            VRTK_SDK_Bridge.GetControllerSDK().LeftControllerReady += LeftControllerReady;
-            VRTK_SDK_Bridge.GetControllerSDK().RightControllerReady += RightControllerReady;
         }
 
-        protected virtual void OnDisable()
+        protected override void OnDisable()
         {
-            sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
+            base.OnDisable();
             if (checkToggleRoutine != null)
             {
                 StopCoroutine(checkToggleRoutine);
             }
         }
 
-        protected virtual void LeftControllerReady(object sender, VRTKSDKBaseControllerEventArgs e)
+        protected override void ControllerReady(VRTK_ControllerReference controllerReference)
         {
-            ToggleOnController(e.controllerReference);
-        }
-
-        protected virtual void RightControllerReady(object sender, VRTKSDKBaseControllerEventArgs e)
-        {
-            ToggleOnController(e.controllerReference);
+            ToggleOnController(controllerReference);
         }
 
         protected virtual IEnumerator CheckToggleAtEndOfFrame()
@@ -85,16 +75,10 @@ namespace VRTK
             CheckToggle();
         }
 
-        protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
-        {
-            CheckToggle();
-        }
-
         protected virtual void CheckToggle()
         {
             ToggleOnSDK();
             ToggleOnHeadset();
-            ToggleOnController(null);
         }
 
         protected virtual void ToggleOnSDK()


### PR DESCRIPTION
The Controller Ready event wasn't being emitted correctly due to the
SDK switching happening when the scene first starts. This meant that
the SDK Transform Modify and SDK Object State script were not working
on SDK switch correctly.

The solution is to ensure the Controller Ready event is always
unregistered and re-registered when then SDK setup changes.

This now happens in a new base script called SDK Controller Ready and
the relevant scripts that need to deal with the controller being ready
can now just extend that script and have access to the controller ready
event even when the SDK setup switches.

The Device Finder has also had a few more methods that make it easy
to find the Controller Reference of the left or right hand.