### PR TITLE
feat(SnapDropZone): enable object stacking- fixes #1503

### DIFF
--- a/Assets/VRTK/Examples/041_Controller_ObjectSnappingToDropZones.unity
+++ b/Assets/VRTK/Examples/041_Controller_ObjectSnappingToDropZones.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -37,11 +38,11 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -66,13 +67,27 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -89,6 +104,8 @@ NavMeshSettings:
     minRegionArea: 2
     manualCellSize: 0
     cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &16330799
@@ -122,7 +139,7 @@ Transform:
   - {fileID: 731679017}
   - {fileID: 917345520}
   m_Father: {fileID: 743911481}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &17312989
 GameObject:
@@ -191,8 +208,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 36098913}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -214,6 +231,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &36098916
 MeshFilter:
@@ -294,6 +312,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &85712404
 BoxCollider:
@@ -339,9 +358,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -356,6 +376,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!114 &85712408
 MonoBehaviour:
@@ -447,6 +470,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &109547599
 MeshFilter:
@@ -485,7 +509,7 @@ Transform:
   - {fileID: 2035492402}
   - {fileID: 475138834}
   m_Father: {fileID: 743911481}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &140056613
 GameObject:
@@ -547,6 +571,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &140056616
 MeshFilter:
@@ -614,13 +639,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eba3cd5456cd79e49948f5ceb58544b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pointerToggleButton: 10
-  pointerSetButton: 10
-  grabToggleButton: 7
-  useToggleButton: 3
-  uiClickButton: 3
-  menuToggleButton: 14
   axisFidelity: 1
+  senseAxisForceZeroThreshold: 0.15
+  senseAxisPressThreshold: 0.95
   triggerClickThreshold: 1
   triggerForceZeroThreshold: 0.01
   triggerAxisZeroOnUntouch: 0
@@ -632,6 +653,7 @@ MonoBehaviour:
   triggerHairlinePressed: 0
   triggerClicked: 0
   triggerAxisChanged: 0
+  triggerSenseAxisChanged: 0
   gripPressed: 0
   gripTouched: 0
   gripHairlinePressed: 0
@@ -640,16 +662,17 @@ MonoBehaviour:
   touchpadPressed: 0
   touchpadTouched: 0
   touchpadAxisChanged: 0
+  touchpadSenseAxisChanged: 0
+  touchpadTwoTouched: 0
+  touchpadTwoAxisChanged: 0
   buttonOnePressed: 0
   buttonOneTouched: 0
   buttonTwoPressed: 0
   buttonTwoTouched: 0
   startMenuPressed: 0
-  pointerPressed: 0
-  grabPressed: 0
-  usePressed: 0
-  uiClickPressed: 0
-  menuPressed: 0
+  middleFingerSenseAxisChanged: 0
+  ringFingerSenseAxisChanged: 0
+  pinkyFingerSenseAxisChanged: 0
   controllerVisible: 1
 --- !u!4 &150224874
 Transform:
@@ -788,6 +811,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Spheres
+--- !u!114 &186169662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 186169660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 186169661}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &191322222
 GameObject:
   m_ObjectHideFlags: 0
@@ -849,6 +887,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &191322225
 BoxCollider:
@@ -929,6 +968,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &202726841
 MeshFilter:
@@ -1091,6 +1131,8 @@ SpringJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &223093316
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1106,6 +1148,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Spheres
+--- !u!114 &223093317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 223093312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 223093316}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &291287554
 GameObject:
   m_ObjectHideFlags: 0
@@ -1166,6 +1223,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &291287557
 MeshFilter:
@@ -1226,6 +1284,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!65 &338200179
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1253,6 +1313,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Torso
+--- !u!114 &338200181
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 338200176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 338200180}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &365483936
 GameObject:
   m_ObjectHideFlags: 0
@@ -1306,6 +1381,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!135 &365483938
 SphereCollider:
@@ -1366,9 +1442,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 0, b: 1, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 0, b: 1, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -1383,6 +1460,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!114 &365483943
 MonoBehaviour:
@@ -1431,6 +1511,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18055ba762aa3994f9c10208cd088bc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &369315478 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000010207334600, guid: 41c0760bd81dd084283814f0c432b466,
+    type: 2}
+  m_PrefabInternal: {fileID: 1760973187}
 --- !u!1 &388566456
 GameObject:
   m_ObjectHideFlags: 0
@@ -1509,6 +1594,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &394192774
 BoxCollider:
@@ -1579,6 +1665,177 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 394910853}
   m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: f5a180e78cba3b64d9cffa9c458a391d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &394910856
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 394910853}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &423656763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 423656764}
+  - component: {fileID: 423656772}
+  - component: {fileID: 423656771}
+  - component: {fileID: 423656770}
+  - component: {fileID: 423656769}
+  - component: {fileID: 423656768}
+  - component: {fileID: 423656767}
+  - component: {fileID: 423656766}
+  - component: {fileID: 423656765}
+  m_Layer: 0
+  m_Name: Sphere_Stackable (1)
+  m_TagString: Spheres
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &423656764
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.381, y: 1.375, z: -0.65}
+  m_LocalScale: {x: 0.14999999, y: 0.14999999, z: 0.14999999}
+  m_Children: []
+  m_Father: {fileID: 743911481}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &423656765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c08517e04830d6d44a13c5ea5f574181, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  unhighlightOnDisable: 1
+  thickness: 0.5
+  customOutlineModels: []
+  customOutlineModelPaths: []
+  enableSubmeshHighlight: 0
+--- !u!114 &423656766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18055ba762aa3994f9c10208cd088bc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &423656767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8afa0b205791c9f4496bf2814aeac078, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  precisionGrab: 0
+  rightSnapHandle: {fileID: 0}
+  leftSnapHandle: {fileID: 0}
+  throwVelocityWithAttachDistance: 0
+  throwMultiplier: 1
+  onGrabCollisionDelay: 0
+  destroyImmediatelyOnThrow: 1
+  breakForce: 1500
+--- !u!114 &423656768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableWhenIdle: 1
+  allowedNearTouchControllers: 0
+  allowedTouchControllers: 0
+  ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 0, b: 1, a: 0}
+  isGrabbable: 1
+  holdButtonToGrab: 1
+  stayGrabbedOnTeleport: 1
+  validDrop: 1
+  grabOverrideButton: 0
+  allowedGrabControllers: 0
+  grabAttachMechanicScript: {fileID: 423656767}
+  secondaryGrabActionScript: {fileID: 423656766}
+  isUsable: 0
+  holdButtonToUse: 1
+  useOnlyIfGrabbed: 0
+  pointerActivatesUseAction: 0
+  useOverrideButton: 0
+  allowedUseControllers: 0
+  isStackable: 1
+  objectID: stackableSpheres
+  objectHighlighter: {fileID: 0}
+  usingState: 0
+--- !u!54 &423656769
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!23 &423656770
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_MotionVectors: 1
@@ -1602,14 +1859,27 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!33 &394910856
+--- !u!135 &423656771
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &423656772
 MeshFilter:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 394910853}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+  m_GameObject: {fileID: 423656763}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &432461968
 Prefab:
   m_ObjectHideFlags: 0
@@ -2035,7 +2305,7 @@ Prefab:
     - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 660
+      value: 879
       objectReference: {fileID: 0}
     - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -2097,8 +2367,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 439755038}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2120,6 +2390,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &439755041
 MeshFilter:
@@ -2204,6 +2475,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &475138836
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2249,6 +2522,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!135 &475138838
 SphereCollider:
@@ -2329,6 +2603,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &478650896
 MeshFilter:
@@ -2397,6 +2672,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &491666097
 MeshFilter:
@@ -2503,7 +2779,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
       propertyPath: m_LocalScale.x
@@ -2629,6 +2905,21 @@ MonoBehaviour:
   unhighlightOnDisable: 1
   emissionDarken: 50
   customMaterial: {fileID: 2100000, guid: fd5a094873cfa814b9ca3d4c8a54117f, type: 2}
+--- !u!114 &500423389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 500423385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0.25
+  scaleType: 1
+  validObjectListPolicy: {fileID: 500423387}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &502350259
 GameObject:
   m_ObjectHideFlags: 0
@@ -2689,6 +2980,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &502350262
 MeshFilter:
@@ -2734,8 +3026,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 523789734}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -2757,6 +3049,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &523789737
 MeshFilter:
@@ -2832,6 +3125,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &550770264
 BoxCollider:
@@ -2877,9 +3171,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -2894,6 +3189,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!114 &550770268
 MonoBehaviour:
@@ -2986,6 +3284,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &554083333
 MeshFilter:
@@ -3031,8 +3330,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 568328370}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -3054,6 +3353,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &568328373
 MeshFilter:
@@ -3062,6 +3362,100 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 568328370}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &572383321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 572383322}
+  - component: {fileID: 572383325}
+  - component: {fileID: 572383324}
+  - component: {fileID: 572383323}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &572383322
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572383321}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.0005, y: 0.0005, z: 0.1}
+  m_Children:
+  - {fileID: 850891205}
+  m_Father: {fileID: 1329380603}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.0798, y: 0}
+  m_SizeDelta: {x: 300, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &572383323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572383321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &572383324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572383321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &572383325
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572383321}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1001 &585266932
 Prefab:
   m_ObjectHideFlags: 0
@@ -3189,8 +3583,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 638829500}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -3212,6 +3606,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &638829503
 MeshFilter:
@@ -3220,6 +3615,138 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 638829500}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &644886811
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 1.726
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -0.795
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 135000010323760288, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: m_Radius
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: highlightObjectPrefab
+      value: 
+      objectReference: {fileID: 365483936}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: highlightColor.r
+      value: 0.5724139
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: highlightColor.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: highlightColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: snapType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1000010066341254, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_Name
+      value: Sphere_Stackable_SnapDropZone
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: validObjectWithTagOrClass
+      value: Spheres
+      objectReference: {fileID: 0}
+    - target: {fileID: 1000010066341254, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: validObjectTagOrScriptListPolicy
+      value: 
+      objectReference: {fileID: 1329380597}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: validObjectListPolicy
+      value: 
+      objectReference: {fileID: 1329380597}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: cloneNewOnUnsnap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: applyScalingOnSnap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: allowStacking
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: stackType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012880271118, guid: 5d323709f0cbd454196647d9d8f2dd84,
+        type: 2}
+      propertyPath: snapDuration
+      value: 0.1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &682849862
 GameObject:
   m_ObjectHideFlags: 0
@@ -3281,6 +3808,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &682849865
 BoxCollider:
@@ -3459,6 +3987,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Cubes
+--- !u!114 &707219611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 707219609}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 707219610}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1001 &717730733
 Prefab:
   m_ObjectHideFlags: 0
@@ -3592,6 +4135,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Spheres
+--- !u!114 &717730737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 717730735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 1
+  validObjectListPolicy: {fileID: 717730736}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &720633271
 GameObject:
   m_ObjectHideFlags: 0
@@ -3675,6 +4233,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &721340394
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3690,6 +4250,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Arm
+--- !u!114 &721340395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 721340391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 721340394}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &731679016
 GameObject:
   m_ObjectHideFlags: 0
@@ -3757,8 +4332,13 @@ Transform:
   - {fileID: 1141041444}
   - {fileID: 1199898130}
   - {fileID: 1734605856}
+  - {fileID: 2118509906}
   - {fileID: 123850897}
   - {fileID: 16330800}
+  - {fileID: 423656764}
+  - {fileID: 1042250507}
+  - {fileID: 1511795770}
+  - {fileID: 988520764}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3799,8 +4379,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 746045775}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -3822,6 +4402,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &746045778
 MeshFilter:
@@ -3879,9 +4460,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -3896,6 +4478,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &756550054
 MeshRenderer:
@@ -3927,6 +4512,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &756550055
 CapsuleCollider:
@@ -4028,8 +4614,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 758529183}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -4051,6 +4637,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &758529186
 MeshFilter:
@@ -4132,6 +4719,7 @@ MonoBehaviour:
   - {fileID: 1760973191}
   - {fileID: 1760973190}
   - {fileID: 1760973188}
+  excludeTargetGroups: 1b0000001a000000
 --- !u!4 &832467266
 Transform:
   m_ObjectHideFlags: 0
@@ -4145,8 +4733,82 @@ Transform:
   - {fileID: 1760973189}
   - {fileID: 432461969}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &850891204
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 850891205}
+  - component: {fileID: 850891207}
+  - component: {fileID: 850891206}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &850891205
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 850891204}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.4374999, y: 1.68625, z: 1}
+  m_Children: []
+  m_Father: {fileID: 572383322}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -150, y: 85}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &850891206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 850891204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 8
+    m_AlignByGeometry: 1
+    m_RichText: 0
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 0
+--- !u!222 &850891207
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 850891204}
 --- !u!1 &874733995
 GameObject:
   m_ObjectHideFlags: 0
@@ -4184,8 +4846,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 874733995}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -4207,6 +4869,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &874733998
 MeshFilter:
@@ -4215,6 +4878,105 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 874733995}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &874783436
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 874783437}
+  - component: {fileID: 874783439}
+  - component: {fileID: 874783438}
+  m_Layer: 0
+  m_Name: EditorHighlightObject
+  m_TagString: Spheres
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &874783437
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 874783436}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
+  m_Children: []
+  m_Father: {fileID: 878075999}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &874783438
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 874783436}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 76008b803511a8e4c91d6f9bacc10161, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &874783439
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 874783436}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &878075998
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 878075999}
+  m_Layer: 0
+  m_Name: HighlightContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &878075999
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 878075998}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1421152640}
+  - {fileID: 874783437}
+  m_Father: {fileID: 1329380603}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &917345519
 GameObject:
   m_ObjectHideFlags: 0
@@ -4306,6 +5068,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!135 &921052832
 SphereCollider:
@@ -4399,6 +5162,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &939538483
 MeshFilter:
@@ -4451,6 +5215,8 @@ FixedJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &944856949
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -4496,6 +5262,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!135 &944856951
 SphereCollider:
@@ -4553,8 +5320,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 945731557}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -4576,6 +5343,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &945731560
 MeshFilter:
@@ -4777,6 +5545,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &963637306
 BoxCollider:
@@ -4796,6 +5565,88 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 963637303}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &988520763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 988520764}
+  - component: {fileID: 988520767}
+  - component: {fileID: 988520766}
+  - component: {fileID: 988520765}
+  m_Layer: 0
+  m_Name: SphereStackPlate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &988520764
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 988520763}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.8543, y: 1.5124, z: -0.8}
+  m_LocalScale: {x: 0.39999998, y: 0.02, z: 0.39999998}
+  m_Children: []
+  m_Father: {fileID: 743911481}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &988520765
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 988520763}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: d9eb36ce766d5ce4fb2fe51574003ab8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &988520766
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 988520763}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &988520767
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 988520763}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1015537595
 GameObject:
@@ -4846,9 +5697,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -4863,6 +5715,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1015537598
 MeshRenderer:
@@ -4894,6 +5749,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1015537599
 CapsuleCollider:
@@ -5018,6 +5874,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1016017970
 MeshFilter:
@@ -5086,6 +5943,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1020846631
 MeshFilter:
@@ -5186,6 +6044,189 @@ Prefab:
     - {fileID: 135000010323760288, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: 5d323709f0cbd454196647d9d8f2dd84, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &1042250506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1042250507}
+  - component: {fileID: 1042250515}
+  - component: {fileID: 1042250514}
+  - component: {fileID: 1042250513}
+  - component: {fileID: 1042250512}
+  - component: {fileID: 1042250511}
+  - component: {fileID: 1042250510}
+  - component: {fileID: 1042250509}
+  - component: {fileID: 1042250508}
+  m_Layer: 0
+  m_Name: Sphere_Stackable (2)
+  m_TagString: Spheres
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1042250507
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.381, y: 1.375, z: -0.869}
+  m_LocalScale: {x: 0.14999999, y: 0.14999999, z: 0.14999999}
+  m_Children: []
+  m_Father: {fileID: 743911481}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1042250508
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c08517e04830d6d44a13c5ea5f574181, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  unhighlightOnDisable: 1
+  thickness: 0.5
+  customOutlineModels: []
+  customOutlineModelPaths: []
+  enableSubmeshHighlight: 0
+--- !u!114 &1042250509
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18055ba762aa3994f9c10208cd088bc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1042250510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8afa0b205791c9f4496bf2814aeac078, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  precisionGrab: 0
+  rightSnapHandle: {fileID: 0}
+  leftSnapHandle: {fileID: 0}
+  throwVelocityWithAttachDistance: 0
+  throwMultiplier: 1
+  onGrabCollisionDelay: 0
+  destroyImmediatelyOnThrow: 1
+  breakForce: 1500
+--- !u!114 &1042250511
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableWhenIdle: 1
+  allowedNearTouchControllers: 0
+  allowedTouchControllers: 0
+  ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 0, b: 1, a: 0}
+  isGrabbable: 1
+  holdButtonToGrab: 1
+  stayGrabbedOnTeleport: 1
+  validDrop: 1
+  grabOverrideButton: 0
+  allowedGrabControllers: 0
+  grabAttachMechanicScript: {fileID: 1042250510}
+  secondaryGrabActionScript: {fileID: 1042250509}
+  isUsable: 0
+  holdButtonToUse: 1
+  useOnlyIfGrabbed: 0
+  pointerActivatesUseAction: 0
+  useOverrideButton: 0
+  allowedUseControllers: 0
+  isStackable: 1
+  objectID: stackableSpheres
+  objectHighlighter: {fileID: 0}
+  usingState: 0
+--- !u!54 &1042250512
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!23 &1042250513
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: f5a180e78cba3b64d9cffa9c458a391d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &1042250514
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1042250515
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1042250506}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1121303425
 GameObject:
   m_ObjectHideFlags: 0
@@ -5260,6 +6301,8 @@ FixedJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &1125294803
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -5305,6 +6348,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!135 &1125294805
 SphereCollider:
@@ -5325,6 +6369,11 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1125294800}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1133835762 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000010517668602, guid: 41c0760bd81dd084283814f0c432b466,
+    type: 2}
+  m_PrefabInternal: {fileID: 1760973187}
 --- !u!1 &1135670851
 GameObject:
   m_ObjectHideFlags: 0
@@ -5373,6 +6422,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1135670853
 BoxCollider:
@@ -5467,6 +6517,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1141041446
 BoxCollider:
@@ -5565,6 +6616,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &1156011845
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -5592,9 +6645,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -5609,6 +6663,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1156011847
 MeshRenderer:
@@ -5640,6 +6697,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1156011848
 CapsuleCollider:
@@ -5781,6 +6839,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1195194459
 MeshFilter:
@@ -5850,6 +6909,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1199898132
 BoxCollider:
@@ -5898,8 +6958,13 @@ Transform:
   - {fileID: 1355078027}
   - {fileID: 150224874}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1220153972 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000014132296520, guid: 41c0760bd81dd084283814f0c432b466,
+    type: 2}
+  m_PrefabInternal: {fileID: 1760973187}
 --- !u!1 &1247388464
 GameObject:
   m_ObjectHideFlags: 0
@@ -5960,6 +7025,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1247388467
 MeshFilter:
@@ -5968,6 +7034,11 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1247388464}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1275544887 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000011766909148, guid: 41c0760bd81dd084283814f0c432b466,
+    type: 2}
+  m_PrefabInternal: {fileID: 1760973187}
 --- !u!1 &1322842848
 GameObject:
   m_ObjectHideFlags: 0
@@ -6028,6 +7099,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1322842851
 MeshFilter:
@@ -6036,6 +7108,147 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1322842848}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1329380596 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000010066341254, guid: 5d323709f0cbd454196647d9d8f2dd84,
+    type: 2}
+  m_PrefabInternal: {fileID: 644886811}
+--- !u!114 &1329380597
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329380596}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ed2aa1a29b92ca4f84a26a5f6e9218b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  operation: 1
+  checkType: 1
+  identifiers:
+  - Spheres
+--- !u!114 &1329380598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329380596}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c08517e04830d6d44a13c5ea5f574181, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  unhighlightOnDisable: 1
+  thickness: 0.5
+  customOutlineModels: []
+  customOutlineModelPaths: []
+  enableSubmeshHighlight: 0
+--- !u!114 &1329380599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329380596}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0.1
+  scaleType: 0
+  validObjectListPolicy: {fileID: 1329380597}
+  defaultSnappedInteractableObject: {fileID: 0}
+--- !u!145 &1329380602
+SpringJoint:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329380596}
+  m_ConnectedBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0, z: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_ConnectedAnchor: {x: 1.15, y: 1.726, z: -0.795}
+  serializedVersion: 2
+  m_Spring: 1000
+  m_Damper: 100
+  m_MinDistance: 0
+  m_MaxDistance: 0
+  m_Tolerance: 0.025
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!4 &1329380603 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4000013912359922, guid: 5d323709f0cbd454196647d9d8f2dd84,
+    type: 2}
+  m_PrefabInternal: {fileID: 644886811}
+--- !u!1 &1350341081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1350341084}
+  - component: {fileID: 1350341083}
+  - component: {fileID: 1350341082}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1350341082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1350341081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1350341083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1350341081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
+--- !u!4 &1350341084
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1350341081}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1353655387
 GameObject:
   m_ObjectHideFlags: 0
@@ -6073,8 +7286,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1353655387}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -6096,6 +7309,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1353655390
 MeshFilter:
@@ -6163,13 +7377,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eba3cd5456cd79e49948f5ceb58544b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pointerToggleButton: 10
-  pointerSetButton: 10
-  grabToggleButton: 7
-  useToggleButton: 3
-  uiClickButton: 3
-  menuToggleButton: 14
   axisFidelity: 1
+  senseAxisForceZeroThreshold: 0.15
+  senseAxisPressThreshold: 0.95
   triggerClickThreshold: 1
   triggerForceZeroThreshold: 0.01
   triggerAxisZeroOnUntouch: 0
@@ -6181,6 +7391,7 @@ MonoBehaviour:
   triggerHairlinePressed: 0
   triggerClicked: 0
   triggerAxisChanged: 0
+  triggerSenseAxisChanged: 0
   gripPressed: 0
   gripTouched: 0
   gripHairlinePressed: 0
@@ -6189,16 +7400,17 @@ MonoBehaviour:
   touchpadPressed: 0
   touchpadTouched: 0
   touchpadAxisChanged: 0
+  touchpadSenseAxisChanged: 0
+  touchpadTwoTouched: 0
+  touchpadTwoAxisChanged: 0
   buttonOnePressed: 0
   buttonOneTouched: 0
   buttonTwoPressed: 0
   buttonTwoTouched: 0
   startMenuPressed: 0
-  pointerPressed: 0
-  grabPressed: 0
-  usePressed: 0
-  uiClickPressed: 0
-  menuPressed: 0
+  middleFingerSenseAxisChanged: 0
+  ringFingerSenseAxisChanged: 0
+  pinkyFingerSenseAxisChanged: 0
   controllerVisible: 1
 --- !u!4 &1355078027
 Transform:
@@ -6291,6 +7503,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1382961363
 BoxCollider:
@@ -6376,6 +7589,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &1387219892
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6391,6 +7606,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Arm
+--- !u!114 &1387219893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1387219889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 1387219892}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &1396593265
 GameObject:
   m_ObjectHideFlags: 0
@@ -6421,6 +7651,75 @@ Transform:
   m_Father: {fileID: 1387219890}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1421152639
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1421152640}
+  - component: {fileID: 1421152642}
+  - component: {fileID: 1421152641}
+  m_Layer: 0
+  m_Name: HighlightObject
+  m_TagString: Spheres
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1421152640
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1421152639}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
+  m_Children: []
+  m_Father: {fileID: 878075999}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1421152641
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1421152639}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: f5a180e78cba3b64d9cffa9c458a391d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1421152642
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1421152639}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1457627802
 GameObject:
   m_ObjectHideFlags: 0
@@ -6470,9 +7769,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -6487,6 +7787,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1457627805
 MeshRenderer:
@@ -6518,6 +7821,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1457627806
 CapsuleCollider:
@@ -6640,9 +7944,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -6657,6 +7962,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &1477721420
 Rigidbody:
@@ -6776,6 +8084,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1487149706
 MeshFilter:
@@ -6844,6 +8153,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1487737914
 MeshFilter:
@@ -6852,6 +8162,194 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1487737911}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1511795769
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1511795770}
+  - component: {fileID: 1511795778}
+  - component: {fileID: 1511795777}
+  - component: {fileID: 1511795776}
+  - component: {fileID: 1511795775}
+  - component: {fileID: 1511795774}
+  - component: {fileID: 1511795773}
+  - component: {fileID: 1511795772}
+  - component: {fileID: 1511795771}
+  m_Layer: 0
+  m_Name: Sphere_Stackable (3)
+  m_TagString: Spheres
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1511795770
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.496, y: 1.375, z: -0.761}
+  m_LocalScale: {x: 0.14999999, y: 0.14999999, z: 0.14999999}
+  m_Children: []
+  m_Father: {fileID: 743911481}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1511795771
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c08517e04830d6d44a13c5ea5f574181, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  unhighlightOnDisable: 1
+  thickness: 0.5
+  customOutlineModels: []
+  customOutlineModelPaths: []
+  enableSubmeshHighlight: 0
+--- !u!114 &1511795772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18055ba762aa3994f9c10208cd088bc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1511795773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8afa0b205791c9f4496bf2814aeac078, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  precisionGrab: 0
+  rightSnapHandle: {fileID: 0}
+  leftSnapHandle: {fileID: 0}
+  throwVelocityWithAttachDistance: 0
+  throwMultiplier: 1
+  onGrabCollisionDelay: 0
+  destroyImmediatelyOnThrow: 1
+  breakForce: 1500
+--- !u!114 &1511795774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableWhenIdle: 1
+  allowedNearTouchControllers: 0
+  allowedTouchControllers: 0
+  ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 0, b: 1, a: 0}
+  isGrabbable: 1
+  holdButtonToGrab: 1
+  stayGrabbedOnTeleport: 1
+  validDrop: 1
+  grabOverrideButton: 0
+  allowedGrabControllers: 0
+  grabAttachMechanicScript: {fileID: 1511795773}
+  secondaryGrabActionScript: {fileID: 1511795772}
+  isUsable: 0
+  holdButtonToUse: 1
+  useOnlyIfGrabbed: 0
+  pointerActivatesUseAction: 0
+  useOverrideButton: 0
+  allowedUseControllers: 0
+  isStackable: 1
+  objectID: stackableSpheres
+  objectHighlighter: {fileID: 0}
+  usingState: 0
+--- !u!54 &1511795775
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!23 &1511795776
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: f5a180e78cba3b64d9cffa9c458a391d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &1511795777
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1511795778
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1511795769}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1529177424 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000013731061326, guid: 41c0760bd81dd084283814f0c432b466,
+    type: 2}
+  m_PrefabInternal: {fileID: 1760973187}
 --- !u!1 &1563557789
 GameObject:
   m_ObjectHideFlags: 0
@@ -6901,9 +8399,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -6918,6 +8417,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1563557792
 MeshRenderer:
@@ -6949,6 +8451,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1563557793
 CapsuleCollider:
@@ -7091,6 +8594,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &1583407961
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -7118,9 +8623,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -7135,6 +8641,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1583407963
 MeshRenderer:
@@ -7166,6 +8675,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1583407964
 CapsuleCollider:
@@ -7284,6 +8794,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!135 &1610967778
 SphereCollider:
@@ -7329,9 +8840,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -7346,6 +8858,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!114 &1610967782
 MonoBehaviour:
@@ -7377,6 +8892,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18055ba762aa3994f9c10208cd088bc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1616613719 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000010636551700, guid: 41c0760bd81dd084283814f0c432b466,
+    type: 2}
+  m_PrefabInternal: {fileID: 1760973187}
 --- !u!1 &1692954784
 GameObject:
   m_ObjectHideFlags: 0
@@ -7486,6 +9006,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &1695119062
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -7513,9 +9035,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -7530,6 +9053,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1695119064
 MeshRenderer:
@@ -7561,6 +9087,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1695119065
 CapsuleCollider:
@@ -7702,9 +9229,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 1, g: 1, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -7719,6 +9247,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &1719093154
 Rigidbody:
@@ -7838,6 +9369,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1734605858
 BoxCollider:
@@ -7931,6 +9463,66 @@ Prefab:
       propertyPath: modelAliasRightController
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualBoundaries
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualHeadset
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualLeftController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualRightController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasLeftController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasRightController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualBoundaries
+      value: 
+      objectReference: {fileID: 369315478}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualHeadset
+      value: 
+      objectReference: {fileID: 1220153972}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualLeftController
+      value: 
+      objectReference: {fileID: 1616613719}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualRightController
+      value: 
+      objectReference: {fileID: 1529177424}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasLeftController
+      value: 
+      objectReference: {fileID: 1133835762}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasRightController
+      value: 
+      objectReference: {fileID: 1275544887}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 41c0760bd81dd084283814f0c432b466, type: 2}
   m_IsPrefabParent: 0
@@ -8037,8 +9629,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1774213494}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -8060,6 +9652,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1774213497
 MeshFilter:
@@ -8110,7 +9703,7 @@ Transform:
   m_Children:
   - {fileID: 554083330}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1835964711
 GameObject:
@@ -8149,8 +9742,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1835964711}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -8172,6 +9765,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1835964714
 MeshFilter:
@@ -8258,6 +9852,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &1849463934
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -8285,9 +9881,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -8302,6 +9899,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1849463936
 MeshRenderer:
@@ -8333,6 +9933,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!136 &1849463937
 CapsuleCollider:
@@ -8444,6 +10045,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1855537435
 MeshFilter:
@@ -8489,8 +10091,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1866221005}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -8512,6 +10114,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1866221008
 MeshFilter:
@@ -8549,6 +10152,7 @@ GameObject:
   - component: {fileID: 1897168828}
   - component: {fileID: 1897168827}
   - component: {fileID: 1897168831}
+  - component: {fileID: 1897168832}
   m_Layer: 0
   m_Name: RightLegDropZone
   m_TagString: Untagged
@@ -8598,6 +10202,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!136 &1897168828
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -8643,11 +10249,15 @@ MonoBehaviour:
   snapType: 1
   snapDuration: 0
   applyScalingOnSnap: 0
+  cloneNewOnUnsnap: 0
   highlightColor: {r: 1, g: 0, b: 0, a: 0}
+  validHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   highlightAlwaysActive: 0
   validObjectListPolicy: {fileID: 1897168831}
   displayDropZoneInEditor: 1
+  snapAttachMechanicScript: {fileID: 1897168832}
   defaultSnappedObject: {fileID: 0}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!114 &1897168831
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8663,6 +10273,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Leg
+--- !u!114 &1897168832
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1897168826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 1897168831}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &1938511125
 GameObject:
   m_ObjectHideFlags: 0
@@ -8724,6 +10349,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1938511128
 BoxCollider:
@@ -8922,6 +10548,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &1954792373
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8937,6 +10565,21 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Leg
+--- !u!114 &1954792374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1954792370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 0
+  validObjectListPolicy: {fileID: 1954792373}
+  defaultSnappedInteractableObject: {fileID: 0}
 --- !u!1 &1972604675
 GameObject:
   m_ObjectHideFlags: 0
@@ -9025,7 +10668,7 @@ Transform:
   m_Children:
   - {fileID: 2131464789}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2033784374
 GameObject:
@@ -9121,6 +10764,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2035492400
 BoxCollider:
@@ -9205,9 +10849,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders: []
+  touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   isGrabbable: 1
   holdButtonToGrab: 1
   stayGrabbedOnTeleport: 1
@@ -9222,6 +10867,9 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  isStackable: 0
+  objectID: defaultInteractableObjectID
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &2084466894
 MeshRenderer:
@@ -9253,6 +10901,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2084466895
 BoxCollider:
@@ -9481,6 +11130,103 @@ MonoBehaviour:
   checkType: 1
   identifiers:
   - Saucers
+--- !u!114 &2107897286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2107897283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2d07c7c293044f9148171b53427f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  snapDuration: 0
+  scaleType: 1
+  validObjectListPolicy: {fileID: 2107897285}
+  defaultSnappedInteractableObject: {fileID: 0}
+--- !u!1 &2118509905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2118509906}
+  - component: {fileID: 2118509909}
+  - component: {fileID: 2118509908}
+  - component: {fileID: 2118509907}
+  m_Layer: 0
+  m_Name: Body Bits Table Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2118509906
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2118509905}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.864, y: 1.001, z: -0.8025}
+  m_LocalScale: {x: 0.19999999, y: 1, z: 0.3944533}
+  m_Children: []
+  m_Father: {fileID: 743911481}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2118509907
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2118509905}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 2be9fb9bcea91e7419d90800fabf8e0d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &2118509908
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2118509905}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &2118509909
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2118509905}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &2121472633
 GameObject:
   m_ObjectHideFlags: 0
@@ -9518,8 +11264,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2121472633}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -9541,6 +11287,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2121472636
 MeshFilter:
@@ -9572,7 +11319,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2123877843}
   m_Enabled: 1
-  serializedVersion: 7
+  serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
@@ -9597,6 +11344,22 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &2123877845
@@ -9672,6 +11435,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2125161420
 MeshFilter:

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/SnapDropZoneGroup_Switcher.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/SnapDropZoneGroup_Switcher.cs
@@ -25,7 +25,7 @@
 
         private void DoCubeZoneSnapped(object sender, SnapDropZoneEventArgs e)
         {
-            if (sphereZone.GetCurrentSnappedObject() == null)
+            if (sphereZone.snapAttachMechanicScript.GetCurrentSnappedObject() == null)
             {
                 sphereZone.gameObject.SetActive(false);
             }
@@ -33,7 +33,7 @@
 
         private void DoCubeZoneUnsnapped(object sender, SnapDropZoneEventArgs e)
         {
-            if (cubeZone.GetCurrentSnappedObject() == null)
+            if (cubeZone.snapAttachMechanicScript.GetCurrentSnappedObject() == null)
             {
                 sphereZone.gameObject.SetActive(true);
             }
@@ -41,7 +41,7 @@
 
         private void DoSphereZoneSnapped(object sender, SnapDropZoneEventArgs e)
         {
-            if (cubeZone.GetCurrentSnappedObject() == null)
+            if (cubeZone.snapAttachMechanicScript.GetCurrentSnappedObject() == null)
             {
                 cubeZone.gameObject.SetActive(false);
             }
@@ -49,7 +49,7 @@
 
         private void DoSphereZoneUnsnapped(object sender, SnapDropZoneEventArgs e)
         {
-            if (sphereZone.GetCurrentSnappedObject() == null)
+            if (sphereZone.snapAttachMechanicScript.GetCurrentSnappedObject() == null)
             {
                 cubeZone.gameObject.SetActive(true);
             }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f5e6a285fc77878469337f1b4ccb9555
+folderAsset: yes
+timeCreated: 1507993800
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_BaseSnapAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_BaseSnapAttach.cs
@@ -1,0 +1,592 @@
+﻿// Base Snap Attach|SnapAttachMechanics
+namespace VRTK.SnapAttachMechanics
+{
+    using UnityEngine;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides a base that all mechanics for snapping to a `VRTK_SnapDropZone' can inherit from.
+    /// </summary>
+    /// <remarks>
+    /// **Script Usage:**
+    ///   > This is an abstract class that is to be inherited to a concrete class that provides grab attach functionality, therefore this script should not be directly used.
+    /// </remarks>
+
+    [ExecuteInEditMode]
+    public abstract class VRTK_BaseSnapAttach : MonoBehaviour
+    {
+        /// <summary>
+        /// The types of object stacking available.
+        /// </summary>
+        public enum ScaleTypes
+        {
+            /// <summary>
+            /// The snapped Interactable Object will not be scaled.
+            /// </summary>
+            None,
+            /// <summary>
+            /// The snapped Interactable Object will be given the same scale as the Snap Drop Zone.
+            /// </summary>
+            MatchScale,
+            /// <summary>
+            /// The snapped Interactable Object will be scaled to fit within the bounds of the Snap Drop Zone highlight object.
+            /// </summary>
+            MatchBounds
+        }
+
+        [Tooltip("The amount of time it takes for the object being snapped to move into the new snapped position, rotation and scale.")]
+        public float snapDuration = 0f;
+        [Tooltip("How snapped objects should be scaled when dropped into the `VRTK_SnapDropZone`.")]
+        public ScaleTypes scaleType = ScaleTypes.None;
+        [Tooltip("A specified VRTK_PolicyList to use to determine which interactable objects will be snapped to the snap drop zone on release.")]
+        public VRTK_PolicyList validObjectListPolicy;
+        [Tooltip("The Interactable Object to snap into the dropzone when the drop zone is enabled. The Interactable Object must be valid in any given policy list to snap.")]
+        public VRTK_InteractableObject defaultSnappedInteractableObject;
+
+        protected VRTK_SnapDropZone pairedSnapDropZone = null;
+        protected List<VRTK_InteractableObject> currentValidSnapInteractableObjects = new List<VRTK_InteractableObject>();
+        protected VRTK_InteractableObject currentSnappedObject = null;
+        
+        protected bool willSnap = false;
+        protected bool isSnapped = false;
+        protected bool wasSnapped = false;
+
+        protected Coroutine transitionInPlaceRoutine;
+        protected Coroutine attemptTransitionAtEndOfFrameRoutine;
+        protected Coroutine checkCanSnapRoutine;
+        protected bool originalJointCollisionState = false;
+
+        /// <summary>
+        /// The GetHoveringInteractableObjects method returns a List of valid Interactable Object scripts that are currently hovering (but not snapped) in the snap drop zone area.
+        /// </summary>
+        /// <returns>The List of valid Interactable Object scripts that are hovering (but not snapped) in the snap drop zone area.</returns>
+        public virtual List<VRTK_InteractableObject> GetHoveringInteractableObjects()
+        {
+            return currentValidSnapInteractableObjects;
+        }
+
+        /// <summary>
+        /// The GetCurrentSnappedObejct method returns the GameObject that is currently snapped in the Snap Drop Zone area.
+        /// </summary>
+        /// <returns>The GameObject that is currently snapped in the Snap Drop Zone area.</returns>
+        public virtual GameObject GetCurrentSnappedObject()
+        {
+            return (currentSnappedObject != null ? currentSnappedObject.gameObject : null);
+        }
+
+        /// <summary>
+        /// The GetCurrentSnappedInteractableObject method returns the Interactable Object script that is currently snapped in the Snap Drop Zone area.
+        /// </summary>
+        /// <returns>The Interactable Object script that is currently snapped in the snap Drop Zone Area.</returns>
+        public virtual VRTK_InteractableObject GetCurrentSnappedInteractableObject()
+        {
+            return currentSnappedObject;
+        }
+
+        protected virtual void OnEnable()
+        {
+            pairedSnapDropZone = gameObject.GetComponentInParent<VRTK_SnapDropZone>();
+            currentValidSnapInteractableObjects.Clear();
+            currentSnappedObject = null;
+            willSnap = false;
+            isSnapped = false;
+            wasSnapped = false;
+
+            ///[Obsolete] Move deprecated properties over gracefully
+#pragma warning disable 618
+            if (pairedSnapDropZone.snapDuration != 0f && snapDuration == 0f)
+            {
+                snapDuration = pairedSnapDropZone.snapDuration;
+                //Wipe the deprecated value after moving it over so that this code only runs once, even if snapDuration is later intentionally set to 0f
+                pairedSnapDropZone.snapDuration = 0f;
+            }
+
+            if (pairedSnapDropZone.applyScalingOnSnap != false && scaleType == ScaleTypes.None)
+            {
+                scaleType = ScaleTypes.MatchScale;
+                //Wipe the deprecated value after moving it over so that this code only runs once, even if scaleType is later changed from MatchScale
+                pairedSnapDropZone.applyScalingOnSnap = false;
+            }
+
+            if (pairedSnapDropZone.validObjectListPolicy != null && validObjectListPolicy == null)
+            {
+                validObjectListPolicy = pairedSnapDropZone.validObjectListPolicy;
+            }
+
+            if (defaultSnappedInteractableObject == null)
+            {
+                //When handling deprecation for the already obselete defaultSnappedObject property
+                if (pairedSnapDropZone.defaultSnappedObject != null)
+                {
+                    defaultSnappedInteractableObject = pairedSnapDropZone.defaultSnappedObject.GetComponentInParent<VRTK_InteractableObject>();
+                    if (defaultSnappedInteractableObject != null)
+                    {
+                        pairedSnapDropZone.defaultSnappedObject = null;
+                    }
+                }
+                //When handling deprecation for the defaultSnappedInteractableObject property for those users who have been on the 3.3.0 alpha branch
+                if (pairedSnapDropZone.defaultSnappedInteractableObject != null)
+                {
+                    defaultSnappedInteractableObject = pairedSnapDropZone.defaultSnappedInteractableObject.GetComponentInParent<VRTK_InteractableObject>();
+                    if (defaultSnappedInteractableObject != null) 
+                    {
+                        pairedSnapDropZone.defaultSnappedInteractableObject = null;    
+                    }
+                } 
+            }
+#pragma warning restore 618
+
+            if (!VRTK_SharedMethods.IsEditTime() && Application.isPlaying && defaultSnappedInteractableObject != null)
+            {
+                ForceSnap(defaultSnappedInteractableObject);
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            //Stop any active animation or snapping coroutines
+            if (transitionInPlaceRoutine != null)
+            {
+                StopCoroutine(transitionInPlaceRoutine);
+            }
+
+            if (attemptTransitionAtEndOfFrameRoutine != null)
+            {
+                StopCoroutine(attemptTransitionAtEndOfFrameRoutine);
+            }
+
+            if (checkCanSnapRoutine != null)
+            {
+                StopCoroutine(checkCanSnapRoutine);
+            }
+
+            ForceUnsnap();
+            UnregisterAllGrabEvents();
+        }
+
+        /// <summary>
+        /// The IsSnapped method returns true if an Interactable Object is currently snapped to the Snap Drop Zone paired with this attach script
+        /// </summary>
+        /// <returns>Whetehr an Interactable Object is currently snapped to the Snap Drop Zone paired with this attach script.</returns>
+        public virtual bool IsSnapped()
+        {
+            return isSnapped;
+        }
+
+        /// <summary>
+        /// The CheckCanSnap method tests to see if an Interactable Object can be snapped to the Snap Drop Zone paired with this attach script, and then triggers a snap event.
+        /// </summary>
+        /// /// <param name="interactableObjectCheck">The Interactable Object to test.</param>
+        public virtual void CheckCanSnap(VRTK_InteractableObject interactableObjectCheck)
+        {
+            if (interactableObjectCheck != null)
+            {
+                AddCurrentValidSnapObject(interactableObjectCheck);
+                if (!isSnapped && ValidSnapObject(interactableObjectCheck, true))
+                {
+                    pairedSnapDropZone.ToggleHighlight(interactableObjectCheck, true);
+                    interactableObjectCheck.SetSnapDropZoneHover(pairedSnapDropZone, true);
+                    if (!willSnap)
+                    {
+                        pairedSnapDropZone.OnObjectEnteredSnapDropZone(pairedSnapDropZone.SetSnapDropZoneEvent(interactableObjectCheck.gameObject));
+                    }
+                    willSnap = true;
+                    pairedSnapDropZone.ToggleHighlightColor();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The ForceSnap method attempts to automatically attach a valid GameObject to the snap drop zone.
+        /// </summary>
+        /// <param name="objectToSnap">The GameObject to attempt to snap.</param>
+        public virtual void ForceSnap(GameObject objectToSnap)
+        {
+            ForceSnap(objectToSnap.GetComponentInParent<VRTK_InteractableObject>());
+        }
+
+        /// <summary>
+        /// The ForceSnap method attempts to automatically attach a valid Interactable Object to the snap drop zone.
+        /// </summary>
+        /// <param name="interactableObjectToSnap">The Interactable Object to attempt to snap.</param>
+        public virtual void ForceSnap(VRTK_InteractableObject interactableObjectToSnap)
+        {
+            if (interactableObjectToSnap != null)
+            {
+                if (attemptTransitionAtEndOfFrameRoutine != null)
+                {
+                    StopCoroutine(attemptTransitionAtEndOfFrameRoutine);
+                }
+
+                if (checkCanSnapRoutine != null)
+                {
+                    StopCoroutine(checkCanSnapRoutine);
+                }
+
+                if (interactableObjectToSnap.IsGrabbed())
+                {
+                    interactableObjectToSnap.ForceStopInteracting();
+                }
+
+                if (gameObject.activeInHierarchy)
+                {
+                    attemptTransitionAtEndOfFrameRoutine = StartCoroutine(AttemptForceSnapAtEndOfFrame(interactableObjectToSnap));
+                }
+            }
+        }
+
+        protected virtual IEnumerator AttemptForceSnapAtEndOfFrame(VRTK_InteractableObject objectToSnap)
+        {
+            yield return new WaitForEndOfFrame();
+            objectToSnap.SaveCurrentState();
+            AttemptForceSnap(objectToSnap);
+        }
+
+        protected virtual void AttemptForceSnap(VRTK_InteractableObject objectToSnap)
+        {
+            //Force snap settings on
+            willSnap = true;
+            //Force touch one of the Interactable Objects's colliders on this trigger collider
+            SnapObjectToZone(objectToSnap);
+        }
+
+        protected virtual void SnapObjectToZone(VRTK_InteractableObject objectToSnap)
+        {
+            //Snap if the Interactable Object if not already snapped and if both valid and not currently grabbed
+            if (!isSnapped && ValidSnapObject(objectToSnap, false))
+            {
+                SnapObject(objectToSnap);
+            }
+        }
+
+        /// <summary>
+        /// The SnapObject method implements the logic for snapping Interactable Objects to the paired Snap Drop Zone.
+        /// </summary>
+        protected virtual void SnapObject(VRTK_InteractableObject interactableObjectCheck)
+        {
+            
+        }
+
+        /// <summary>
+        /// The CheckCanUnsnap method tests to see if an Interactable Object is available to be unsnapped, and if so, runs through the unsnap logic.
+        /// </summary>
+        public virtual void CheckCanUnsnap(VRTK_InteractableObject interactableObjectCheck)
+        {
+            if (interactableObjectCheck != null && currentValidSnapInteractableObjects.Contains(interactableObjectCheck) && ValidUnsnap(interactableObjectCheck))
+            {
+                if (isSnapped && currentSnappedObject == interactableObjectCheck)
+                {
+                    ForceUnsnap();
+                }
+
+                RemoveCurrentValidSnapObject(interactableObjectCheck);
+
+                if (!pairedSnapDropZone.ValidSnappableObjectIsHovering())
+                {
+                    pairedSnapDropZone.ToggleHighlight(interactableObjectCheck, false);
+                    willSnap = false;
+                }
+
+                interactableObjectCheck.SetSnapDropZoneHover(pairedSnapDropZone, false);
+
+                if (ValidSnapObject(interactableObjectCheck, true))
+                {
+                    pairedSnapDropZone.ToggleHighlightColor();
+                    pairedSnapDropZone.OnObjectExitedSnapDropZone(pairedSnapDropZone.SetSnapDropZoneEvent(interactableObjectCheck.gameObject));
+                }
+            }
+        }
+
+        /// <summary>
+        /// The ForceUnsnap method attempts to automatically remove the current snapped game object from the snap drop zone.
+        /// </summary>
+        public virtual void ForceUnsnap()
+        {
+            if (isSnapped && ValidSnapObject(currentSnappedObject, false))
+            {
+                currentSnappedObject.ToggleSnapDropZone(pairedSnapDropZone, false);
+            }
+        }
+
+        /// <summary>
+        /// The UnsnapObject method handles the core logic for unsnapping an Interactable Object from SnapDropZone associated with this snap attach script.
+        /// </summary>
+        public virtual void UnsnapObject()
+        {
+            
+        }
+
+        /// <summary>
+        /// The ValidSnapObject method tests to see if an Interactable Object is a valid snappable object based on its grab state and this component's `VRTK_PolicyList`.
+        /// </summary>
+        /// <param name="interactableObjectToSnap">The Interactable Object to check.</param>
+        /// <param name="grabState">The desired Interactable Object grabbed state to test for.</param>
+        /// <param name="checkGrabState">Whether the grab state affects snap validity.</param>
+        /// <returns>Whether an Interactable Object is currently snapped to the Snap Drop Zone.</returns>
+        public virtual bool ValidSnapObject(VRTK_InteractableObject interactableObjectCheck, bool grabState, bool checkGrabState = true)
+        {
+            return (interactableObjectCheck != null && (!checkGrabState || interactableObjectCheck.IsGrabbed() == grabState) && !VRTK_PolicyList.Check(interactableObjectCheck.gameObject, validObjectListPolicy));
+        }
+
+        /// <summary>
+        /// The ValidUnsnap method tests to see if an Interactable Object is permitted to be unsnapped.
+        /// </summary>
+        /// <param name="interactableObjectToSnap">The Interactable Object to check.</param>
+        /// <returns>Whether an Interactable Object is permitted to be unsnapped.</returns>
+        protected virtual bool ValidUnsnap(VRTK_InteractableObject interactableObjectCheck)
+        {
+            return (interactableObjectCheck.IsGrabbed() || ((pairedSnapDropZone.snapType != VRTK_SnapDropZone.SnapTypes.UseJoint || !float.IsInfinity(GetComponent<Joint>().breakForce)) && interactableObjectCheck.validDrop == VRTK_InteractableObject.ValidDropTypes.DropAnywhere));
+        }
+
+        protected virtual Vector3 GetNewLocalScale(VRTK_InteractableObject checkObject)
+        {
+
+            Vector3 newLocalScale = checkObject.transform.localScale;
+
+            if (scaleType == ScaleTypes.MatchBounds)
+            {
+                //Save and wipe object position and rotation so that we can get a proper set of bounds
+                Vector3 savedGrabbedPosition = checkObject.transform.position;
+                Quaternion savedGrabbedRotation = checkObject.transform.rotation;
+                checkObject.transform.position = pairedSnapDropZone.highlightContainer.transform.position;
+                checkObject.transform.rotation = pairedSnapDropZone.highlightContainer.transform.rotation;
+
+                checkObject.StoreLocalScale();
+                BoxCollider slotCollider = gameObject.GetComponentInChildren<Renderer>().gameObject.AddComponent<BoxCollider>();
+                Bounds slotBounds = slotCollider.bounds;
+
+                MeshCollider objectCollider = checkObject.GetComponentInChildren<MeshCollider>();
+                if (objectCollider != null)
+                {
+                    Bounds objectBounds = objectCollider.bounds;
+
+                    //Make sure the largest dimension of the snapped object fits within the smallest bound of the Snap Drop Zone, assuming that the zone has the same x, y, and z dimensions
+                    float smallestSlotBound = Mathf.Min(slotBounds.size.x, slotBounds.size.y);
+                    float largestObjectBound = Mathf.Max(objectBounds.size.x, objectBounds.size.y, objectBounds.size.z);
+                    float scaleMultiplier = smallestSlotBound / largestObjectBound;
+
+                    //Calculate the object bounds accounting for all all colliders
+                    Vector3 min = Vector3.positiveInfinity;
+                    Vector3 max = Vector3.negativeInfinity;
+                    foreach (Collider collider in checkObject.GetComponents<Collider>())
+                    {
+                        Bounds bounds = collider.bounds;
+                        min = Vector3.Min(min, bounds.min);
+                        max = Vector3.Max(max, bounds.max);
+                    }
+
+                    newLocalScale = new Vector3(checkObject.transform.localScale.x * scaleMultiplier, checkObject.transform.localScale.y * scaleMultiplier, checkObject.transform.localScale.z * scaleMultiplier);
+
+                    //Scale it down by a small amount to prevent z-fighting
+                    newLocalScale = newLocalScale * .99f;
+                    Destroy(slotCollider);
+                }
+                //Re-apply saved position and rotation to the grabbed interactable object
+                checkObject.transform.position = savedGrabbedPosition;
+                checkObject.transform.rotation = savedGrabbedRotation;
+            }
+            else if (scaleType == ScaleTypes.MatchScale)
+            {
+                checkObject.StoreLocalScale();
+                newLocalScale = Vector3.Scale(checkObject.transform.localScale, transform.localScale);
+            }
+
+            return newLocalScale;
+        }
+
+        protected virtual Vector3 getLocalPositionOffset(VRTK_InteractableObject checkObject, Vector3 endScale)
+        {
+            Vector3 newPositionOffset = checkObject.transform.position;
+
+            //Save and wipe object position, rotation and scale so that we can get a proper set of bounds
+            Vector3 savedGrabbedPosition = checkObject.transform.position;
+            Quaternion savedGrabbedRotation = checkObject.transform.rotation;
+            Vector3 savedGrabbedScale = checkObject.transform.localScale;
+            checkObject.transform.position = pairedSnapDropZone.highlightContainer.transform.position;
+            checkObject.transform.rotation = pairedSnapDropZone.highlightContainer.transform.rotation;
+            checkObject.transform.localScale = endScale;
+
+            MeshCollider objectCollider = checkObject.GetComponentInChildren<MeshCollider>();
+            if (objectCollider != null)
+            {
+                //Create a new collider just for measuring the bounds of the Snap Drop Zone
+                BoxCollider slotCollider = gameObject.GetComponentInChildren<Renderer>().gameObject.AddComponent<BoxCollider>();
+                Bounds slotBounds = slotCollider.bounds;
+
+                Bounds objectBounds = objectCollider.bounds;
+                newPositionOffset = slotBounds.center - objectBounds.center;
+                Destroy(slotCollider);
+            }
+            else
+            {
+                VRTK_Logger.Warn("VRTK_BaseSnapAttach.getLocalPositionOffset could not fine a mesh collider on Interactable Object " + checkObject.name);
+                newPositionOffset = Vector3.zero;
+            }
+            //Re-apply saved position and rotation to the grabbed interactable object
+            checkObject.transform.position = savedGrabbedPosition;
+            checkObject.transform.rotation = savedGrabbedRotation;
+            checkObject.transform.localScale = savedGrabbedScale;
+
+            return newPositionOffset;
+        }
+
+        public virtual void CheckSnappedItemExists()
+        {
+            if (isSnapped && (currentSnappedObject == null || !currentSnappedObject.gameObject.activeInHierarchy))
+            {
+                ForceUnsnap();
+                pairedSnapDropZone.OnObjectUnsnappedFromDropZone(pairedSnapDropZone.SetSnapDropZoneEvent((currentSnappedObject != null ? currentSnappedObject.gameObject : null)));
+            }
+        }
+
+        public virtual void AddCurrentValidSnapObject(VRTK_InteractableObject givenObject)
+        {
+            if (givenObject != null)
+            {
+                if (VRTK_SharedMethods.AddListValue(currentValidSnapInteractableObjects, givenObject, true))
+                {
+                    givenObject.InteractableObjectGrabbed += InteractableObjectGrabbed;
+                    givenObject.InteractableObjectUngrabbed += InteractableObjectUngrabbed;
+                }
+            }
+        }
+
+        public virtual void RemoveCurrentValidSnapObject(VRTK_InteractableObject givenObject)
+        {
+            if (givenObject != null)
+            {
+                if (currentValidSnapInteractableObjects.Remove(givenObject))
+                {
+                    givenObject.InteractableObjectGrabbed -= InteractableObjectGrabbed;
+                    givenObject.InteractableObjectUngrabbed -= InteractableObjectUngrabbed;
+                }
+            }
+        }
+
+        protected virtual IEnumerator CheckCanSnapObjectAtEndOfFrame(VRTK_InteractableObject interactableObjectCheck)
+        {
+            yield return new WaitForEndOfFrame();
+            CheckCanSnap(interactableObjectCheck);
+        }
+
+        protected virtual IEnumerator UpdateTransformDimensions(VRTK_InteractableObject ioCheck, GameObject endSettings, Vector3 endScale, float duration)
+        {
+            float elapsedTime = 0f;
+            Transform ioTransform = ioCheck.transform;
+            Vector3 startPosition = ioTransform.position;
+            Quaternion startRotation = ioTransform.rotation;
+            Vector3 startScale = ioTransform.localScale;
+            Vector3 correctedPosition = endSettings.transform.position;
+            bool storedKinematicState = ioCheck.isKinematic;
+            ioCheck.isKinematic = true;
+
+            if (scaleType == ScaleTypes.MatchBounds)
+            {
+                correctedPosition = endSettings.transform.position + getLocalPositionOffset(ioCheck, endScale);
+            }
+
+            while (elapsedTime <= duration)
+            {
+                elapsedTime += Time.deltaTime;
+                if (ioTransform != null && endSettings != null)
+                {
+                    ioTransform.position = Vector3.Lerp(startPosition, correctedPosition, (elapsedTime / duration));
+                    ioTransform.rotation = Quaternion.Lerp(startRotation, endSettings.transform.rotation, (elapsedTime / duration));
+                    ioTransform.localScale = Vector3.Lerp(startScale, endScale, (elapsedTime / duration));
+                }
+                yield return null;
+            }
+
+            //Force all to the last setting in case anything has moved during the transition
+            ioTransform.position = correctedPosition;
+            ioTransform.rotation = endSettings.transform.rotation;
+            ioTransform.localScale = endScale;
+
+            ioCheck.isKinematic = storedKinematicState;
+            SetDropSnapType(ioCheck);
+        }
+
+        protected virtual void InteractableObjectGrabbed(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject grabbedInteractableObject = sender as VRTK_InteractableObject;
+            if (!grabbedInteractableObject.IsInSnapDropZone())
+            {
+                CheckCanSnap(grabbedInteractableObject);
+            }
+        }
+
+        protected virtual void InteractableObjectUngrabbed(object sender, InteractableObjectEventArgs e)
+        {
+            VRTK_InteractableObject releasedInteractableObject = sender as VRTK_InteractableObject;
+
+            if (attemptTransitionAtEndOfFrameRoutine != null)
+            {
+                StopCoroutine(attemptTransitionAtEndOfFrameRoutine);
+            }
+            attemptTransitionAtEndOfFrameRoutine = StartCoroutine(AttemptForceSnapAtEndOfFrame(releasedInteractableObject));
+        }
+
+        protected virtual void UnregisterAllGrabEvents()
+        {
+            for (int i = 0; i < GetHoveringInteractableObjects().Count; i++)
+            {
+                GetHoveringInteractableObjects()[i].InteractableObjectGrabbed -= InteractableObjectGrabbed;
+                GetHoveringInteractableObjects()[i].InteractableObjectUngrabbed -= InteractableObjectUngrabbed;
+            }
+        }
+
+        protected virtual void SetDropSnapType(VRTK_InteractableObject ioCheck)
+        {
+            switch (pairedSnapDropZone.snapType)
+            {
+                case VRTK_SnapDropZone.SnapTypes.UseKinematic:
+                    ioCheck.SaveCurrentState();
+                    ioCheck.isKinematic = true;
+                    break;
+                case VRTK_SnapDropZone.SnapTypes.UseParenting:
+                    ioCheck.SaveCurrentState();
+                    ioCheck.isKinematic = true;
+                    ioCheck.transform.SetParent(transform);
+                    break;
+                case VRTK_SnapDropZone.SnapTypes.UseJoint:
+                    SetSnapDropZoneJoint(ioCheck.GetComponent<Rigidbody>());
+                    break;
+            }
+            pairedSnapDropZone.OnObjectSnappedToDropZone(pairedSnapDropZone.SetSnapDropZoneEvent(ioCheck.gameObject));
+        }
+
+        protected virtual void SetSnapDropZoneJoint(Rigidbody snapTo)
+        {
+            Joint snapDropZoneJoint = GetComponent<Joint>();
+            if (snapDropZoneJoint == null)
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "SnapDropZone:" + name, "Joint", "the same", " because the `Snap Type` is set to `Use Joint`"));
+                return;
+            }
+            if (snapTo == null)
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_SnapDropZone", "Rigidbody", "the `VRTK_InteractableObject`"));
+                return;
+            }
+
+            snapDropZoneJoint.connectedBody = snapTo;
+            originalJointCollisionState = snapDropZoneJoint.enableCollision;
+            //need to set this to true otherwise highlighting doesn't work again on grab
+            snapDropZoneJoint.enableCollision = true;
+        }
+
+        protected virtual void ResetSnapDropZoneJoint()
+        {
+            Joint snapDropZoneJoint = GetComponent<Joint>();
+            if (snapDropZoneJoint != null)
+            {
+                snapDropZoneJoint.enableCollision = originalJointCollisionState;
+            }
+        }
+
+        public bool WillSnap () {
+            return willSnap;
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_BaseSnapAttach.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_BaseSnapAttach.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1d550f4a1d75097409065556c6a1460c
+timeCreated: 1512314340
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_CloneSnapAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_CloneSnapAttach.cs
@@ -1,0 +1,124 @@
+﻿// Base Snap Attach|SnapAttachMechanics
+namespace VRTK.SnapAttachMechanics
+{
+    using UnityEngine;
+    using VRTK.Highlighters;
+
+    /// <summary>
+    /// Provides unsnapping behavior that leaves a copy of the snapped Interactable Object in place when the original object is grabbed. Built on top of the basic Simple Snap Attach mechanic.
+    /// </summary>
+
+    [ExecuteInEditMode]
+    public class VRTK_CloneSnapAttach : VRTK_SimpleSnapAttach
+    {
+        protected GameObject objectToClone = null;
+        protected bool[] clonedObjectColliderStates = new bool[0];
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            objectToClone = null;
+            clonedObjectColliderStates = new bool[0];
+        }
+
+        protected override void SnapObject(VRTK_InteractableObject interactableObjectCheck)
+        {
+            Vector3 newLocalScale = GetNewLocalScale(interactableObjectCheck);
+
+            //If the item is in a snappable position and this drop zone isn't snapped and the collider is a valid interactable object
+            if (willSnap && !isSnapped && ValidSnapObject(interactableObjectCheck, false))
+            {
+                //Only snap it to the drop zone if it's not already in a drop zone, or if we're resnapping from a stack
+                if (!interactableObjectCheck.IsInSnapDropZone())
+                {
+                    //Turn off the drop zone highlighter
+                    pairedSnapDropZone.SetHighlightObjectActive(false);
+                    
+                    if (transitionInPlaceRoutine != null)
+                    {
+                        StopCoroutine(transitionInPlaceRoutine);
+                    }
+
+                    isSnapped = true;
+                    currentSnappedObject = interactableObjectCheck;
+
+                    CreatePermanentClone();
+                   
+                    if (gameObject.activeInHierarchy)
+                    {
+                        transitionInPlaceRoutine = StartCoroutine(UpdateTransformDimensions(interactableObjectCheck, pairedSnapDropZone.highlightContainer, newLocalScale, snapDuration));
+                    }
+
+                    interactableObjectCheck.ToggleSnapDropZone(pairedSnapDropZone, true);
+                }
+            }
+           
+            //force reset isSnapped if the item is grabbed but isSnapped is still true
+            isSnapped = (isSnapped && interactableObjectCheck != null && interactableObjectCheck.IsGrabbed() ? false : isSnapped);
+            //allow other objects to pass through snapped stackable interactable objects by setting isTrigger to true for all object colliders
+            willSnap = !isSnapped;
+            wasSnapped = false;
+        }
+
+        public override void UnsnapObject()
+        {
+            if (currentSnappedObject != null)
+            {
+                RemoveCurrentValidSnapObject(currentSnappedObject);
+            }
+
+            isSnapped = false;
+            wasSnapped = true;
+            VRTK_InteractableObject checkCanSnapObject = currentSnappedObject;
+            currentSnappedObject = null;
+            ResetSnapDropZoneJoint();
+
+            if (transitionInPlaceRoutine != null)
+            {
+                StopCoroutine(transitionInPlaceRoutine);
+            }
+
+            ResnapPermanentClone();
+            
+            //With any cloned or next-in-stack Interactable Objects resnapped and their collider's isTrigger value set to true, turn the unsnapped Interactable Object's colliders back on.
+            checkCanSnapObject.LoadPreviousColliderStates();
+
+            if (checkCanSnapRoutine != null)
+            {
+                StopCoroutine(checkCanSnapRoutine);
+            }
+
+            if (gameObject.activeInHierarchy)
+            {
+                checkCanSnapRoutine = StartCoroutine(CheckCanSnapObjectAtEndOfFrame(checkCanSnapObject));
+            }
+
+            checkCanSnapObject = null;
+        }
+
+        protected virtual void CreatePermanentClone()
+        {
+            VRTK_BaseHighlighter currentSnappedObjectHighlighter = currentSnappedObject.GetComponent<VRTK_BaseHighlighter>();
+            if (currentSnappedObjectHighlighter != null)
+            {
+                currentSnappedObjectHighlighter.Unhighlight();
+            }
+            objectToClone = Instantiate(currentSnappedObject.gameObject);
+            objectToClone.transform.position = pairedSnapDropZone.transform.position;
+            objectToClone.transform.rotation = pairedSnapDropZone.transform.rotation;
+            objectToClone.SetActive(false);
+        }
+
+        protected virtual void ResnapPermanentClone()
+        {
+            if (objectToClone != null)
+            {
+                float savedSnapDuration = snapDuration;
+                snapDuration = 0f;
+                objectToClone.SetActive(true);
+                ForceSnap(objectToClone);
+                snapDuration = savedSnapDuration;
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_CloneSnapAttach.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_CloneSnapAttach.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 54f0c73fbca431e4fbd75c11e52d953b
+timeCreated: 1512314340
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_SimpleSnapAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_SimpleSnapAttach.cs
@@ -1,0 +1,85 @@
+﻿// Base Snap Attach|SnapAttachMechanics
+namespace VRTK.SnapAttachMechanics
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Provides basic snapping functionality and serves as the default mechanic for a `VRTK_SnapDropZone'.
+    /// </summary>
+    /// <remarks>
+
+    [ExecuteInEditMode]
+    public class VRTK_SimpleSnapAttach : VRTK_BaseSnapAttach
+    {
+
+        protected override void SnapObject(VRTK_InteractableObject interactableObjectCheck)
+        {
+            Vector3 newLocalScale = GetNewLocalScale(interactableObjectCheck);
+
+            //If the item is in a snappable position and this drop zone isn't snapped and the collider is a valid interactable object
+            if (willSnap && !isSnapped && ValidSnapObject(interactableObjectCheck, false))
+            {
+                //Only snap it to the drop zone if it's not already in a drop zone, or if we're resnapping from a stack
+                if (!interactableObjectCheck.IsInSnapDropZone())
+                {
+                    //Turn off the drop zone highlighter
+                    pairedSnapDropZone.SetHighlightObjectActive(false);
+                    
+                    if (transitionInPlaceRoutine != null)
+                    {
+                        StopCoroutine(transitionInPlaceRoutine);
+                    }
+
+                    isSnapped = true;
+                    currentSnappedObject = interactableObjectCheck;
+
+                    if (gameObject.activeInHierarchy)
+                    {
+                        transitionInPlaceRoutine = StartCoroutine(UpdateTransformDimensions(interactableObjectCheck, pairedSnapDropZone.highlightContainer, newLocalScale, snapDuration));
+                    }
+
+                    interactableObjectCheck.ToggleSnapDropZone(pairedSnapDropZone, true);
+                }
+            }
+           
+            //force reset isSnapped if the item is grabbed but isSnapped is still true
+            isSnapped = (isSnapped && interactableObjectCheck != null && interactableObjectCheck.IsGrabbed() ? false : isSnapped);
+            willSnap = !isSnapped;
+            wasSnapped = false;
+        }
+
+        public override void UnsnapObject()
+        {
+            if (currentSnappedObject != null)
+            {
+                RemoveCurrentValidSnapObject(currentSnappedObject);
+            }
+
+            isSnapped = false;
+            wasSnapped = true;
+            VRTK_InteractableObject checkCanSnapObject = currentSnappedObject;
+            currentSnappedObject = null;
+            ResetSnapDropZoneJoint();
+
+            if (transitionInPlaceRoutine != null)
+            {
+                StopCoroutine(transitionInPlaceRoutine);
+            }
+
+            //With any cloned or next-in-stack Interactable Objects resnapped and their collider's isTrigger value set to true, turn the unsnapped Interactable Object's colliders back on.
+            checkCanSnapObject.LoadPreviousColliderStates();
+
+            if (checkCanSnapRoutine != null)
+            {
+                StopCoroutine(checkCanSnapRoutine);
+            }
+
+            if (gameObject.activeInHierarchy)
+            {
+                checkCanSnapRoutine = StartCoroutine(CheckCanSnapObjectAtEndOfFrame(checkCanSnapObject));
+            }
+
+            checkCanSnapObject = null;
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_SimpleSnapAttach.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_SimpleSnapAttach.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 84f2d07c7c293044f9148171b53427f8
+timeCreated: 1512314340
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_StackSnapAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_StackSnapAttach.cs
@@ -1,0 +1,249 @@
+﻿// Base Snap Attach|SnapAttachMechanics
+namespace VRTK.SnapAttachMechanics
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using UnityEngine;
+    using UnityEngine.Assertions;
+    using UnityEngine.UI;
+
+    /// <summary>
+    /// Provides snapping and unsnapping behavior that permits stacking of identical Interactable Objects. Built on top of the basic Simple Snap Attach mechanic.
+    /// </summary>
+    /// <remarks>
+
+    [ExecuteInEditMode]
+    public class VRTK_StackSnapAttach : VRTK_SimpleSnapAttach
+    {
+        [Tooltip("How snapped objects should be scaled when dropped into the `VRTK_SnapDropZone`.")]
+        public float scaleModifier = 1f;
+        [Tooltip("The number of stacks where the Snap Drop Zone starts displaying numbers")]
+        public int startCountDisplayAt = 2;
+
+        protected int snapCount = 0;
+        protected Text snapCountText;
+        protected bool isResnapping = false;
+        protected Stack<GameObject> snapStack = new Stack<GameObject>();
+      
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            initializeSnapCountText();
+        }
+
+        public override void CheckCanSnap(VRTK_InteractableObject interactableObjectCheck)
+        {
+            if (interactableObjectCheck != null)
+            {
+                AddCurrentValidSnapObject(interactableObjectCheck);
+                if ((!isSnapped && ValidSnapObject(interactableObjectCheck, true)) || (isSnapped && ValidStackableObject(interactableObjectCheck)))
+                {
+                    pairedSnapDropZone.ToggleHighlight(interactableObjectCheck, true);
+                    interactableObjectCheck.SetSnapDropZoneHover(pairedSnapDropZone, true);
+                    if (!willSnap)
+                    {
+                        pairedSnapDropZone.OnObjectEnteredSnapDropZone(pairedSnapDropZone.SetSnapDropZoneEvent(interactableObjectCheck.gameObject));
+                    }
+                    willSnap = true;
+                    pairedSnapDropZone.ToggleHighlightColor();
+                }
+            }
+        }
+
+        protected override void SnapObjectToZone(VRTK_InteractableObject objectToSnap)
+        {
+            if ((!isSnapped && ValidSnapObject(objectToSnap, false)) || ( isSnapped && ValidStackableObject(objectToSnap)))
+            {
+                SnapObject(objectToSnap);
+            }
+        }
+
+        protected override void SnapObject(VRTK_InteractableObject interactableObjectCheck)
+        {
+            Vector3 newLocalScale = GetNewLocalScale(interactableObjectCheck);
+
+            //If the item is in a snappable position and this drop zone isn't snapped and the collider is a valid interactable object
+            if (willSnap && !isSnapped && ValidSnapObject(interactableObjectCheck, false))
+            {
+                //Only snap it to the drop zone if it's not already in a drop zone, or if we're resnapping from a stack
+                if (!interactableObjectCheck.IsInSnapDropZone() || isResnapping)
+                {
+                    //Turn off the drop zone highlighter
+                    pairedSnapDropZone.SetHighlightObjectActive(false);
+
+
+                    if (transitionInPlaceRoutine != null)
+                    {
+                        StopCoroutine(transitionInPlaceRoutine);
+                    }
+
+                    isSnapped = true;
+                    currentSnappedObject = interactableObjectCheck;
+
+                    //Don't increment item count if re-snapping a stack clone after removing the top interactable object
+                    if (!isResnapping)
+                    {
+                        snapCount += 1;
+                        SetSnapCountText(snapCount);
+                    }
+                    else
+                    {
+                        isResnapping = false;
+                    }
+
+                    if (gameObject.activeInHierarchy)
+                    {
+                        transitionInPlaceRoutine = StartCoroutine(UpdateTransformDimensions(interactableObjectCheck, pairedSnapDropZone.highlightContainer, newLocalScale, snapDuration));
+                    }
+
+                    interactableObjectCheck.ToggleSnapDropZone(pairedSnapDropZone, true);
+                }
+            }
+            //If the item is in a snappable position and this drop zone has a snapped object, and if both interactable objects can be stacked
+            else if (ValidStackableObject(interactableObjectCheck) && ValidSnapObject(interactableObjectCheck, false))
+            {
+                pairedSnapDropZone.SetHighlightObjectActive(false);
+
+                if (transitionInPlaceRoutine != null)
+                {
+                    StopCoroutine(transitionInPlaceRoutine);
+                }
+
+                isSnapped = true;
+                snapCount += 1;
+                SetSnapCountText(snapCount);
+                
+                if (gameObject.activeInHierarchy)
+                {
+                    transitionInPlaceRoutine = StartCoroutine(StackObjectAndUpdateTransform(interactableObjectCheck, pairedSnapDropZone.highlightContainer, newLocalScale, snapDuration));
+                }
+
+                interactableObjectCheck.ToggleSnapDropZone(pairedSnapDropZone, true);
+            }
+
+            //Force reset isSnapped if the item is grabbed but isSnapped is still true
+            isSnapped = (isSnapped && interactableObjectCheck != null && interactableObjectCheck.IsGrabbed() ? false : isSnapped);
+            //Allow other objects to pass through snapped stackable interactable objects by setting isTrigger to true for all snapped object colliders
+            if (isSnapped)
+            {
+                interactableObjectCheck.SaveColliderStates(false);
+                Collider[] objectColliderStates = interactableObjectCheck.GetComponentsInChildren<Collider>();
+                for (int i = 0; i < objectColliderStates.Length; i++)
+                {
+                    objectColliderStates[i].isTrigger = true;
+                }
+            }
+            willSnap = !isSnapped;
+            wasSnapped = false;
+        }
+
+        public override void UnsnapObject()
+        {
+            if (currentSnappedObject != null)
+            {
+                RemoveCurrentValidSnapObject(currentSnappedObject);
+            }
+
+            isSnapped = false;
+            wasSnapped = true;
+            VRTK_InteractableObject checkCanSnapObject = currentSnappedObject;
+            currentSnappedObject = null;
+            ResetSnapDropZoneJoint();
+
+            if (transitionInPlaceRoutine != null)
+            {
+                StopCoroutine(transitionInPlaceRoutine);
+            }
+
+            snapCount -= 1;
+            SetSnapCountText(snapCount);
+
+            if (snapStack.Count > 0)
+            {
+                ResnapNextInStack();
+            }
+
+            //With any next-in-stack Interactable Objects resnapped and their collider's isTrigger value set to true, turn the unsnapped Interactable Object's colliders back on.
+            if (checkCanSnapObject != null)
+            {
+                checkCanSnapObject.LoadPreviousColliderStates();
+            }
+
+            if (checkCanSnapRoutine != null)
+            {
+                StopCoroutine(checkCanSnapRoutine);
+            }
+
+            if (gameObject.activeInHierarchy)
+            {
+                checkCanSnapRoutine = StartCoroutine(CheckCanSnapObjectAtEndOfFrame(checkCanSnapObject));
+            }
+
+            checkCanSnapObject = null;
+        }
+
+        protected virtual void ResnapNextInStack()
+        {
+            isResnapping = true;
+            float savedSnapDuration = snapDuration;
+            snapDuration = 0f;
+            GameObject nextInStack = snapStack.Pop();
+            nextInStack.SetActive(true);
+            ForceSnap(nextInStack);
+            snapDuration = savedSnapDuration;
+        }
+
+        protected bool ValidStackableObject(VRTK_InteractableObject interactableObjectCheck)
+        {
+            return (currentSnappedObject.objectID == interactableObjectCheck.objectID && currentSnappedObject.isStackable && interactableObjectCheck.isStackable);
+        }
+
+        protected virtual void initializeSnapCountText()
+        {
+            snapCountText = GetComponentInChildren<Text>();
+            if(snapCountText == null)
+            {
+                VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "SnapDropZone:" + name, "Text", "the `VRTK_SnapDropZone`", " if `VRTK_SnapDropZone.stackType` is set to `StackTypes.StackIdentical`"));
+            }
+            SetSnapCountText(snapCount);
+        }
+
+        protected void SetSnapCountText(int count)
+        {
+            if (snapCountText != null)
+            {
+                if (count >= startCountDisplayAt)
+                {
+                    snapCountText.text = count.ToString();
+                }
+                else
+                {
+                    snapCountText.text = "";
+                }
+            }
+        }
+
+        protected override Vector3 GetNewLocalScale(VRTK_InteractableObject checkObject)
+        {
+            //If this object is being re-snapped to the Snap Drop Zone (after being pushed to the stack when another Interactable Object was stacked on top of it), it has already been scaled and doesn't need to be again
+            if (!isResnapping)
+            {
+                return base.GetNewLocalScale(checkObject) * scaleModifier;
+            }
+            else
+            {
+                return checkObject.transform.localScale;
+            }
+
+            
+        }
+
+        protected virtual IEnumerator StackObjectAndUpdateTransform(VRTK_InteractableObject ioCheck, GameObject endSettings, Vector3 endScale, float duration)
+        {
+            yield return StartCoroutine(UpdateTransformDimensions(ioCheck, endSettings, endScale, duration));
+            snapStack.Push(currentSnappedObject.gameObject);
+            currentSnappedObject.gameObject.SetActive(false);
+            currentSnappedObject = ioCheck;
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_StackSnapAttach.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SnapAttachMechanics/VRTK_StackSnapAttach.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5b5bcac340ed78a49a03397df9034119
+timeCreated: 1512314340
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
SnapDropZones can now hold multiple InteractableObjects that share the same identifier. When in stack-mode SDZs now allow other objects to pass through currently held objects, which makes it easier to put additional objects into the SDZ without dealing with between-object collisions.

I haven't yet added a text component to the SDZ prefab. At present, an SDZ in stack mode will look to find a child Text object and make use of that, which is available for testing in example 41. 

This is an initial version and deserves some review and discussion before merging.

