### PR TITLE
feat(Interaction): add new Button controllable replacing 3d control - fixes #1333 - resolves #1409

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -12,6 +12,8 @@ This file describes all of the public methods, variables and events utilised by 
  * [Interactables](#interactables-vrtksourcescriptsinteractionsinteractables)
    * [Grab Attach Mechanics](#grab-attach-mechanics-vrtksourcescriptsinteractionsgrabattachmechanics)
    * [Secondary Controller Grab Actions](#secondary-controller-grab-actions-vrtksourcescriptsinteractionssecondarycontrollergrabactions)
+   * [Controllables](#controllables-vrtksourcescriptsinteractionscontrollables)
+     * [Physics Controllables](#physics-controllables-vrtksourcescriptsinteractionscontrollablesphysics)
  * [Presence](#presence-vrtksourcescriptspresence)
  * [UI](#ui-vrtksourcescriptsui)
  * [3D Controls](#3d-controls-vrtksourcescriptscontrols3d)
@@ -1544,7 +1546,7 @@ The ToggleVisibility method enables or disables the play area cursor renderers t
 
 # Pointer Renderers (VRTK/Source/Scripts/Pointers/PointerRenderers)
 
-This directory contains scripts that are used to provide different renderers for the VRTK_Pointer.
+A collection of scripts that are used to provide different renderers for the VRTK_Pointer.
 
  * [Base Pointer Renderer](#base-pointer-renderer-vrtk_basepointerrenderer)
  * [Straight Pointer Renderer](#straight-pointer-renderer-vrtk_straightpointerrenderer)
@@ -2553,7 +2555,7 @@ Applys a tunnel overlay effect to the active VR camera when the play area is mov
 
 # Object Control Actions (VRTK/Source/Scripts/Locomotion/ObjectControlActions)
 
-This directory contains scripts that are used to provide different actions when using Object Control.
+A collection of scripts that are used to provide different actions when using Object Control.
 
  * [Base Object Control Action](#base-object-control-action-vrtk_baseobjectcontrolaction)
  * [Slide Object Control Action](#slide-object-control-action-vrtk_slideobjectcontrolaction)
@@ -2723,7 +2725,7 @@ To enable the Warp Object Control Action, ensure one of the `TouchpadControlOpti
 
 # Highlighters (VRTK/Source/Scripts/Interactions/Highlighters)
 
-This directory contains scripts that are used to provide highlighting.
+A collection of scripts that are used to provide highlighting.
 
  * [Base Highlighter](#base-highlighter-vrtk_basehighlighter)
  * [Material Colour Swap](#material-colour-swap-vrtk_materialcolorswaphighlighter)
@@ -4031,6 +4033,7 @@ A collection of scripts that provide the ability denote objects as being interac
  * [Interact Object Appearance](#interact-object-appearance-vrtk_interactobjectappearance)
  * [Interact Object Highlighter](#interact-object-highlighter-vrtk_interactobjecthighlighter)
  * [Object Touch Auto Interact](#object-touch-auto-interact-vrtk_objecttouchautointeract)
+ * [Ignore Interact Touch Colliders](#ignore-interact-touch-colliders-vrtk_ignoreinteracttouchcolliders)
 
 ---
 
@@ -4905,9 +4908,26 @@ Allows for Interact Grab or Interact Use interactions to automatically happen up
 
 ---
 
+## Ignore Interact Touch Colliders (VRTK_IgnoreInteractTouchColliders)
+ > extends VRTK_SDKControllerReady
+
+### Overview
+
+Ignores the collisions between the given Interact Touch colliders and the colliders on the GameObject this script is attached to.
+
+**Required Components:**
+ * `Collider` - Unity Colliders on the current GameObject or child GameObjects to ignore collisions from the given Interact Touch colliders.
+
+**Script Usage:**
+ * Place the `VRTK_IgnoreInteractTouchColliders` script on the GameObject with colliders to ignore collisions from the given Interact Touch colliders.
+ * Increase the size of the `Interact Touch To Ignore` element list.
+ * Add the appropriate GameObjects that have the `VRTK_InteractTouch` script attached to use when ignoring collisions with the colliders on GameObject the script is attached to.
+
+---
+
 # Grab Attach Mechanics (VRTK/Source/Scripts/Interactions/GrabAttachMechanics)
 
-This directory contains scripts that are used to provide different mechanics to apply when grabbing an interactable object.
+A collection of scripts that are used to provide different mechanics to apply when grabbing an interactable object.
 
  * [Base Grab Attach](#base-grab-attach-vrtk_basegrabattach)
  * [Base Joint Grab Attach](#base-joint-grab-attach-vrtk_basejointgrabattach)
@@ -5840,7 +5860,7 @@ The GetRotationSpeed returns the current speed in which the Interactable Object 
 
 # Secondary Controller Grab Actions (VRTK/Source/Scripts/Interactions/SecondaryControllerGrabActions)
 
-This directory contains scripts that are used to provide different actions when a secondary controller grabs a grabbed object.
+A collection of scripts that are used to provide different actions when a secondary controller grabs a grabbed object.
 
  * [Base Grab Action](#base-grab-action-vrtk_basegrabaction)
  * [Swap Controller Grab Action](#swap-controller-grab-action-vrtk_swapcontrollergrabaction)
@@ -6110,6 +6130,159 @@ The ProcessFixedUpdate method runs in every FixedUpdate on the Interactable Obje
 ### Example
 
 `VRTK/Examples/043_Controller_SecondaryControllerActions` demonstrates the ability to grab an object with one controller and control their direction with the second controller.
+
+---
+
+# Controllables (VRTK/Source/Scripts/Interactions/Controllables)
+
+Contains scripts that form the basis of interactable 3D controls that are either Physics based or artificially simulated.
+
+ * [Base Controllable](#base-controllable-vrtk_basecontrollable)
+
+---
+
+## Base Controllable (VRTK_BaseControllable)
+
+### Overview
+
+Provides a base that all Controllables can inherit from.
+
+**Script Usage:**
+  > This is an abstract class that is to be inherited to a concrete class that provides controllable functionality, therefore this script should not be directly used.
+
+### Inspector Parameters
+
+ * **Operate Axis:** The local axis in which the Controllable will operate through.
+ * **Ignore Collisions With:** A collection of GameObjects to ignore collision events with.
+
+### Class Variables
+
+ * `public enum OperatingAxis` - The local axis that the Controllable will be operated through.
+   * `xAxis` - The local x axis.
+   * `yAxis` - The local y axis.
+   * `zAxis` - The local z axis.
+
+### Class Events
+
+ * `ValueChanged` - Emitted when the Controllable value has changed.
+ * `MinLimitReached` - Emitted when the Controllable value has reached it's minimum limit.
+ * `MinLimitExited` - Emitted when the Controllable value has exited it's minimum limit.
+ * `MaxLimitReached` - Emitted when the Controllable value has reached it's maximum limit.
+ * `MaxLimitExited` - Emitted when the Controllable value has exited it's maximum limit.
+
+### Unity Events
+
+Adding the `VRTK_BaseControllable_UnityEvents` component to `VRTK_BaseControllable` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+ * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
+
+### Event Payload
+
+ * `GameObject interactingObject` - The GameObject that is performing the interaction (e.g. a controller).
+ * `float value` - The current value being reported by the controllable.
+ * `float normalizedValue` - The normalized value being reported by the controllable.
+
+### Class Methods
+
+#### AtMinLimit/0
+
+  > `public virtual bool AtMinLimit()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `bool` - Returns `true` if the Controllable is at it's minimum limit.
+
+The AtMinLimit method returns whether the Controllable is currently at it's minimum limit.
+
+#### AtMaxLimit/0
+
+  > `public virtual bool AtMaxLimit()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `bool` - Returns `true` if the Controllable is at it's maximum limit.
+
+The AtMaxLimit method returns whether the Controllable is currently at it's maximum limit.
+
+---
+
+# Physics Controllables (VRTK/Source/Scripts/Interactions/Controllables/Physics)
+
+A collection of scripts that provide physics based controls that mimiic real life objects.
+
+ * [Base Physics Controllable](#base-physics-controllable-vrtk_basephysicscontrollable)
+ * [Physics Button](#physics-button-vrtk_button)
+
+---
+
+## Base Physics Controllable (VRTK_BasePhysicsControllable)
+ > extends [VRTK_BaseControllable](#base-controllable-vrtk_basecontrollable)
+
+### Overview
+
+Provides a base that all physics based Controllables can inherit from.
+
+**Script Usage:**
+  > This is an abstract class that is to be inherited to a concrete class that provides physics based controllable functionality, therefore this script should not be directly used.
+
+### Inspector Parameters
+
+ * **Auto Interaction:** If this is checked then a VRTK_ControllerRigidbodyActivator will automatically be added to the Controllable so the interacting object's rigidbody is enabled on touch.
+ * **Connected To:** The Rigidbody that the Controllable is connected to.
+
+---
+
+## Physics Button (VRTK_Button)
+ > extends [VRTK_BasePhysicsControllable](#base-physics-controllable-vrtk_basephysicscontrollable)
+
+### Overview
+
+A physics based pushable button.
+
+**Required Components:**
+ * `Collider` - A Unity Collider to determine when an interaction has occured. Can be a compound collider set in child GameObjects. Will be automatically added at runtime.
+ * `Rigidbody` - A Unity Rigidbody to allow the GameObject to be affected by the Unity Physics System. Will be automatically added at runtime.
+
+**Optional Components:**
+ * `ConstantForce` - A Unity Constant Force to push the button back to it's origin position. Will be automatically created if the `Reset Force` is not `0f`.
+ * `VRTK_ControllerRigidbodyActivator` - A Controller Rigidbody Activator to automatically enable the controller rigidbody upon touching the button. Will be automatically created if the `Auto Interaction` paramter is checked.
+
+**Script Usage:**
+ * Place the `VRTK_Button` script onto the GameObject that is to become the button.
+
+### Inspector Parameters
+
+ * **Pressed Distance:** The distance along the `Operate Axis` until the button reaches the pressed position.
+ * **Pressed Threshold:** The threshold in which the button's current position along the `Operate Axis` has to be within the pressed position for the button to be considered pressed.
+ * **Stay Pressed:** If this is checked then the button will stay in the pressed position when it reaches the pressed position.
+ * **Position Target:** The position of the button between the original position and the pressed position. `0f` will set the button position to the original position, `1f` will set the button position to the pressed position.
+ * **Target Force:** The amount of force to apply to push the Button towards the `Target Position`
+
+### Class Methods
+
+#### GetValue/0
+
+  > `public override float GetValue()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `float` - The actual position of the button.
+
+The GetValue method returns the current position value of the button.
+
+#### GetNormalizedValue/0
+
+  > `public override float GetNormalizedValue()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `float` - The normalized position of the button.
+
+The GetNormalizedValue method returns the current position value of the button normalized between `0f` and `1f`.
 
 ---
 
@@ -7031,7 +7204,6 @@ A number of controls are available which partially support auto-configuration. S
 All 3D controls extend the `VRTK_Control` abstract class which provides common methods and events.
 
  * [Control](#control-vrtk_control)
- * [Button](#button-vrtk_button)
  * [Chest](#chest-vrtk_chest)
  * [Door](#door-vrtk_door)
  * [Drawer](#drawer-vrtk_drawer)
@@ -7123,55 +7295,6 @@ The SetContent method sets the given game object as the content of the control. 
    * `GameObject` - The currently stored content for the control.
 
 The GetContent method returns the current game object of the control's content.
-
----
-
-## Button (VRTK_Button)
- > extends [VRTK_Control](#control-vrtk_control)
-
-### Overview
-
-Attaching the script to a game object will allow the user to interact with it as if it were a push button. The direction into which the button should be pushable can be freely set and auto-detection is supported. Since this is physics-based there needs to be empty space in the push direction so that the button can move.
-
-The script will instantiate the required Rigidbody and ConstantForce components automatically in case they do not exist yet.
-
-### Inspector Parameters
-
- * **Connected To:** An optional game object to which the button will be connected. If the game object moves the button will follow along.
- * **Direction:** The axis on which the button should move. All other axis will be frozen.
- * **Activation Distance:** The local distance the button needs to be pushed until a push event is triggered.
- * **Button Strength:** The amount of force needed to push the button down as well as the speed with which it will go back into its original position.
-
-### Class Variables
-
- * `public enum ButtonDirection` - 3D Control Button Directions
-   * `autodetect` - Attempt to auto detect the axis.
-   * `x` - The world x direction.
-   * `y` - The world y direction.
-   * `z` - The world z direction.
-   * `negX` - The world negative x direction.
-   * `negY` - The world negative y direction.
-   * `negZ` - The world negative z direction.
-
-### Class Events
-
- * `Pushed` - Emitted when the 3D Button has reached its activation distance.
- * `Released` - Emitted when the 3D Button's position has become less than activation distance after being pressed.
-
-### Unity Events
-
-Adding the `VRTK_Button_UnityEvents` component to `VRTK_Button` object allows access to `UnityEvents` that will react identically to the Class Events.
-
- * All C# delegate events are mapped to a Unity Event with the `On` prefix. e.g. `MyEvent` -> `OnMyEvent`.
-
-### Event Payload
-
- * `float value` - The current value being reported by the control.
- * `float normalizedValue` - The normalized value being reported by the control.
-
-### Example
-
-`VRTK/Examples/025_Controls_Overview` shows a collection of pressable buttons that are interacted with by activating the rigidbody on the controller by pressing the grab button without grabbing an object.
 
 ---
 
@@ -8321,6 +8444,18 @@ The DividerToMultiplier method takes a number to be used in a division and conve
    * `float` -
 
 The NormalizeValue method takes a given value between a specified range and returns the normalized value between 0f and 1f.
+
+#### AxisDirection/2
+
+  > `public static Vector3 AxisDirection(int axisIndex, Transform givenTransform = null)`
+
+ * Parameters
+   * `int axisIndex` - The axis index of the axis. `0 = x` `1 = y` `2 = z`
+   * `Transform givenTransform` - An optional Transform to get the Axis Direction for. If this is `null` then the World directions will be used.
+ * Returns
+   * `Vector3` - The direction Vector3 based on the given axis index.
+
+The AxisDirection method returns the relevant direction Vector3 based on the axis index in relation to x,y,z.
 
 #### GetTypeUnknownAssembly/1
 

--- a/Assets/VRTK/Examples/025_Controls_Overview.unity
+++ b/Assets/VRTK/Examples/025_Controls_Overview.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -41,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 9
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 8
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -66,13 +67,27 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_ShadowMaskMode: 2
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -89,6 +104,8 @@ NavMeshSettings:
     minRegionArea: 2
     manualCellSize: 0
     cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &4989974
@@ -134,12 +151,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 88356432}
@@ -209,6 +220,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &16236385
 BoxCollider:
@@ -290,6 +302,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &29000807
 MeshFilter:
@@ -340,7 +353,7 @@ Transform:
   - {fileID: 637393436}
   - {fileID: 1848526919}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 16
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &39470025
 GameObject:
@@ -403,6 +416,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &39470028
 BoxCollider:
@@ -484,6 +498,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &39677374
 BoxCollider:
@@ -564,6 +579,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &42330028
 MeshFilter:
@@ -679,12 +695,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -739,6 +749,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &48415611
 MeshFilter:
@@ -791,12 +802,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -849,6 +854,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &48637174
 BoxCollider:
@@ -963,6 +969,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &49668788
 BoxCollider:
@@ -1044,6 +1051,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &53679397
 BoxCollider:
@@ -1122,12 +1130,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -1182,6 +1184,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &58892938
 MeshFilter:
@@ -1238,6 +1241,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &64707181
 BoxCollider:
@@ -1316,6 +1320,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -1333,6 +1338,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &80646939
 Rigidbody:
@@ -1379,6 +1385,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &80646941
 BoxCollider:
@@ -1410,8 +1417,9 @@ GameObject:
   - component: {fileID: 81025282}
   - component: {fileID: 81025281}
   - component: {fileID: 81025280}
+  - component: {fileID: 81025283}
   m_Layer: 0
-  m_Name: ButtonBox
+  m_Name: ButtonBoxDown (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1460,6 +1468,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &81025281
 BoxCollider:
@@ -1480,6 +1489,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 81025278}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &81025283
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 81025278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &84058375
 GameObject:
   m_ObjectHideFlags: 0
@@ -1541,6 +1564,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &84058378
 BoxCollider:
@@ -1605,8 +1629,9 @@ GameObject:
   - component: {fileID: 91285376}
   - component: {fileID: 91285375}
   - component: {fileID: 91285374}
+  - component: {fileID: 91285377}
   m_Layer: 0
-  m_Name: ButtonBox (2)
+  m_Name: ButtonBoxBack (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1655,6 +1680,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &91285375
 BoxCollider:
@@ -1675,6 +1701,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 91285372}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &91285377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 91285372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &99641761
 GameObject:
   m_ObjectHideFlags: 0
@@ -1736,6 +1776,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &99641764
 BoxCollider:
@@ -1817,6 +1858,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &121664890
 BoxCollider:
@@ -1898,6 +1940,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &123826724
 BoxCollider:
@@ -1927,7 +1970,7 @@ GameObject:
   m_Component:
   - component: {fileID: 125528463}
   m_Layer: 0
-  m_Name: ButtonBox
+  m_Name: ButtonBoxRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2011,6 +2054,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &136390091
 BoxCollider:
@@ -2145,6 +2189,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &159847024
 GameObject:
@@ -2207,6 +2252,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &159847027
 BoxCollider:
@@ -2288,6 +2334,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &166613084
 BoxCollider:
@@ -2369,6 +2416,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &180018270
 BoxCollider:
@@ -2483,6 +2531,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &202275856
 BoxCollider:
@@ -2597,6 +2646,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &208521911
 BoxCollider:
@@ -2678,6 +2728,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &208798828
 BoxCollider:
@@ -2697,87 +2748,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 208798825}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &211316602
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 211316603}
-  - component: {fileID: 211316606}
-  - component: {fileID: 211316605}
-  - component: {fileID: 211316604}
-  m_Layer: 0
-  m_Name: ButtonBox (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &211316603
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 211316602}
-  m_LocalRotation: {x: -0.5001786, y: 0.49982175, z: -0.49982136, w: 0.50017834}
-  m_LocalPosition: {x: 0.369, y: 0.626, z: 0.028}
-  m_LocalScale: {x: 0.069746755, y: 0.014500359, z: 0.15642191}
-  m_Children: []
-  m_Father: {fileID: 455225190}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: -0.0409, y: 90, z: -90}
---- !u!23 &211316604
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 211316602}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: fa756b232992781448908e45ad28eece, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!65 &211316605
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 211316602}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &211316606
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 211316602}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &211722559
 GameObject:
@@ -2840,6 +2810,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &211722562
 BoxCollider:
@@ -2923,6 +2894,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &212646788
 BoxCollider:
@@ -2980,6 +2952,7 @@ GameObject:
   - component: {fileID: 214899994}
   - component: {fileID: 214899993}
   - component: {fileID: 214899992}
+  - component: {fileID: 214899995}
   m_Layer: 0
   m_Name: Shelf
   m_TagString: Untagged
@@ -2993,12 +2966,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 214899990}
-  m_LocalRotation: {x: 0, y: 0, z: -0.70685434, w: 0.70735925}
-  m_LocalPosition: {x: 0.855, y: 0.4471428, z: 0}
-  m_LocalScale: {x: 0.02430599, y: 1.4030167, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0.70685434, w: 0.70735925}
+  m_LocalPosition: {x: -1.83233, y: -0.14112782, z: -0.94173074}
+  m_LocalScale: {x: 0.034028392, y: 0.2806044, z: 1.5857425}
   m_Children: []
-  m_Father: {fileID: 1499571915}
-  m_RootOrder: 1
+  m_Father: {fileID: 2085183771}
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -89.9591}
 --- !u!23 &214899992
 MeshRenderer:
@@ -3030,6 +3003,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &214899993
 BoxCollider:
@@ -3050,6 +3024,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 214899990}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &214899995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 214899990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &218295334
 GameObject:
   m_ObjectHideFlags: 0
@@ -3111,6 +3099,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &218295337
 BoxCollider:
@@ -3192,6 +3181,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &225972150
 BoxCollider:
@@ -3257,6 +3247,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -3274,6 +3265,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &226280889
 Rigidbody:
@@ -3320,6 +3312,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &226280891
 BoxCollider:
@@ -3401,6 +3394,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &226557047
 BoxCollider:
@@ -3479,12 +3473,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -3539,6 +3527,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &233901378
 MeshFilter:
@@ -3608,6 +3597,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &234486587
 BoxCollider:
@@ -3740,6 +3730,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &241994295
 BoxCollider:
@@ -3948,6 +3939,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &253184980
 BoxCollider:
@@ -4038,12 +4030,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2473c1519b730d346b724d18267dc7fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 1
@@ -4080,6 +4066,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &253195182
 MeshFilter:
@@ -4099,8 +4086,9 @@ GameObject:
   - component: {fileID: 253390671}
   - component: {fileID: 253390670}
   - component: {fileID: 253390669}
+  - component: {fileID: 253390672}
   m_Layer: 0
-  m_Name: ButtonBox
+  m_Name: ButtonBoxRight (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4149,6 +4137,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &253390670
 BoxCollider:
@@ -4169,6 +4158,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 253390667}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &253390672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 253390667}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &254518093
 GameObject:
   m_ObjectHideFlags: 0
@@ -4230,6 +4233,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &254518096
 BoxCollider:
@@ -4311,6 +4315,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &264332021
 BoxCollider:
@@ -4391,6 +4396,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &271212862
 MeshFilter:
@@ -4460,6 +4466,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &272049517
 BoxCollider:
@@ -4512,7 +4519,7 @@ Transform:
   - {fileID: 1140647815}
   - {fileID: 373788830}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 20
+  m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!114 &283242256
 MonoBehaviour:
@@ -4537,12 +4544,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   door: {fileID: 2070436702}
@@ -4618,6 +4619,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &285725476
 BoxCollider:
@@ -4637,6 +4639,108 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 285725473}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &294359798
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 294359799}
+  - component: {fileID: 294359803}
+  - component: {fileID: 294359802}
+  - component: {fileID: 294359801}
+  - component: {fileID: 294359800}
+  m_Layer: 0
+  m_Name: CloseButton3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &294359799
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 294359798}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.39999998, y: -0.286, z: 0.328}
+  m_LocalScale: {x: 0.03, y: 0.08, z: 0.08}
+  m_Children: []
+  m_Father: {fileID: 861792205}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &294359800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 294359798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &294359801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 294359798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  operateAxis: 0
+  ignoreCollisionsWith: []
+  autoInteraction: 1
+  connectedTo: {fileID: 0}
+  pressedDistance: -0.015
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
+--- !u!23 &294359802
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 294359798}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: b43e5571a9fe23946bf3070cdfceb1b0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &294359803
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 294359798}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &299548016
 GameObject:
@@ -4699,6 +4803,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &299548019
 BoxCollider:
@@ -4844,6 +4949,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &307760780
 BoxCollider:
@@ -4925,6 +5031,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &310259257
 BoxCollider:
@@ -5015,12 +5122,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -5063,6 +5164,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &310476738
 MeshFilter:
@@ -5116,6 +5218,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -5133,6 +5236,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &318632998
 Rigidbody:
@@ -5179,6 +5283,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &318633000
 BoxCollider:
@@ -5260,6 +5365,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &323521432
 BoxCollider:
@@ -5342,12 +5448,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 1655260105}
@@ -5385,8 +5485,9 @@ GameObject:
   - component: {fileID: 337570963}
   - component: {fileID: 337570962}
   - component: {fileID: 337570961}
+  - component: {fileID: 337570966}
   m_Layer: 0
-  m_Name: MovingPanel2
+  m_Name: ButtonPanelMoving2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5401,9 +5502,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.12800002, y: 0.0697217, z: -0.147}
   m_LocalScale: {x: 0.023182273, y: 0.22138526, z: 0.23293917}
-  m_Children: []
+  m_Children:
+  - {fileID: 752776152}
   m_Father: {fileID: 861792205}
-  m_RootOrder: 10
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &337570961
 Rigidbody:
@@ -5430,7 +5532,7 @@ Animator:
   m_Enabled: 1
   m_Avatar: {fileID: 0}
   m_Controller: {fileID: 9100000, guid: e5bb6a3130268d84394c2e803b296645, type: 2}
-  m_CullingMode: 2
+  m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
@@ -5467,6 +5569,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &337570964
 BoxCollider:
@@ -5487,6 +5590,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 337570959}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &337570966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 337570959}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &338366543
 GameObject:
   m_ObjectHideFlags: 0
@@ -5514,12 +5631,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   door: {fileID: 433076924}
@@ -5546,7 +5657,7 @@ Transform:
   m_Children:
   - {fileID: 433076925}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 10
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &340763019
 GameObject:
@@ -5610,6 +5721,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &340763023
 MeshFilter:
@@ -5679,6 +5791,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &341674754
 BoxCollider:
@@ -5760,6 +5873,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &348216395
 BoxCollider:
@@ -5872,6 +5986,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &349249310
 BoxCollider:
@@ -5953,6 +6068,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &350719281
 BoxCollider:
@@ -6048,10 +6164,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playareaCursor: {fileID: 0}
+  directionIndicator: {fileID: 0}
   customRaycast: {fileID: 0}
-  layersToIgnore:
-    serializedVersion: 2
-    m_Bits: 4
   pointerOriginSmoothingSettings:
     smoothsPosition: 0
     maxAllowedPerFrameDistanceDifference: 0.003
@@ -6080,13 +6194,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eba3cd5456cd79e49948f5ceb58544b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pointerToggleButton: 10
-  pointerSetButton: 10
-  grabToggleButton: 7
-  useToggleButton: 3
-  uiClickButton: 3
-  menuToggleButton: 14
   axisFidelity: 1
+  senseAxisForceZeroThreshold: 0.15
+  senseAxisPressThreshold: 0.95
   triggerClickThreshold: 1
   triggerForceZeroThreshold: 0.01
   triggerAxisZeroOnUntouch: 0
@@ -6098,6 +6208,7 @@ MonoBehaviour:
   triggerHairlinePressed: 0
   triggerClicked: 0
   triggerAxisChanged: 0
+  triggerSenseAxisChanged: 0
   gripPressed: 0
   gripTouched: 0
   gripHairlinePressed: 0
@@ -6106,16 +6217,15 @@ MonoBehaviour:
   touchpadPressed: 0
   touchpadTouched: 0
   touchpadAxisChanged: 0
+  touchpadSenseAxisChanged: 0
   buttonOnePressed: 0
   buttonOneTouched: 0
   buttonTwoPressed: 0
   buttonTwoTouched: 0
   startMenuPressed: 0
-  pointerPressed: 0
-  grabPressed: 0
-  usePressed: 0
-  uiClickPressed: 0
-  menuPressed: 0
+  middleFingerSenseAxisChanged: 0
+  ringFingerSenseAxisChanged: 0
+  pinkyFingerSenseAxisChanged: 0
   controllerVisible: 1
 --- !u!114 &352592077
 MonoBehaviour:
@@ -6129,6 +6239,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enableTeleport: 1
+  targetListPolicy: {fileID: 0}
   pointerRenderer: {fileID: 352592075}
   activationButton: 10
   holdButtonToActivate: 1
@@ -6143,7 +6254,6 @@ MonoBehaviour:
   controller: {fileID: 0}
   interactUse: {fileID: 0}
   customOrigin: {fileID: 0}
-  directionIndicator: {fileID: 0}
 --- !u!1 &354636356
 GameObject:
   m_ObjectHideFlags: 0
@@ -6231,12 +6341,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa2d32246d121964fbaddd05cf008d55, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 2
@@ -6279,6 +6383,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &355251651
 MeshFilter:
@@ -6345,12 +6450,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -6405,6 +6504,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &359216078
 MeshFilter:
@@ -6474,6 +6574,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &370642401
 BoxCollider:
@@ -6539,6 +6640,7 @@ MonoBehaviour:
   distanceBlinkDelay: 0
   headsetPositionCompensation: 1
   targetListPolicy: {fileID: 0}
+  navMeshData: {fileID: 0}
   navMeshLimitDistance: 0
 --- !u!1 &373235668
 GameObject:
@@ -6600,6 +6702,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &373235672
 MeshFilter:
@@ -6689,6 +6792,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &374432423
 GameObject:
@@ -6771,6 +6875,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &376868173
 GameObject:
@@ -6833,6 +6938,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &376868176
 BoxCollider:
@@ -6894,7 +7000,6 @@ GameObject:
   - component: {fileID: 386808177}
   - component: {fileID: 386808183}
   - component: {fileID: 386808181}
-  - component: {fileID: 386808180}
   - component: {fileID: 386808179}
   - component: {fileID: 386808178}
   m_Layer: 0
@@ -6911,11 +7016,11 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 386808176}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.028971195, y: 0.239, z: -0.16325903}
-  m_LocalScale: {x: 0.12089271, y: 0.04616272, z: 0.09585239}
+  m_LocalPosition: {x: -0.02, y: 0.23, z: -0.15}
+  m_LocalScale: {x: 0.12, y: 0.045, z: 0.1}
   m_Children: []
   m_Father: {fileID: 861792205}
-  m_RootOrder: 4
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &386808178
 MonoBehaviour:
@@ -6928,8 +7033,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &386808179
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6938,56 +7041,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 386808176}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableWhenIdle: 1
-  touchHighlightColor: {r: 0.034482718, g: 1, b: 0, a: 0}
-  allowedTouchControllers: 0
-  ignoredColliders: []
-  isGrabbable: 0
-  holdButtonToGrab: 1
-  stayGrabbedOnTeleport: 1
-  validDrop: 1
-  grabOverrideButton: 0
-  allowedGrabControllers: 0
-  grabAttachMechanicScript: {fileID: 0}
-  secondaryGrabActionScript: {fileID: 0}
-  isUsable: 0
-  holdButtonToUse: 1
-  useOnlyIfGrabbed: 0
-  pointerActivatesUseAction: 0
-  useOverrideButton: 0
-  allowedUseControllers: 0
-  usingState: 0
---- !u!114 &386808180
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 386808176}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 1
+  operateAxis: 1
+  ignoreCollisionsWith: []
+  autoInteraction: 1
   connectedTo: {fileID: 0}
-  direction: 0
-  activationDistance: 0.031024741
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  pressedDistance: 0.025
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
 --- !u!23 &386808181
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -7018,6 +7083,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &386808183
 MeshFilter:
@@ -7140,6 +7206,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -7157,6 +7224,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!1 &403538802
 GameObject:
@@ -7219,6 +7287,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &403538805
 BoxCollider:
@@ -7300,6 +7369,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &409921316
 BoxCollider:
@@ -7346,7 +7416,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 21
+  m_RootOrder: 23
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &416193695
 GameObject:
@@ -7409,6 +7479,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &416193698
 BoxCollider:
@@ -7429,6 +7500,34 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 416193695}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &416314762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 416314763}
+  m_Layer: 0
+  m_Name: ButtonsClose
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &416314763
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 416314762}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 861792205}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &418828629
 GameObject:
   m_ObjectHideFlags: 0
@@ -7490,6 +7589,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &418828632
 BoxCollider:
@@ -7571,6 +7671,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &419532990
 BoxCollider:
@@ -7652,6 +7753,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &422717201
 BoxCollider:
@@ -7716,12 +7818,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 1198275049}
@@ -7812,12 +7908,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -7860,6 +7950,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &427001882
 MeshFilter:
@@ -7949,6 +8040,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &432246048
 GameObject:
@@ -8011,6 +8103,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &432246051
 BoxCollider:
@@ -8092,6 +8185,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &433076927
 MeshFilter:
@@ -8156,12 +8250,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 389718527}
   direction: 0
@@ -8202,6 +8290,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &443618990
 BoxCollider:
@@ -8283,6 +8372,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &444094819
 BoxCollider:
@@ -8364,6 +8454,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &448188061
 BoxCollider:
@@ -8465,6 +8556,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &451237932
 GameObject:
@@ -8527,6 +8619,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &451237935
 BoxCollider:
@@ -8591,39 +8684,6 @@ MonoBehaviour:
   control: {fileID: 1574929627}
   inside: {fileID: 1588813355}
   outside: {fileID: 1886053591}
---- !u!1 &455225189
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 455225190}
-  m_Layer: 0
-  m_Name: DispenserBox
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &455225190
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 455225189}
-  m_LocalRotation: {x: -0.00000019535477, y: 0.00000026484173, z: -0.70710635, w: 0.7071072}
-  m_LocalPosition: {x: -1.1105001, y: 0.32999992, z: 0.054233275}
-  m_LocalScale: {x: 0.9691338, y: 6.7839365, z: 0.8556164}
-  m_Children:
-  - {fileID: 1418623282}
-  - {fileID: 518559197}
-  - {fileID: 1782252065}
-  - {fileID: 211316603}
-  - {fileID: 691668004}
-  m_Father: {fileID: 1499571915}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -89.9999}
 --- !u!1 &457054531
 GameObject:
   m_ObjectHideFlags: 0
@@ -8694,12 +8754,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -8742,6 +8796,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &457054537
 MeshFilter:
@@ -8777,12 +8832,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 793700859}
@@ -8899,6 +8948,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &465954573
 BoxCollider:
@@ -8980,6 +9030,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &466703730
 BoxCollider:
@@ -9081,6 +9132,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &469879064
 GameObject:
@@ -9129,6 +9181,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &469879066
 MeshFilter:
@@ -9212,6 +9265,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &479503982
 BoxCollider:
@@ -9313,6 +9367,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &481220120
 GameObject:
@@ -9375,6 +9430,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &481220124
 BoxCollider:
@@ -9456,6 +9512,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &482136121
 BoxCollider:
@@ -9537,6 +9594,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &483491786
 BoxCollider:
@@ -9618,6 +9676,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &483915700
 BoxCollider:
@@ -9719,6 +9778,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &496930643
 GameObject:
@@ -9767,6 +9827,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &496930646
 MeshFilter:
@@ -9851,6 +9912,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &501133087
 BoxCollider:
@@ -9929,12 +9991,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 1848526918}
   grabType: 0
@@ -9989,6 +10045,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &506314285
 MeshFilter:
@@ -10057,6 +10114,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &507031316
 MeshFilter:
@@ -10126,6 +10184,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &508057934
 BoxCollider:
@@ -10145,87 +10204,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 508057931}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &518559196
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 518559197}
-  - component: {fileID: 518559200}
-  - component: {fileID: 518559199}
-  - component: {fileID: 518559198}
-  m_Layer: 0
-  m_Name: ButtonBox (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &518559197
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 518559196}
-  m_LocalRotation: {x: 0, y: 0, z: -0.70685434, w: 0.70735925}
-  m_LocalPosition: {x: 0.448, y: 0.626, z: -0.038622886}
-  m_LocalScale: {x: 0.06974636, y: 0.013311465, z: 0.14504232}
-  m_Children: []
-  m_Father: {fileID: 455225190}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -89.9591}
---- !u!23 &518559198
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 518559196}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: fa756b232992781448908e45ad28eece, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!65 &518559199
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 518559196}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &518559200
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 518559196}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &519929508
 GameObject:
@@ -10288,6 +10266,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &519929511
 BoxCollider:
@@ -10368,6 +10347,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &544844317
 MeshFilter:
@@ -10470,6 +10450,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &558066650
 BoxCollider:
@@ -10546,12 +10527,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -10592,6 +10567,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &561372882
 BoxCollider:
@@ -10722,6 +10698,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &562601793
 BoxCollider:
@@ -10797,12 +10774,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 01b86803f9669aa40be161b11ec9272e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 2
@@ -10841,6 +10812,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &564304744
 MeshFilter:
@@ -10964,6 +10936,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &572456005
 GameObject:
@@ -11026,6 +10999,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &572456008
 BoxCollider:
@@ -11127,6 +11101,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &574664242
 GameObject:
@@ -11189,6 +11164,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &574664245
 BoxCollider:
@@ -11270,6 +11246,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &579753251
 BoxCollider:
@@ -11351,6 +11328,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &581055189
 BoxCollider:
@@ -11485,6 +11463,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &583920396
 GameObject:
@@ -11547,6 +11526,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &583920399
 BoxCollider:
@@ -11628,6 +11608,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &587904034
 BoxCollider:
@@ -11741,6 +11722,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &602927353
 BoxCollider:
@@ -11822,6 +11804,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &610081551
 BoxCollider:
@@ -11902,6 +11885,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &615115127
 MeshFilter:
@@ -11970,6 +11954,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &618575947
 MeshFilter:
@@ -12039,6 +12024,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &621085144
 BoxCollider:
@@ -12104,6 +12090,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -12121,6 +12108,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &630186608
 Rigidbody:
@@ -12167,6 +12155,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &630186610
 BoxCollider:
@@ -12248,6 +12237,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &631197961
 BoxCollider:
@@ -12361,6 +12351,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &638229501
 BoxCollider:
@@ -12442,6 +12433,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &641287245
 BoxCollider:
@@ -12507,6 +12499,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -12524,6 +12517,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &643236390
 Rigidbody:
@@ -12570,6 +12564,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &643236392
 BoxCollider:
@@ -12651,6 +12646,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &649053605
 BoxCollider:
@@ -12801,7 +12797,7 @@ Prefab:
     - target: {fileID: 224000012326194302, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012326194302, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12811,7 +12807,7 @@ Prefab:
     - target: {fileID: 224000012326194302, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12831,7 +12827,7 @@ Prefab:
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12841,7 +12837,7 @@ Prefab:
     - target: {fileID: 224000012859001416, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12861,7 +12857,7 @@ Prefab:
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -30
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12871,7 +12867,7 @@ Prefab:
     - target: {fileID: 224000012504011746, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12891,7 +12887,7 @@ Prefab:
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12901,7 +12897,7 @@ Prefab:
     - target: {fileID: 224000010358937380, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12921,7 +12917,7 @@ Prefab:
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12931,7 +12927,7 @@ Prefab:
     - target: {fileID: 224000012747905524, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12951,7 +12947,7 @@ Prefab:
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12961,7 +12957,7 @@ Prefab:
     - target: {fileID: 224000010901609716, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 16
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12981,7 +12977,7 @@ Prefab:
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -30
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -12991,7 +12987,7 @@ Prefab:
     - target: {fileID: 224000010722234208, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -13011,7 +13007,7 @@ Prefab:
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -55
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -13021,7 +13017,7 @@ Prefab:
     - target: {fileID: 224000010535295132, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -13041,7 +13037,7 @@ Prefab:
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -25.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -13051,7 +13047,7 @@ Prefab:
     - target: {fileID: 224000012484682510, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 41
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -13071,7 +13067,7 @@ Prefab:
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -82
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
@@ -13081,7 +13077,37 @@ Prefab:
     - target: {fileID: 224000010031187690, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 66
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 329
+      objectReference: {fileID: 0}
+    - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 142
+      objectReference: {fileID: 0}
+    - target: {fileID: 224000012623161658, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d46cf6b1ad9d84a48ae7548a2a6b41b3, type: 2}
@@ -13146,12 +13172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 1
   lid: {fileID: 206119189}
@@ -13170,7 +13190,6 @@ GameObject:
   - component: {fileID: 670552607}
   - component: {fileID: 670552613}
   - component: {fileID: 670552611}
-  - component: {fileID: 670552610}
   - component: {fileID: 670552609}
   - component: {fileID: 670552608}
   m_Layer: 0
@@ -13186,13 +13205,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 670552606}
-  m_LocalRotation: {x: 0.5000002, y: 0.50000024, z: 0.49999988, w: 0.49999982}
-  m_LocalPosition: {x: 0.1534, y: -0.1366, z: 0.18560427}
-  m_LocalScale: {x: 0.05820466, y: 0.08904197, z: 0.1176197}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.1534, y: -0.14, z: 0.18560427}
+  m_LocalScale: {x: 0.11, y: 0.05, z: 0.08}
   m_Children: []
   m_Father: {fileID: 861792205}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &670552608
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13204,8 +13223,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &670552609
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13214,56 +13231,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 670552606}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableWhenIdle: 1
-  touchHighlightColor: {r: 0.034482718, g: 1, b: 0, a: 0}
-  allowedTouchControllers: 0
-  ignoredColliders: []
-  isGrabbable: 0
-  holdButtonToGrab: 1
-  stayGrabbedOnTeleport: 1
-  validDrop: 1
-  grabOverrideButton: 0
-  allowedGrabControllers: 0
-  grabAttachMechanicScript: {fileID: 0}
-  secondaryGrabActionScript: {fileID: 0}
-  isUsable: 0
-  holdButtonToUse: 1
-  useOnlyIfGrabbed: 0
-  pointerActivatesUseAction: 0
-  useOverrideButton: 0
-  allowedUseControllers: 0
-  usingState: 0
---- !u!114 &670552610
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 670552606}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 1
+  operateAxis: 1
+  ignoreCollisionsWith: []
+  autoInteraction: 1
   connectedTo: {fileID: 0}
-  direction: 0
-  activationDistance: 0.046147197
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  pressedDistance: -0.025
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
 --- !u!23 &670552611
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -13294,6 +13273,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &670552613
 MeshFilter:
@@ -13363,6 +13343,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &679776122
 BoxCollider:
@@ -13453,12 +13434,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -13501,6 +13476,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &679789515
 MeshFilter:
@@ -13564,32 +13540,92 @@ Prefab:
         type: 2}
       propertyPath: actualBoundaries
       value: 
-      objectReference: {fileID: 686392171}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: actualHeadset
       value: 
-      objectReference: {fileID: 686392174}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: actualLeftController
       value: 
-      objectReference: {fileID: 686392173}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: actualRightController
       value: 
-      objectReference: {fileID: 686392172}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: modelAliasLeftController
       value: 
-      objectReference: {fileID: 686392170}
+      objectReference: {fileID: 0}
     - target: {fileID: 114000010315091656, guid: 41c0760bd81dd084283814f0c432b466,
         type: 2}
       propertyPath: modelAliasRightController
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualBoundaries
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualHeadset
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualLeftController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualRightController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasLeftController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114325014944607380, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasRightController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualBoundaries
+      value: 
+      objectReference: {fileID: 686392174}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualHeadset
+      value: 
       objectReference: {fileID: 686392169}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualLeftController
+      value: 
+      objectReference: {fileID: 686392173}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: actualRightController
+      value: 
+      objectReference: {fileID: 686392171}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasLeftController
+      value: 
+      objectReference: {fileID: 686392172}
+    - target: {fileID: 114000012492157348, guid: 41c0760bd81dd084283814f0c432b466,
+        type: 2}
+      propertyPath: modelAliasRightController
+      value: 
+      objectReference: {fileID: 686392170}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 41c0760bd81dd084283814f0c432b466, type: 2}
   m_IsPrefabParent: 0
@@ -13630,32 +13666,32 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eeda6d41317f444b900e374895f14e95, type: 3}
 --- !u!1 &686392169 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1846200688178366, guid: 41c0760bd81dd084283814f0c432b466,
+  m_PrefabParentObject: {fileID: 1000014132296520, guid: 41c0760bd81dd084283814f0c432b466,
     type: 2}
   m_PrefabInternal: {fileID: 686392162}
 --- !u!1 &686392170 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1297872528131846, guid: 41c0760bd81dd084283814f0c432b466,
+  m_PrefabParentObject: {fileID: 1000011766909148, guid: 41c0760bd81dd084283814f0c432b466,
     type: 2}
   m_PrefabInternal: {fileID: 686392162}
 --- !u!1 &686392171 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1000012704122952, guid: 41c0760bd81dd084283814f0c432b466,
+  m_PrefabParentObject: {fileID: 1000013731061326, guid: 41c0760bd81dd084283814f0c432b466,
     type: 2}
   m_PrefabInternal: {fileID: 686392162}
 --- !u!1 &686392172 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1000012404417072, guid: 41c0760bd81dd084283814f0c432b466,
+  m_PrefabParentObject: {fileID: 1000010517668602, guid: 41c0760bd81dd084283814f0c432b466,
     type: 2}
   m_PrefabInternal: {fileID: 686392162}
 --- !u!1 &686392173 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1000012074436610, guid: 41c0760bd81dd084283814f0c432b466,
+  m_PrefabParentObject: {fileID: 1000010636551700, guid: 41c0760bd81dd084283814f0c432b466,
     type: 2}
   m_PrefabInternal: {fileID: 686392162}
 --- !u!1 &686392174 stripped
 GameObject:
-  m_PrefabParentObject: {fileID: 1000013428897076, guid: 41c0760bd81dd084283814f0c432b466,
+  m_PrefabParentObject: {fileID: 1000010207334600, guid: 41c0760bd81dd084283814f0c432b466,
     type: 2}
   m_PrefabInternal: {fileID: 686392162}
 --- !u!1 &687120172
@@ -13719,6 +13755,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &687120175
 BoxCollider:
@@ -13772,34 +13809,6 @@ Transform:
   - {fileID: 873129646}
   m_Father: {fileID: 2085183771}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &691668003
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 691668004}
-  m_Layer: 0
-  m_Name: Dispenser
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &691668004
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 691668003}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.3425, y: 0.6517, z: -0.0391}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 455225190}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &692367762
 GameObject:
@@ -13862,6 +13871,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &692367765
 BoxCollider:
@@ -13942,6 +13952,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &695205550
 MeshFilter:
@@ -14011,6 +14022,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &698243010
 BoxCollider:
@@ -14089,12 +14101,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -14137,6 +14143,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &701002156
 BoxCollider:
@@ -14218,6 +14225,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &703930581
 BoxCollider:
@@ -14319,6 +14327,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &722950352
 GameObject:
@@ -14384,6 +14393,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &722950355
 BoxCollider:
@@ -14465,6 +14475,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &723062686
 BoxCollider:
@@ -14555,12 +14566,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -14603,6 +14608,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &730372007
 MeshFilter:
@@ -14671,6 +14677,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &730950278
 MeshFilter:
@@ -14740,6 +14747,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &731355290
 BoxCollider:
@@ -14807,6 +14815,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &734257393
 MeshFilter:
@@ -14910,6 +14919,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &741144691
 GameObject:
@@ -14967,12 +14977,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -15013,6 +15017,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &741144696
 BoxCollider:
@@ -15094,6 +15099,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &742620899
 BoxCollider:
@@ -15174,6 +15180,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &743151572
 MeshFilter:
@@ -15242,6 +15249,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &744175909
 MeshFilter:
@@ -15320,12 +15328,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -15368,6 +15370,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &747276590
 MeshFilter:
@@ -15437,6 +15440,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &752307147
 BoxCollider:
@@ -15467,11 +15471,10 @@ GameObject:
   - component: {fileID: 752776152}
   - component: {fileID: 752776157}
   - component: {fileID: 752776156}
-  - component: {fileID: 752776155}
   - component: {fileID: 752776154}
   - component: {fileID: 752776153}
   m_Layer: 0
-  m_Name: ButtonWall2AutoSetup
+  m_Name: ButtonMoving2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -15483,12 +15486,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 752776151}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.07459998, y: 0.07700002, z: -0.143}
-  m_LocalScale: {x: 0.029705092, y: 0.098105855, z: 0.0958524}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.5019104, y: 0.03287628, z: 0.017171836}
+  m_LocalScale: {x: 1.2940923, y: 0.45170125, z: 0.42929664}
   m_Children: []
-  m_Father: {fileID: 861792205}
-  m_RootOrder: 11
+  m_Father: {fileID: 337570960}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &752776153
 MonoBehaviour:
@@ -15501,8 +15504,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &752776154
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15511,56 +15512,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 752776151}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableWhenIdle: 1
-  touchHighlightColor: {r: 0.034482718, g: 1, b: 0, a: 0}
-  allowedTouchControllers: 0
-  ignoredColliders: []
-  isGrabbable: 0
-  holdButtonToGrab: 1
-  stayGrabbedOnTeleport: 1
-  validDrop: 1
-  grabOverrideButton: 0
-  allowedGrabControllers: 0
-  grabAttachMechanicScript: {fileID: 0}
-  secondaryGrabActionScript: {fileID: 0}
-  isUsable: 0
-  holdButtonToUse: 1
-  useOnlyIfGrabbed: 0
-  pointerActivatesUseAction: 0
-  useOverrideButton: 0
-  allowedUseControllers: 0
-  usingState: 0
---- !u!114 &752776155
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 752776151}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 1
-  connectedTo: {fileID: 337570959}
-  direction: 0
-  activationDistance: 0.025608616
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  operateAxis: 0
+  ignoreCollisionsWith: []
+  autoInteraction: 1
+  connectedTo: {fileID: 337570961}
+  pressedDistance: -0.02
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
 --- !u!23 &752776156
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -15591,6 +15554,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &752776157
 MeshFilter:
@@ -15660,6 +15624,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &753655396
 BoxCollider:
@@ -15725,6 +15690,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -15742,6 +15708,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &758710436
 Rigidbody:
@@ -15788,6 +15755,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &758710438
 BoxCollider:
@@ -15869,6 +15837,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &759819375
 BoxCollider:
@@ -15970,6 +15939,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &773366195
 GameObject:
@@ -16065,6 +16035,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &774814179
 BoxCollider:
@@ -16166,6 +16137,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &776786559
 GameObject:
@@ -16215,6 +16187,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &776786561
 BoxCollider:
@@ -16309,6 +16282,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &779174870
 BoxCollider:
@@ -16389,6 +16363,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &782321211
 MeshFilter:
@@ -16495,6 +16470,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &790567674
 BoxCollider:
@@ -16576,6 +16552,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &791830648
 BoxCollider:
@@ -16667,7 +16644,7 @@ Transform:
   - {fileID: 4989975}
   - {fileID: 667658574}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 23
+  m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &795545441
 GameObject:
@@ -16750,6 +16727,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &801254833
 GameObject:
@@ -16796,6 +16774,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -16813,6 +16792,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &801254836
 Rigidbody:
@@ -16859,6 +16839,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &801254838
 BoxCollider:
@@ -16975,6 +16956,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &809313532
 BoxCollider:
@@ -17043,6 +17025,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &812621660
 BoxCollider:
@@ -17182,6 +17165,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &822064750
 MeshFilter:
@@ -17248,12 +17232,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -17308,6 +17286,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &829005382
 MeshFilter:
@@ -17421,6 +17400,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &836183235
 BoxCollider:
@@ -17501,6 +17481,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &841002133
 MeshFilter:
@@ -17541,7 +17522,7 @@ Transform:
   - {fileID: 427001877}
   - {fileID: 747276585}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 15
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &845422756
 GameObject:
@@ -17604,6 +17585,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &845422759
 BoxCollider:
@@ -17649,20 +17631,22 @@ Transform:
   m_LocalPosition: {x: -1.75933, y: -0.4528495, z: -1.2747307}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 989800202}
-  - {fileID: 670552607}
-  - {fileID: 1578491620}
-  - {fileID: 1931883182}
-  - {fileID: 386808177}
-  - {fileID: 125528463}
+  - {fileID: 2095760749}
   - {fileID: 951483493}
+  - {fileID: 670552607}
   - {fileID: 1111980837}
+  - {fileID: 1578491620}
+  - {fileID: 125528463}
   - {fileID: 1955316052}
-  - {fileID: 1413909002}
   - {fileID: 337570960}
-  - {fileID: 752776152}
+  - {fileID: 386808177}
+  - {fileID: 1931883182}
+  - {fileID: 416314763}
+  - {fileID: 1567409580}
+  - {fileID: 1363681011}
+  - {fileID: 294359799}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &862512961
 GameObject:
@@ -17725,6 +17709,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &862512964
 BoxCollider:
@@ -17838,6 +17823,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &866988466
 MeshFilter:
@@ -17938,6 +17924,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &873062142
 BoxCollider:
@@ -18039,6 +18026,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &878348679
 GameObject:
@@ -18085,6 +18073,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -18102,6 +18091,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &878348682
 Rigidbody:
@@ -18148,6 +18138,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &878348684
 BoxCollider:
@@ -18249,6 +18240,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &886177590
 GameObject:
@@ -18311,6 +18303,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &886177593
 BoxCollider:
@@ -18391,6 +18384,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &887206084
 MeshFilter:
@@ -18459,6 +18453,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &890684509
 MeshFilter:
@@ -18530,6 +18525,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &910524194
 BoxCollider:
@@ -18611,6 +18607,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &912211375
 BoxCollider:
@@ -18692,6 +18689,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &927550168
 BoxCollider:
@@ -18773,6 +18771,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &934276609
 BoxCollider:
@@ -18853,6 +18852,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &935276391
 MeshFilter:
@@ -18921,6 +18921,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &945334726
 MeshFilter:
@@ -18971,7 +18972,7 @@ GameObject:
   m_Component:
   - component: {fileID: 951483493}
   m_Layer: 0
-  m_Name: ButtonBox (1)
+  m_Name: ButtonBoxBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -18992,7 +18993,7 @@ Transform:
   - {fileID: 91285373}
   - {fileID: 1694904088}
   m_Father: {fileID: 861792205}
-  m_RootOrder: 6
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 75.1948, z: 0}
 --- !u!1 &957849495
 GameObject:
@@ -19088,6 +19089,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &958206736
 BoxCollider:
@@ -19189,6 +19191,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &959864201
 GameObject:
@@ -19251,6 +19254,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &959864204
 BoxCollider:
@@ -19332,6 +19336,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &960657198
 BoxCollider:
@@ -19413,6 +19418,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &960983907
 BoxCollider:
@@ -19527,6 +19533,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &963675838
 BoxCollider:
@@ -19608,6 +19615,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &963760554
 BoxCollider:
@@ -19709,6 +19717,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &978587802
 GameObject:
@@ -19770,6 +19779,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &978587806
 MeshFilter:
@@ -19836,12 +19846,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -19896,6 +19900,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &987254704
 MeshFilter:
@@ -19964,6 +19969,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &988600947
 MeshFilter:
@@ -19997,11 +20003,11 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 989800201}
-  m_LocalRotation: {x: -0, y: -0.12884067, z: -0, w: 0.99166536}
-  m_LocalPosition: {x: 0.1888, y: -0.16467834, z: -0.1515}
-  m_LocalScale: {x: 0.1208927, y: 0.07018248, z: 0.19750018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.07, z: 0.18999997}
   m_Children: []
-  m_Father: {fileID: 861792205}
+  m_Father: {fileID: 2095760749}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: -14.8052, z: 0}
 --- !u!114 &989800203
@@ -20015,8 +20021,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &989800204
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20025,26 +20029,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 989800201}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 1
+  operateAxis: 0
+  ignoreCollisionsWith: []
+  autoInteraction: 1
   connectedTo: {fileID: 0}
-  direction: 1
-  activationDistance: 0.1
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  pressedDistance: -0.15
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 30
 --- !u!23 &989800205
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -20075,6 +20071,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &989800206
 MeshFilter:
@@ -20144,6 +20141,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &991284171
 BoxCollider:
@@ -20225,6 +20223,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1002809583
 BoxCollider:
@@ -20338,6 +20337,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1005612427
 MeshFilter:
@@ -20407,6 +20407,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1012303518
 BoxCollider:
@@ -20485,12 +20486,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -20545,6 +20540,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1014493205
 MeshFilter:
@@ -20614,6 +20610,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1020111037
 BoxCollider:
@@ -20735,6 +20732,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1028624022
 BoxCollider:
@@ -20816,6 +20814,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1034954701
 MeshFilter:
@@ -20885,6 +20884,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1035951826
 BoxCollider:
@@ -20966,6 +20966,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1039761443
 BoxCollider:
@@ -21067,6 +21068,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1045123401
 GameObject:
@@ -21138,12 +21140,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -21186,6 +21182,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1045123407
 MeshFilter:
@@ -21255,6 +21252,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1046436319
 BoxCollider:
@@ -21307,7 +21305,7 @@ Transform:
   - {fileID: 701002152}
   - {fileID: 730372002}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 14
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1054604253
 GameObject:
@@ -21385,12 +21383,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 1536700038}
@@ -21457,12 +21449,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 3
   door: {fileID: 0}
@@ -21507,6 +21493,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1067194362
 MeshFilter:
@@ -21564,6 +21551,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1068412303
 MeshFilter:
@@ -21596,12 +21584,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 01b86803f9669aa40be161b11ec9272e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -21650,7 +21632,7 @@ Transform:
   - {fileID: 1276602018}
   - {fileID: 1067194359}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 22
+  m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1078750245
 GameObject:
@@ -21733,6 +21715,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1080801593
 GameObject:
@@ -21792,12 +21775,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -21852,6 +21829,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1080801599
 MeshFilter:
@@ -21920,6 +21898,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1080961580
 MeshFilter:
@@ -21989,6 +21968,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1086432789
 BoxCollider:
@@ -22077,6 +22057,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1088267109
 Transform:
@@ -22172,6 +22153,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1097269206
 GameObject:
@@ -22200,12 +22182,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 1
   lid: {fileID: 48941951}
@@ -22291,6 +22267,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1100259810
 BoxCollider:
@@ -22372,6 +22349,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1102428216
 BoxCollider:
@@ -22473,6 +22451,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1109596560
 GameObject:
@@ -22530,12 +22509,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -22576,6 +22549,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1109596565
 BoxCollider:
@@ -22654,12 +22628,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -22714,6 +22682,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1110221671
 MeshFilter:
@@ -22731,7 +22700,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1111980837}
   m_Layer: 0
-  m_Name: ButtonBox (2)
+  m_Name: ButtonBoxDown
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -22752,7 +22721,7 @@ Transform:
   - {fileID: 1207567907}
   - {fileID: 1617217079}
   m_Father: {fileID: 861792205}
-  m_RootOrder: 7
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1113662392
 GameObject:
@@ -22822,6 +22791,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1113662395
 Transform:
@@ -22864,12 +22834,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   door: {fileID: 469879064}
@@ -22900,7 +22864,7 @@ Transform:
   - {fileID: 1426182960}
   - {fileID: 1323988948}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1115677710
 MonoBehaviour:
@@ -22975,6 +22939,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1116909571
 BoxCollider:
@@ -23055,6 +23020,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1127187758
 MeshFilter:
@@ -23124,6 +23090,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1128882296
 BoxCollider:
@@ -23259,6 +23226,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1135670851
 GameObject:
@@ -23308,6 +23276,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1135670853
 BoxCollider:
@@ -23422,6 +23391,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1138379884
 GameObject:
@@ -23468,6 +23438,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -23485,6 +23456,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &1138379887
 Rigidbody:
@@ -23531,6 +23503,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1138379889
 BoxCollider:
@@ -23642,6 +23615,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1147452608
 MeshFilter:
@@ -23711,6 +23685,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1173581220
 BoxCollider:
@@ -23791,6 +23766,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1176819067
 MeshFilter:
@@ -23860,6 +23836,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1177915725
 BoxCollider:
@@ -23941,6 +23918,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1180381655
 BoxCollider:
@@ -24022,6 +24000,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1182989574
 BoxCollider:
@@ -24103,6 +24082,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1186227156
 BoxCollider:
@@ -24184,6 +24164,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1187059376
 BoxCollider:
@@ -24289,12 +24270,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -24335,6 +24310,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1193295662
 BoxCollider:
@@ -24418,6 +24394,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1196313813
 BoxCollider:
@@ -24592,6 +24569,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1203303157
 MeshFilter:
@@ -24611,8 +24589,9 @@ GameObject:
   - component: {fileID: 1207567910}
   - component: {fileID: 1207567909}
   - component: {fileID: 1207567908}
+  - component: {fileID: 1207567911}
   m_Layer: 0
-  m_Name: ButtonBox (2)
+  m_Name: ButtonBoxDown (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -24661,6 +24640,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1207567909
 BoxCollider:
@@ -24681,6 +24661,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1207567906}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1207567911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1207567906}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1212154328
 GameObject:
   m_ObjectHideFlags: 0
@@ -24741,6 +24735,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1212154331
 MeshFilter:
@@ -24781,7 +24776,7 @@ Transform:
   - {fileID: 458676138}
   - {fileID: 1311182401}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 18
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1213696889
 MonoBehaviour:
@@ -24806,12 +24801,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   door: {fileID: 1034954698}
@@ -24887,6 +24876,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1218128883
 BoxCollider:
@@ -24968,6 +24958,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1227160590
 BoxCollider:
@@ -25049,6 +25040,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1227347815
 BoxCollider:
@@ -25130,6 +25122,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1231338406
 BoxCollider:
@@ -25231,6 +25224,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1236701106
 GameObject:
@@ -25292,6 +25286,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1236701109
 MeshFilter:
@@ -25365,6 +25360,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1249537963
 BoxCollider:
@@ -25477,6 +25473,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1253528819
 BoxCollider:
@@ -25616,12 +25613,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -25664,6 +25655,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1262602243
 MeshFilter:
@@ -25699,12 +25691,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 2
   lid: {fileID: 1733974794}
@@ -25790,6 +25776,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1269755670
 BoxCollider:
@@ -25871,6 +25858,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1273747111
 BoxCollider:
@@ -25952,6 +25940,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1276425287
 BoxCollider:
@@ -26014,12 +26003,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 2
   door: {fileID: 0}
@@ -26064,6 +26047,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1276602021
 MeshFilter:
@@ -26134,6 +26118,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1278442294
 BoxCollider:
@@ -26271,6 +26256,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1281008558
 MeshFilter:
@@ -26374,6 +26360,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1293294904
 BoxCollider:
@@ -26475,6 +26462,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1298072822
 GameObject:
@@ -26536,6 +26524,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1298072825
 MeshFilter:
@@ -26605,6 +26594,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1298629979
 BoxCollider:
@@ -26690,7 +26680,7 @@ Transform:
   - {fileID: 1617259575}
   - {fileID: 374432424}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 17
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1299809251
 MonoBehaviour:
@@ -26703,12 +26693,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   door: {fileID: 734257391}
@@ -26796,6 +26780,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1300948614
 BoxCollider:
@@ -26876,6 +26861,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1302278521
 MeshFilter:
@@ -26965,6 +26951,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1309004133
 GameObject:
@@ -27027,6 +27014,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1309004136
 BoxCollider:
@@ -27108,6 +27096,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1309273015
 BoxCollider:
@@ -27209,6 +27198,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1314653504
 GameObject:
@@ -27271,6 +27261,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1314653507
 BoxCollider:
@@ -27385,6 +27376,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1318428761
 BoxCollider:
@@ -27466,6 +27458,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1321231466
 BoxCollider:
@@ -27591,6 +27584,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1333450682
 BoxCollider:
@@ -27672,6 +27666,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1339961013
 BoxCollider:
@@ -27753,6 +27748,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1342029603
 BoxCollider:
@@ -27784,8 +27780,9 @@ GameObject:
   - component: {fileID: 1355285944}
   - component: {fileID: 1355285943}
   - component: {fileID: 1355285942}
+  - component: {fileID: 1355285945}
   m_Layer: 0
-  m_Name: ButtonBox (2)
+  m_Name: ButtonBoxRight (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -27834,6 +27831,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1355285943
 BoxCollider:
@@ -27854,6 +27852,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1355285940}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1355285945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1355285940}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1001 &1356735698
 Prefab:
   m_ObjectHideFlags: 0
@@ -27952,6 +27964,7 @@ GameObject:
   - component: {fileID: 1358126071}
   - component: {fileID: 1358126070}
   - component: {fileID: 1358126069}
+  - component: {fileID: 1358126072}
   m_Layer: 0
   m_Name: ButtonTable
   m_TagString: Untagged
@@ -27965,12 +27978,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1358126067}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.7500001, y: -0.21428578, z: 0}
-  m_LocalScale: {x: 2.5, y: 0.5714286, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.65333, y: -1.0671278, z: -0.94173074}
+  m_LocalScale: {x: 0.5, y: 0.8, z: 1.5857425}
   m_Children: []
-  m_Father: {fileID: 1499571915}
-  m_RootOrder: 0
+  m_Father: {fileID: 2085183771}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1358126069
 MeshRenderer:
@@ -28002,6 +28015,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1358126070
 BoxCollider:
@@ -28022,6 +28036,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1358126067}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1358126072
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1358126067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1358629694
 GameObject:
   m_ObjectHideFlags: 0
@@ -28086,6 +28114,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1358629697
 BoxCollider:
@@ -28187,7 +28216,110 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &1363681010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1363681011}
+  - component: {fileID: 1363681015}
+  - component: {fileID: 1363681014}
+  - component: {fileID: 1363681013}
+  - component: {fileID: 1363681012}
+  m_Layer: 0
+  m_Name: CloseButton2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1363681011
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1363681010}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.39999998, y: -0.286, z: 0.211}
+  m_LocalScale: {x: 0.03, y: 0.08, z: 0.08}
+  m_Children: []
+  m_Father: {fileID: 861792205}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1363681012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1363681010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1363681013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1363681010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  operateAxis: 0
+  ignoreCollisionsWith: []
+  autoInteraction: 1
+  connectedTo: {fileID: 0}
+  pressedDistance: -0.015
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
+--- !u!23 &1363681014
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1363681010}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: b43e5571a9fe23946bf3070cdfceb1b0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1363681015
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1363681010}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1365880200
 GameObject:
   m_ObjectHideFlags: 0
@@ -28248,6 +28380,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1365880203
 MeshFilter:
@@ -28304,6 +28437,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1369360965
 BoxCollider:
@@ -28398,6 +28532,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1371201757
 BoxCollider:
@@ -28499,6 +28634,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1375963968
 GameObject:
@@ -28561,6 +28697,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1375963971
 BoxCollider:
@@ -28642,6 +28779,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1376350800
 BoxCollider:
@@ -28743,6 +28881,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1395482687
 GameObject:
@@ -28804,6 +28943,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1395482690
 MeshFilter:
@@ -28873,6 +29013,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1397658864
 BoxCollider:
@@ -28954,6 +29095,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1409274652
 BoxCollider:
@@ -29035,6 +29177,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1411484575
 BoxCollider:
@@ -29116,6 +29259,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1413734217
 BoxCollider:
@@ -29146,13 +29290,10 @@ GameObject:
   - component: {fileID: 1413909002}
   - component: {fileID: 1413909008}
   - component: {fileID: 1413909006}
-  - component: {fileID: 1413909005}
   - component: {fileID: 1413909004}
   - component: {fileID: 1413909003}
-  - component: {fileID: 1413909010}
-  - component: {fileID: 1413909007}
   m_Layer: 0
-  m_Name: ButtonWallManualSetup
+  m_Name: ButtonMoving1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29164,12 +29305,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1413909001}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.0746, y: 0.077, z: 0.199}
-  m_LocalScale: {x: 0.029705092, y: 0.098105855, z: 0.0958524}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.5019104, y: 0.03287628, z: 0.017171836}
+  m_LocalScale: {x: 1.2940923, y: 0.45170125, z: 0.42929664}
   m_Children: []
-  m_Father: {fileID: 861792205}
-  m_RootOrder: 9
+  m_Father: {fileID: 1955316052}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1413909003
 MonoBehaviour:
@@ -29182,8 +29323,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &1413909004
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29192,56 +29331,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 1413909001}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableWhenIdle: 1
-  touchHighlightColor: {r: 0.034482718, g: 1, b: 0, a: 0}
-  allowedTouchControllers: 0
-  ignoredColliders: []
-  isGrabbable: 0
-  holdButtonToGrab: 1
-  stayGrabbedOnTeleport: 1
-  validDrop: 1
-  grabOverrideButton: 0
-  allowedGrabControllers: 0
-  grabAttachMechanicScript: {fileID: 0}
-  secondaryGrabActionScript: {fileID: 0}
-  isUsable: 0
-  holdButtonToUse: 1
-  useOnlyIfGrabbed: 0
-  pointerActivatesUseAction: 0
-  useOverrideButton: 0
-  allowedUseControllers: 0
-  usingState: 0
---- !u!114 &1413909005
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1413909001}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 1
-  connectedTo: {fileID: 0}
-  direction: 0
-  activationDistance: 0.025608616
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  operateAxis: 0
+  ignoreCollisionsWith: []
+  autoInteraction: 1
+  connectedTo: {fileID: 1955316053}
+  pressedDistance: -0.02
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
 --- !u!23 &1413909006
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -29272,99 +29373,8 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!153 &1413909007
-ConfigurableJoint:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1413909001}
-  m_ConnectedBody: {fileID: 1955316053}
-  m_Anchor: {x: 0, y: 0.5, z: 0}
-  m_Axis: {x: 1, y: 0, z: 0}
-  m_AutoConfigureConnectedAnchor: 1
-  m_ConnectedAnchor: {x: 2.303486, y: 0.2544491, z: 0.017171836}
-  serializedVersion: 2
-  m_SecondaryAxis: {x: 0, y: 1, z: 0}
-  m_XMotion: 2
-  m_YMotion: 2
-  m_ZMotion: 2
-  m_AngularXMotion: 2
-  m_AngularYMotion: 2
-  m_AngularZMotion: 2
-  m_LinearLimitSpring:
-    spring: 0
-    damper: 0
-  m_LinearLimit:
-    limit: 0
-    bounciness: 0
-    contactDistance: 0
-  m_AngularXLimitSpring:
-    spring: 0
-    damper: 0
-  m_LowAngularXLimit:
-    limit: 0
-    bounciness: 0
-    contactDistance: 0
-  m_HighAngularXLimit:
-    limit: 0
-    bounciness: 0
-    contactDistance: 0
-  m_AngularYZLimitSpring:
-    spring: 0
-    damper: 0
-  m_AngularYLimit:
-    limit: 0
-    bounciness: 0
-    contactDistance: 0
-  m_AngularZLimit:
-    limit: 0
-    bounciness: 0
-    contactDistance: 0
-  m_TargetPosition: {x: 0, y: 0, z: 0}
-  m_TargetVelocity: {x: 0, y: 0, z: 0}
-  m_XDrive:
-    serializedVersion: 3
-    positionSpring: 0
-    positionDamper: 0
-    maximumForce: 3.4028233e+38
-  m_YDrive:
-    serializedVersion: 3
-    positionSpring: 0
-    positionDamper: 0
-    maximumForce: 3.4028233e+38
-  m_ZDrive:
-    serializedVersion: 3
-    positionSpring: 0
-    positionDamper: 0
-    maximumForce: 3.4028233e+38
-  m_TargetRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_TargetAngularVelocity: {x: 0, y: 0, z: 0}
-  m_RotationDriveMode: 0
-  m_AngularXDrive:
-    serializedVersion: 3
-    positionSpring: 0
-    positionDamper: 0
-    maximumForce: 3.4028233e+38
-  m_AngularYZDrive:
-    serializedVersion: 3
-    positionSpring: 0
-    positionDamper: 0
-    maximumForce: 3.4028233e+38
-  m_SlerpDrive:
-    serializedVersion: 3
-    positionSpring: 0
-    positionDamper: 0
-    maximumForce: 3.4028233e+38
-  m_ProjectionMode: 0
-  m_ProjectionDistance: 0.1
-  m_ProjectionAngle: 180
-  m_ConfiguredInWorldSpace: 0
-  m_SwapBodies: 0
-  m_BreakForce: Infinity
-  m_BreakTorque: Infinity
-  m_EnableCollision: 0
-  m_EnablePreprocessing: 1
 --- !u!33 &1413909008
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -29372,21 +29382,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1413909001}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!54 &1413909010
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1413909001}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!1 &1414961547
 GameObject:
   m_ObjectHideFlags: 0
@@ -29468,6 +29463,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1416144530
 GameObject:
@@ -29517,87 +29513,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1416144530}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1418623281
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1418623282}
-  - component: {fileID: 1418623285}
-  - component: {fileID: 1418623284}
-  - component: {fileID: 1418623283}
-  m_Layer: 0
-  m_Name: ButtonBox
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1418623282
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1418623281}
-  m_LocalRotation: {x: 0, y: 0, z: -0.70685434, w: 0.70735925}
-  m_LocalPosition: {x: 0.291, y: 0.626, z: -0.038622886}
-  m_LocalScale: {x: 0.06974615, y: 0.013311425, z: 0.14504232}
-  m_Children: []
-  m_Father: {fileID: 455225190}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -89.9591}
---- !u!23 &1418623283
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1418623281}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: fa756b232992781448908e45ad28eece, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!65 &1418623284
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1418623281}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &1418623285
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1418623281}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1426182957
 GameObject:
@@ -29667,6 +29582,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1426182960
 Transform:
@@ -29736,12 +29652,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d5264f69557f7c46ae368ee023d5b1a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 1
   connectedTo: {fileID: 0}
   direction: 0
@@ -29832,6 +29742,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1436270168
 GameObject:
@@ -29844,8 +29755,9 @@ GameObject:
   - component: {fileID: 1436270172}
   - component: {fileID: 1436270171}
   - component: {fileID: 1436270170}
+  - component: {fileID: 1436270173}
   m_Layer: 0
-  m_Name: ButtonBox (3)
+  m_Name: ButtonBoxRight (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -29894,6 +29806,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1436270171
 BoxCollider:
@@ -29914,6 +29827,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1436270168}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1436270173
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1436270168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1439572035
 GameObject:
   m_ObjectHideFlags: 0
@@ -29974,6 +29901,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1439572039
 MeshFilter:
@@ -30043,6 +29971,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1443960174
 BoxCollider:
@@ -30123,6 +30052,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1445663197
 MeshFilter:
@@ -30192,6 +30122,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1461478067
 BoxCollider:
@@ -30273,6 +30204,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1467583473
 BoxCollider:
@@ -30338,6 +30270,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -30355,6 +30288,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &1473594646
 Rigidbody:
@@ -30401,6 +30335,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1473594648
 BoxCollider:
@@ -30482,6 +30417,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1478001864
 BoxCollider:
@@ -30594,6 +30530,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1482968646
 BoxCollider:
@@ -30675,6 +30612,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1484304277
 BoxCollider:
@@ -30706,8 +30644,9 @@ GameObject:
   - component: {fileID: 1491842988}
   - component: {fileID: 1491842987}
   - component: {fileID: 1491842986}
+  - component: {fileID: 1491842989}
   m_Layer: 0
-  m_Name: ButtonBox (1)
+  m_Name: ButtonBoxDown (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30756,6 +30695,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1491842987
 BoxCollider:
@@ -30776,6 +30716,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1491842984}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1491842989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1491842984}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1495571453
 GameObject:
   m_ObjectHideFlags: 0
@@ -30824,6 +30778,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1495571455
 BoxCollider:
@@ -30868,6 +30823,7 @@ GameObject:
   - component: {fileID: 1499571918}
   - component: {fileID: 1499571917}
   - component: {fileID: 1499571916}
+  - component: {fileID: 1499571919}
   m_Layer: 0
   m_Name: ButtonWall
   m_TagString: Untagged
@@ -30884,10 +30840,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.00333, y: -0.76712775, z: -0.94173074}
   m_LocalScale: {x: 0.2, y: 1.4, z: 1.5857425}
-  m_Children:
-  - {fileID: 1358126068}
-  - {fileID: 214899991}
-  - {fileID: 455225190}
+  m_Children: []
   m_Father: {fileID: 2085183771}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -30921,6 +30874,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1499571917
 BoxCollider:
@@ -30941,6 +30895,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1499571914}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1499571919
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1499571914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1500334709
 GameObject:
   m_ObjectHideFlags: 0
@@ -31001,6 +30969,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1500334712
 MeshFilter:
@@ -31070,6 +31039,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1503947235
 BoxCollider:
@@ -31151,6 +31121,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1511312238
 BoxCollider:
@@ -31252,6 +31223,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1511872289
 GameObject:
@@ -31311,12 +31283,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -31371,6 +31337,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1511872295
 MeshFilter:
@@ -31440,6 +31407,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1518418672
 BoxCollider:
@@ -31521,6 +31489,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1520566993
 BoxCollider:
@@ -31602,6 +31571,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1521962133
 BoxCollider:
@@ -31683,6 +31653,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1526877300
 BoxCollider:
@@ -31764,6 +31735,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1528480484
 BoxCollider:
@@ -31811,12 +31783,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 1299706961}
@@ -31902,6 +31868,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1535934680
 BoxCollider:
@@ -32015,6 +31982,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1542820049
 MeshFilter:
@@ -32084,6 +32052,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1555328667
 BoxCollider:
@@ -32165,6 +32134,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1556660834
 BoxCollider:
@@ -32243,12 +32213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -32303,6 +32267,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1558406074
 MeshFilter:
@@ -32379,6 +32344,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1559814396
 Transform:
@@ -32454,6 +32420,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1563942299
 BoxCollider:
@@ -32473,6 +32440,108 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1563942296}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1567409579
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1567409580}
+  - component: {fileID: 1567409584}
+  - component: {fileID: 1567409583}
+  - component: {fileID: 1567409582}
+  - component: {fileID: 1567409581}
+  m_Layer: 0
+  m_Name: CloseButton1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1567409580
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567409579}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: -0.286, z: 0.098}
+  m_LocalScale: {x: 0.03, y: 0.08, z: 0.08}
+  m_Children: []
+  m_Father: {fileID: 861792205}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1567409581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567409579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1567409582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567409579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  operateAxis: 0
+  ignoreCollisionsWith: []
+  autoInteraction: 1
+  connectedTo: {fileID: 0}
+  pressedDistance: -0.015
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
+--- !u!23 &1567409583
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567409579}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: b43e5571a9fe23946bf3070cdfceb1b0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1567409584
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567409579}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1574929626
 GameObject:
@@ -32502,12 +32571,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 582109180}
@@ -32606,6 +32669,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1578335464
 BoxCollider:
@@ -32636,7 +32700,6 @@ GameObject:
   - component: {fileID: 1578491620}
   - component: {fileID: 1578491626}
   - component: {fileID: 1578491624}
-  - component: {fileID: 1578491623}
   - component: {fileID: 1578491622}
   - component: {fileID: 1578491621}
   m_Layer: 0
@@ -32654,10 +32717,10 @@ Transform:
   m_GameObject: {fileID: 1578491619}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.1500287, y: -0.1551584, z: 0.50862}
-  m_LocalScale: {x: 0.1634596, y: 0.07018248, z: 0.1056366}
+  m_LocalScale: {x: 0.16, y: 0.07, z: 0.1}
   m_Children: []
   m_Father: {fileID: 861792205}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1578491621
 MonoBehaviour:
@@ -32670,8 +32733,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &1578491622
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32680,56 +32741,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 1578491619}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableWhenIdle: 1
-  touchHighlightColor: {r: 0.034482718, g: 1, b: 0, a: 0}
-  allowedTouchControllers: 0
-  ignoredColliders: []
-  isGrabbable: 0
-  holdButtonToGrab: 1
-  stayGrabbedOnTeleport: 1
-  validDrop: 1
-  grabOverrideButton: 0
-  allowedGrabControllers: 0
-  grabAttachMechanicScript: {fileID: 0}
-  secondaryGrabActionScript: {fileID: 0}
-  isUsable: 0
-  holdButtonToUse: 1
-  useOnlyIfGrabbed: 0
-  pointerActivatesUseAction: 0
-  useOverrideButton: 0
-  allowedUseControllers: 0
-  usingState: 0
---- !u!114 &1578491623
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1578491619}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 1
+  operateAxis: 2
+  ignoreCollisionsWith: []
+  autoInteraction: 1
   connectedTo: {fileID: 0}
-  direction: 6
-  activationDistance: 0.08
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  pressedDistance: 0.15
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 30
 --- !u!23 &1578491624
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -32760,6 +32783,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1578491626
 MeshFilter:
@@ -32829,6 +32853,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1579105881
 BoxCollider:
@@ -32942,6 +32967,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1583270442
 BoxCollider:
@@ -33056,6 +33082,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1592977979
 BoxCollider:
@@ -33137,6 +33164,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1595118507
 BoxCollider:
@@ -33218,6 +33246,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1597113683
 BoxCollider:
@@ -33299,6 +33328,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1600182475
 BoxCollider:
@@ -33394,10 +33424,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playareaCursor: {fileID: 0}
+  directionIndicator: {fileID: 0}
   customRaycast: {fileID: 0}
-  layersToIgnore:
-    serializedVersion: 2
-    m_Bits: 4
   pointerOriginSmoothingSettings:
     smoothsPosition: 0
     maxAllowedPerFrameDistanceDifference: 0.003
@@ -33426,13 +33454,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eba3cd5456cd79e49948f5ceb58544b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pointerToggleButton: 10
-  pointerSetButton: 10
-  grabToggleButton: 7
-  useToggleButton: 3
-  uiClickButton: 3
-  menuToggleButton: 14
   axisFidelity: 1
+  senseAxisForceZeroThreshold: 0.15
+  senseAxisPressThreshold: 0.95
   triggerClickThreshold: 1
   triggerForceZeroThreshold: 0.01
   triggerAxisZeroOnUntouch: 0
@@ -33444,6 +33468,7 @@ MonoBehaviour:
   triggerHairlinePressed: 0
   triggerClicked: 0
   triggerAxisChanged: 0
+  triggerSenseAxisChanged: 0
   gripPressed: 0
   gripTouched: 0
   gripHairlinePressed: 0
@@ -33452,16 +33477,15 @@ MonoBehaviour:
   touchpadPressed: 0
   touchpadTouched: 0
   touchpadAxisChanged: 0
+  touchpadSenseAxisChanged: 0
   buttonOnePressed: 0
   buttonOneTouched: 0
   buttonTwoPressed: 0
   buttonTwoTouched: 0
   startMenuPressed: 0
-  pointerPressed: 0
-  grabPressed: 0
-  usePressed: 0
-  uiClickPressed: 0
-  menuPressed: 0
+  middleFingerSenseAxisChanged: 0
+  ringFingerSenseAxisChanged: 0
+  pinkyFingerSenseAxisChanged: 0
   controllerVisible: 1
 --- !u!114 &1604692961
 MonoBehaviour:
@@ -33475,6 +33499,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enableTeleport: 1
+  targetListPolicy: {fileID: 0}
   pointerRenderer: {fileID: 1604692959}
   activationButton: 10
   holdButtonToActivate: 1
@@ -33489,7 +33514,6 @@ MonoBehaviour:
   controller: {fileID: 0}
   interactUse: {fileID: 0}
   customOrigin: {fileID: 0}
-  directionIndicator: {fileID: 0}
 --- !u!1 &1610546886
 GameObject:
   m_ObjectHideFlags: 0
@@ -33551,6 +33575,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1610546889
 BoxCollider:
@@ -33582,8 +33607,9 @@ GameObject:
   - component: {fileID: 1617217082}
   - component: {fileID: 1617217081}
   - component: {fileID: 1617217080}
+  - component: {fileID: 1617217083}
   m_Layer: 0
-  m_Name: ButtonBox (3)
+  m_Name: ButtonBoxDown (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -33632,6 +33658,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1617217081
 BoxCollider:
@@ -33652,6 +33679,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1617217078}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1617217083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617217078}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1617259574
 GameObject:
   m_ObjectHideFlags: 0
@@ -33775,6 +33816,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1638466393
 BoxCollider:
@@ -33856,6 +33898,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1638726675
 BoxCollider:
@@ -33937,6 +33980,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1641163805
 BoxCollider:
@@ -34067,6 +34111,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1645436566
 BoxCollider:
@@ -34148,6 +34193,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1651868916
 BoxCollider:
@@ -34262,6 +34308,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1655275752
 BoxCollider:
@@ -34343,6 +34390,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1655674759
 BoxCollider:
@@ -34479,6 +34527,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1662784852
 GameObject:
@@ -34525,6 +34574,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -34542,6 +34592,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &1662784855
 Rigidbody:
@@ -34588,6 +34639,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1662784857
 BoxCollider:
@@ -34669,6 +34721,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1665253422
 BoxCollider:
@@ -34750,6 +34803,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1671814422
 BoxCollider:
@@ -34840,12 +34894,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 1
@@ -34888,6 +34936,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1678362121
 MeshFilter:
@@ -34987,12 +35036,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -35047,6 +35090,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1688852545
 MeshFilter:
@@ -35116,6 +35160,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1691208311
 BoxCollider:
@@ -35147,8 +35192,9 @@ GameObject:
   - component: {fileID: 1694904091}
   - component: {fileID: 1694904090}
   - component: {fileID: 1694904089}
+  - component: {fileID: 1694904092}
   m_Layer: 0
-  m_Name: ButtonBox (3)
+  m_Name: ButtonBoxBack (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -35197,6 +35243,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1694904090
 BoxCollider:
@@ -35217,6 +35264,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1694904087}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1694904092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1694904087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1697411761
 GameObject:
   m_ObjectHideFlags: 0
@@ -35275,12 +35336,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -35335,6 +35390,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1697411767
 MeshFilter:
@@ -35404,6 +35460,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1697514210
 BoxCollider:
@@ -35484,6 +35541,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1699292377
 MeshFilter:
@@ -35538,12 +35596,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -35598,6 +35650,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1699592260
 MeshFilter:
@@ -35679,6 +35732,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1705442772
 BoxCollider:
@@ -35794,6 +35848,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1718956402
 BoxCollider:
@@ -35875,6 +35930,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1720086240
 BoxCollider:
@@ -35942,6 +35998,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1723976831
 MeshFilter:
@@ -36023,6 +36080,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1724955388
 MeshFilter:
@@ -36092,6 +36150,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1729361846
 BoxCollider:
@@ -36173,6 +36232,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1731035615
 BoxCollider:
@@ -36254,6 +36314,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1731899247
 BoxCollider:
@@ -36368,6 +36429,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1739514480
 BoxCollider:
@@ -36469,6 +36531,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1753797629
 GameObject:
@@ -36530,6 +36593,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1753797632
 MeshFilter:
@@ -36599,6 +36663,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1755412262
 BoxCollider:
@@ -36700,6 +36765,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1766161996
 GameObject:
@@ -36777,6 +36843,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1766162000
 BoxCollider:
@@ -36808,12 +36875,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2473c1519b730d346b724d18267dc7fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 1
@@ -36901,6 +36962,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1771652278
 GameObject:
@@ -36962,6 +37024,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1771652281
 MeshFilter:
@@ -37031,6 +37094,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1776104066
 BoxCollider:
@@ -37050,87 +37114,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1776104063}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1782252064
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1782252065}
-  - component: {fileID: 1782252068}
-  - component: {fileID: 1782252067}
-  - component: {fileID: 1782252066}
-  m_Layer: 0
-  m_Name: ButtonBox (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1782252065
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1782252064}
-  m_LocalRotation: {x: -0.5001786, y: 0.49982175, z: -0.49982136, w: 0.50017834}
-  m_LocalPosition: {x: 0.369, y: 0.626, z: -0.107}
-  m_LocalScale: {x: 0.069746755, y: 0.014500359, z: 0.15642191}
-  m_Children: []
-  m_Father: {fileID: 455225190}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: -0.0409, y: 90, z: -90}
---- !u!23 &1782252066
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1782252064}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: fa756b232992781448908e45ad28eece, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!65 &1782252067
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1782252064}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &1782252068
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1782252064}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1783395876
 GameObject:
@@ -37193,6 +37176,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1783395879
 BoxCollider:
@@ -37274,6 +37258,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1783565478
 BoxCollider:
@@ -37354,6 +37339,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1794631407
 MeshFilter:
@@ -37423,6 +37409,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1795312375
 BoxCollider:
@@ -37504,6 +37491,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1795645583
 BoxCollider:
@@ -37585,6 +37573,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1802720638
 BoxCollider:
@@ -37697,6 +37686,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1813122959
 BoxCollider:
@@ -37728,8 +37718,9 @@ GameObject:
   - component: {fileID: 1813813355}
   - component: {fileID: 1813813354}
   - component: {fileID: 1813813353}
+  - component: {fileID: 1813813356}
   m_Layer: 0
-  m_Name: ButtonBox
+  m_Name: ButtonBoxBack (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -37778,6 +37769,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1813813354
 BoxCollider:
@@ -37798,6 +37790,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1813813351}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1813813356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1813813351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1815468718
 GameObject:
   m_ObjectHideFlags: 0
@@ -37866,6 +37872,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1815468721
 Transform:
@@ -37921,12 +37928,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 3
   door: {fileID: 730950275}
@@ -38022,6 +38023,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1831864387
 GameObject:
@@ -38114,6 +38116,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1833257773
 MeshFilter:
@@ -38182,6 +38185,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1834578733
 MeshFilter:
@@ -38217,12 +38221,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2cadbd5e873ef214b958081ac103fdff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   lid: {fileID: 561422149}
@@ -38308,6 +38306,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1838483784
 BoxCollider:
@@ -38389,6 +38388,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1840253262
 BoxCollider:
@@ -38490,6 +38490,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1843521918
 GameObject:
@@ -38552,6 +38553,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1843521921
 BoxCollider:
@@ -38640,6 +38642,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1846351372
 Transform:
@@ -38733,6 +38736,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -38750,6 +38754,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!23 &1848526924
 MeshRenderer:
@@ -38781,6 +38786,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1848526925
 BoxCollider:
@@ -38861,6 +38867,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1852991149
 MeshFilter:
@@ -38950,6 +38957,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1856178137
 GameObject:
@@ -39032,6 +39040,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1858063945
 GameObject:
@@ -39088,12 +39097,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2473c1519b730d346b724d18267dc7fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 469879064}
   direction: 1
@@ -39130,6 +39133,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1858063950
 MeshFilter:
@@ -39151,7 +39155,7 @@ Transform:
   - {fileID: 958206734}
   - {fileID: 1461478065}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 12
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: -449.98547, z: -270.0055}
 --- !u!1 &1874737937
 GameObject:
@@ -39213,6 +39217,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1874737940
 MeshFilter:
@@ -39282,6 +39287,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1878376023
 BoxCollider:
@@ -39347,6 +39353,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -39364,6 +39371,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 8
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &1879024479
 Rigidbody:
@@ -39410,6 +39418,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1879024481
 BoxCollider:
@@ -39498,6 +39507,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!4 &1879134098
 Transform:
@@ -39538,7 +39548,7 @@ Transform:
   m_LocalScale: {x: 0.03843966, y: 0.038439658, z: 0.038439646}
   m_Children: []
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 13
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: -179.8842, z: 0}
 --- !u!1 &1889958037
 GameObject:
@@ -39601,6 +39611,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1889958040
 BoxCollider:
@@ -39681,6 +39692,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1891120026
 MeshFilter:
@@ -39750,6 +39762,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1894159299
 BoxCollider:
@@ -39830,6 +39843,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1897669899
 MeshFilter:
@@ -39899,6 +39913,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1897828309
 BoxCollider:
@@ -39950,12 +39965,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2473c1519b730d346b724d18267dc7fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 1
@@ -39992,6 +40001,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1920008440
 BoxCollider:
@@ -40079,12 +40089,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 1
   direction: 3
   door: {fileID: 245234964}
@@ -40115,7 +40119,7 @@ Transform:
   - {fileID: 1825208513}
   - {fileID: 1846351372}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!1 &1922952838
 GameObject:
@@ -40198,6 +40202,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1931883181
 GameObject:
@@ -40209,11 +40214,10 @@ GameObject:
   - component: {fileID: 1931883182}
   - component: {fileID: 1931883188}
   - component: {fileID: 1931883186}
-  - component: {fileID: 1931883185}
   - component: {fileID: 1931883184}
   - component: {fileID: 1931883183}
   m_Layer: 0
-  m_Name: ButtonWall2
+  m_Name: ButtonRightWall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -40226,11 +40230,11 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1931883181}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.054, y: 0.137, z: 1.043}
-  m_LocalScale: {x: 0.051919047, y: 0.08524621, z: 0.07805358}
+  m_LocalPosition: {x: -0.054, y: 0.137, z: 1.04}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.05}
   m_Children: []
   m_Father: {fileID: 861792205}
-  m_RootOrder: 3
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1931883183
 MonoBehaviour:
@@ -40243,8 +40247,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 350434d2d64bcbd489e0ec0b05f6fcc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  go: {fileID: 123458, guid: cd4ff35fbdd2e344f9f46c1da44572da, type: 2}
-  dispenseLocation: {fileID: 691668004}
 --- !u!114 &1931883184
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -40253,56 +40255,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 1931883181}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a3abaf4521bf2344ea21ed3020b98eb2, type: 3}
+  m_Script: {fileID: 11500000, guid: cc0ebd99abd5f2547ba8276283f08b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  disableWhenIdle: 1
-  touchHighlightColor: {r: 0.034482718, g: 1, b: 0, a: 0}
-  allowedTouchControllers: 0
-  ignoredColliders: []
-  isGrabbable: 0
-  holdButtonToGrab: 1
-  stayGrabbedOnTeleport: 1
-  validDrop: 1
-  grabOverrideButton: 0
-  allowedGrabControllers: 0
-  grabAttachMechanicScript: {fileID: 0}
-  secondaryGrabActionScript: {fileID: 0}
-  isUsable: 0
-  holdButtonToUse: 1
-  useOnlyIfGrabbed: 0
-  pointerActivatesUseAction: 0
-  useOverrideButton: 0
-  allowedUseControllers: 0
-  usingState: 0
---- !u!114 &1931883185
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1931883181}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cd828872d92c3a94090d23b7b719f1e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  interactWithoutGrab: 0
+  operateAxis: 2
+  ignoreCollisionsWith: []
+  autoInteraction: 1
   connectedTo: {fileID: 0}
-  direction: 0
-  activationDistance: 0.036071535
-  buttonStrength: 5
-  events:
-    OnPush:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+  pressedDistance: 0.03
+  pressedThreshold: 0
+  stayPressed: 0
+  positionTarget: 0
+  targetForce: 10
 --- !u!23 &1931883186
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -40333,6 +40297,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1931883188
 MeshFilter:
@@ -40402,6 +40367,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1936719111
 BoxCollider:
@@ -40469,12 +40435,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d5264f69557f7c46ae368ee023d5b1a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -40675,6 +40635,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1948691642
 MeshFilter:
@@ -40744,6 +40705,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1950786938
 BoxCollider:
@@ -40777,8 +40739,9 @@ GameObject:
   - component: {fileID: 1955316049}
   - component: {fileID: 1955316048}
   - component: {fileID: 1955316053}
+  - component: {fileID: 1955316054}
   m_Layer: 0
-  m_Name: MovingPanel
+  m_Name: ButtonPanelMoving1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -40831,6 +40794,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1955316050
 BoxCollider:
@@ -40860,9 +40824,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.12800002, y: 0.0697217, z: 0.19500001}
   m_LocalScale: {x: 0.023182273, y: 0.22138526, z: 0.23293917}
-  m_Children: []
+  m_Children:
+  - {fileID: 1413909002}
   m_Father: {fileID: 861792205}
-  m_RootOrder: 8
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &1955316053
 Rigidbody:
@@ -40879,6 +40844,20 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &1955316054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1955316047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1955895404
 GameObject:
   m_ObjectHideFlags: 0
@@ -40908,7 +40887,7 @@ Transform:
   - {fileID: 354636357}
   - {fileID: 2141398779}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 24
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 24.727098, z: 0}
 --- !u!1 &1963738486
 GameObject:
@@ -40968,12 +40947,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -41028,6 +41001,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1963738492
 MeshFilter:
@@ -41084,6 +41058,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1966047536
 BoxCollider:
@@ -41128,8 +41103,9 @@ GameObject:
   - component: {fileID: 1969411067}
   - component: {fileID: 1969411066}
   - component: {fileID: 1969411065}
+  - component: {fileID: 1969411068}
   m_Layer: 0
-  m_Name: ButtonBox (1)
+  m_Name: ButtonBoxBack (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -41178,6 +41154,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1969411066
 BoxCollider:
@@ -41198,6 +41175,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1969411063}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1969411068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1969411063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1970093779
 GameObject:
   m_ObjectHideFlags: 0
@@ -41259,6 +41250,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1970093782
 BoxCollider:
@@ -41335,12 +41327,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d5264f69557f7c46ae368ee023d5b1a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -41476,6 +41462,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &1987945723
 GameObject:
@@ -41488,8 +41475,9 @@ GameObject:
   - component: {fileID: 1987945727}
   - component: {fileID: 1987945726}
   - component: {fileID: 1987945725}
+  - component: {fileID: 1987945728}
   m_Layer: 0
-  m_Name: ButtonBox (1)
+  m_Name: ButtonBoxRight (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -41538,6 +41526,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1987945726
 BoxCollider:
@@ -41558,6 +41547,20 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1987945723}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1987945728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1987945723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b5a07a74418159438f8997d129d41b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTouchToIgnore:
+  - {fileID: 352592074}
+  - {fileID: 1604692958}
 --- !u!1 &1998628238
 GameObject:
   m_ObjectHideFlags: 0
@@ -41619,6 +41622,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &1998628241
 BoxCollider:
@@ -41700,6 +41704,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2000014891
 BoxCollider:
@@ -41801,6 +41806,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &2016814394
 GameObject:
@@ -41863,6 +41869,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2016814397
 BoxCollider:
@@ -41944,6 +41951,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2022862511
 BoxCollider:
@@ -42022,12 +42030,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -42082,6 +42084,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2026432659
 MeshFilter:
@@ -42206,6 +42209,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &2038285779
 GameObject:
@@ -42288,6 +42292,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &2043498933
 GameObject:
@@ -42350,6 +42355,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2043498936
 BoxCollider:
@@ -42430,6 +42436,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2045731391
 MeshFilter:
@@ -42499,6 +42506,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2048706634
 BoxCollider:
@@ -42600,6 +42608,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &2059752598
 GameObject:
@@ -42657,12 +42666,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d5264f69557f7c46ae368ee023d5b1a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -42765,6 +42768,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!1 &2067650703
 GameObject:
@@ -42814,6 +42818,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2067650705
 BoxCollider:
@@ -42908,6 +42913,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2070436705
 MeshFilter:
@@ -42977,6 +42983,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2081651761
 BoxCollider:
@@ -43057,6 +43064,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2084574615
 MeshFilter:
@@ -43098,6 +43106,8 @@ Transform:
   - {fileID: 1113662395}
   - {fileID: 1579286539}
   - {fileID: 1499571915}
+  - {fileID: 1358126068}
+  - {fileID: 214899991}
   - {fileID: 861792205}
   - {fileID: 1115677709}
   - {fileID: 338366545}
@@ -43179,6 +43189,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2085581306
 BoxCollider:
@@ -43199,6 +43210,35 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2085581303}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2095760748
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2095760749}
+  m_Layer: 0
+  m_Name: ButtonBackContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2095760749
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2095760748}
+  m_LocalRotation: {x: -0, y: -0.12884067, z: -0, w: 0.99166536}
+  m_LocalPosition: {x: 0.196, y: -0.16467834, z: -0.15}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 989800202}
+  m_Father: {fileID: 861792205}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: -14.8052, z: 0}
 --- !u!1 &2097547831
 GameObject:
   m_ObjectHideFlags: 0
@@ -43257,12 +43297,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76fbf9d0bd5e6c48850b2862c549c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   grabType: 0
@@ -43317,6 +43351,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2097547837
 MeshFilter:
@@ -43388,7 +43423,7 @@ Transform:
   - {fileID: 1624923543}
   - {fileID: 1842817472}
   m_Father: {fileID: 2085183771}
-  m_RootOrder: 19
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!114 &2099957108
 MonoBehaviour:
@@ -43413,12 +43448,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de0c455dd96dc6d42a39ffe84e76282b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   direction: 0
   door: {fileID: 29000804}
@@ -43494,6 +43523,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2103946833
 BoxCollider:
@@ -43575,6 +43605,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2108384233
 BoxCollider:
@@ -43640,6 +43671,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
+  allowedNearTouchControllers: 0
   touchHighlightColor: {r: 0.9862069, g: 1, b: 0, a: 0}
   allowedTouchControllers: 0
   ignoredColliders: []
@@ -43657,6 +43689,7 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
   usingState: 0
 --- !u!54 &2111933694
 Rigidbody:
@@ -43703,6 +43736,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2111933696
 BoxCollider:
@@ -43771,6 +43805,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2121046201
 BoxCollider:
@@ -43827,7 +43862,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2123877843}
   m_Enabled: 1
-  serializedVersion: 7
+  serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
@@ -43852,6 +43887,8 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &2123877845
@@ -43928,6 +43965,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2126050049
 BoxCollider:
@@ -44008,6 +44046,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2127395144
 MeshFilter:
@@ -44077,6 +44116,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2132321722
 BoxCollider:
@@ -44157,6 +44197,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &2137374487
 MeshFilter:
@@ -44253,12 +44294,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd7ee1818514f3b4296422c2df5fbe8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultEvents:
-    OnValueChanged:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: VRTK.VRTK_Control+ValueChangedEvent, Assembly-CSharp, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
   interactWithoutGrab: 0
   connectedTo: {fileID: 0}
   direction: 0
@@ -44299,6 +44334,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &2145236448
 BoxCollider:

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/ButtonReactor.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/ButtonReactor.cs
@@ -1,31 +1,33 @@
 ﻿namespace VRTK.Examples
 {
     using UnityEngine;
-    using UnityEventHelper;
+    using VRTK.Controllables.PhysicsBased;
 
     public class ButtonReactor : MonoBehaviour
     {
-        public GameObject go;
-        public Transform dispenseLocation;
+        protected VRTK_Button buttonEvents;
 
-        private VRTK_Button_UnityEvents buttonEvents;
-
-        private void Start()
+        protected virtual void OnEnable()
         {
-            buttonEvents = GetComponent<VRTK_Button_UnityEvents>();
-            if (buttonEvents == null)
+            buttonEvents = GetComponent<VRTK_Button>();
+            if (buttonEvents != null)
             {
-                buttonEvents = gameObject.AddComponent<VRTK_Button_UnityEvents>();
+                buttonEvents.MaxLimitReached += MaxLimitReached;
             }
-            buttonEvents.OnPushed.AddListener(handlePush);
         }
 
-        private void handlePush(object sender, Control3DEventArgs e)
+        protected virtual void OnDisable()
         {
-            VRTK_Logger.Info("Pushed");
+            if (buttonEvents != null)
+            {
+                buttonEvents.MaxLimitReached -= MaxLimitReached;
+            }
+        }
 
-            GameObject newGo = (GameObject)Instantiate(go, dispenseLocation.position, Quaternion.identity);
-            Destroy(newGo, 10f);
+        private void MaxLimitReached(object sender, Controllables.ControllableEventArgs e)
+        {
+            VRTK_Button senderButton = sender as VRTK_Button;
+            VRTK_Logger.Info(senderButton.name + " was pushed");
         }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Button.cs
+++ b/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Button.cs
@@ -20,6 +20,7 @@ namespace VRTK
     /// `VRTK/Examples/025_Controls_Overview` shows a collection of pressable buttons that are interacted with by activating the rigidbody on the controller by pressing the grab button without grabbing an object.
     /// </example>
     [AddComponentMenu("VRTK/Scripts/Controls/3D/VRTK_Button")]
+    [System.Obsolete("`VRTK.VRTK_Button` has been replaced with `VRTK.Controllables.PhysicsBased.VRTK_Button`. This script will be removed in a future version of VRTK.")]
     public class VRTK_Button : VRTK_Control
     {
         /// <summary>

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b85eb69693814dc4b9aba8e076b3a2ff
+folderAsset: yes
+timeCreated: 1507230363
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4766dd8f4d8707441a18851616417ee0
+folderAsset: yes
+timeCreated: 1507230363
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_BasePhysicsControllable.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_BasePhysicsControllable.cs
@@ -1,0 +1,82 @@
+﻿// Base Physics Controllable|PhysicsControllables|110010
+namespace VRTK.Controllables.PhysicsBased
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Provides a base that all physics based Controllables can inherit from.
+    /// </summary>
+    /// <remarks>
+    /// **Script Usage:**
+    ///   > This is an abstract class that is to be inherited to a concrete class that provides physics based controllable functionality, therefore this script should not be directly used.
+    /// </remarks>
+    public abstract class VRTK_BasePhysicsControllable : VRTK_BaseControllable
+    {
+        [Header("Physics Settings")]
+
+        [Tooltip("If this is checked then a VRTK_ControllerRigidbodyActivator will automatically be added to the Controllable so the interacting object's rigidbody is enabled on touch.")]
+        public bool autoInteraction = true;
+        [Tooltip("The Rigidbody that the Controllable is connected to.")]
+        public Rigidbody connectedTo;
+
+        protected Rigidbody controlRigidbody;
+        protected bool createCustomRigidbody;
+        protected GameObject rigidbodyActivatorContainer;
+        protected bool createCustomRigidbodyActivator;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            SetupRigidbody();
+            SetupRigidbodyActivator();
+        }
+
+        protected override void OnDisable()
+        {
+            if (createCustomRigidbodyActivator && rigidbodyActivatorContainer != null)
+            {
+                Destroy(rigidbodyActivatorContainer);
+            }
+            if (createCustomRigidbody)
+            {
+                Destroy(controlRigidbody);
+            }
+            base.OnDisable();
+        }
+
+        protected virtual void SetupRigidbodyActivator()
+        {
+            createCustomRigidbodyActivator = false;
+            if (GetComponentInChildren<VRTK_ControllerRigidbodyActivator>() == null && autoInteraction)
+            {
+                rigidbodyActivatorContainer = new GameObject(VRTK_SharedMethods.GenerateVRTKObjectName(true, name, "Controllable", "PhysicsBased", "ControllerRigidbodyActivator"));
+                rigidbodyActivatorContainer.transform.SetParent(transform);
+                rigidbodyActivatorContainer.transform.localPosition = Vector3.zero;
+                rigidbodyActivatorContainer.transform.localRotation = Quaternion.identity;
+                rigidbodyActivatorContainer.transform.localScale = Vector3.one;
+                rigidbodyActivatorContainer.AddComponent<VRTK_ControllerRigidbodyActivator>();
+                BoxCollider rigidbodyActivatorCollider = rigidbodyActivatorContainer.AddComponent<BoxCollider>();
+                rigidbodyActivatorCollider.isTrigger = true;
+                rigidbodyActivatorCollider.size *= 1.2f;
+                createCustomRigidbodyActivator = true;
+            }
+        }
+
+        protected virtual void SetupRigidbody()
+        {
+            controlRigidbody = GetComponent<Rigidbody>();
+            createCustomRigidbody = false;
+            if (controlRigidbody == null)
+            {
+                controlRigidbody = gameObject.AddComponent<Rigidbody>();
+                createCustomRigidbody = true;
+                ConfigueRigidbody();
+            }
+            controlRigidbody.isKinematic = false;
+        }
+
+        protected virtual void ConfigueRigidbody()
+        {
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_BasePhysicsControllable.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_BasePhysicsControllable.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: cd828872d92c3a94090d23b7b719f1e7
-timeCreated: 1507322273
+guid: 31f2068f6d1ab7a4ca32373f9983d63f
+timeCreated: 1507357695
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9392d92117790dd45b98c0a5a516b274, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_Button.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_Button.cs
@@ -1,0 +1,225 @@
+﻿// Physics Button|PhysicsControllables|110020
+namespace VRTK.Controllables.PhysicsBased
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// A physics based pushable button.
+    /// </summary>
+    /// <remarks>
+    /// **Required Components:**
+    ///  * `Collider` - A Unity Collider to determine when an interaction has occured. Can be a compound collider set in child GameObjects. Will be automatically added at runtime.
+    ///  * `Rigidbody` - A Unity Rigidbody to allow the GameObject to be affected by the Unity Physics System. Will be automatically added at runtime.
+    ///
+    /// **Optional Components:**
+    ///  * `ConstantForce` - A Unity Constant Force to push the button back to it's origin position. Will be automatically created if the `Reset Force` is not `0f`.
+    ///  * `VRTK_ControllerRigidbodyActivator` - A Controller Rigidbody Activator to automatically enable the controller rigidbody upon touching the button. Will be automatically created if the `Auto Interaction` paramter is checked.
+    /// 
+    /// **Script Usage:**
+    ///  * Place the `VRTK_Button` script onto the GameObject that is to become the button.
+    /// </remarks>
+    public class VRTK_Button : VRTK_BasePhysicsControllable
+    {
+        [Header("Button Settings")]
+
+        [Tooltip("The distance along the `Operate Axis` until the button reaches the pressed position.")]
+        public float pressedDistance = 0.1f;
+        [Tooltip("The threshold in which the button's current position along the `Operate Axis` has to be within the pressed position for the button to be considered pressed.")]
+        public float pressedThreshold = 0f;
+        [Tooltip("If this is checked then the button will stay in the pressed position when it reaches the pressed position.")]
+        public bool stayPressed = false;
+        [Tooltip("The position of the button between the original position and the pressed position. `0f` will set the button position to the original position, `1f` will set the button position to the pressed position.")]
+        [Range(0f, 1f)]
+        public float positionTarget = 0f;
+        [Tooltip("The amount of force to apply to push the Button towards the `Target Position`")]
+        public float targetForce = 10f;
+
+        protected ConfigurableJoint controlJoint;
+        protected bool createCustomJoint;
+
+        protected Vector3 targetLocalPosition;
+        protected Vector3 previousLocalPosition;
+        protected bool pressedDown;
+
+        /// <summary>
+        /// The GetValue method returns the current position value of the button.
+        /// </summary>
+        /// <returns>The actual position of the button.</returns>
+        public override float GetValue()
+        {
+            return transform.localPosition[(int)operateAxis];
+        }
+
+        /// <summary>
+        /// The GetNormalizedValue method returns the current position value of the button normalized between `0f` and `1f`.
+        /// </summary>
+        /// <returns>The normalized position of the button.</returns>
+        public override float GetNormalizedValue()
+        {
+            return VRTK_SharedMethods.NormalizeValue(GetValue(), originalLocalPosition[(int)operateAxis], PressedPosition()[(int)operateAxis]);
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            SetupJoint();
+            targetLocalPosition = Vector3.zero;
+            previousLocalPosition = transform.localPosition;
+            pressedDown = false;
+        }
+
+        protected override void OnDisable()
+        {
+            if (createCustomJoint)
+            {
+                Destroy(controlJoint);
+            }
+            base.OnDisable();
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            if (controlRigidbody != null)
+            {
+                controlRigidbody.velocity = Vector3.zero;
+                ForceLocalPosition();
+            }
+        }
+
+        protected virtual void Update()
+        {
+            if (transform.localPosition != previousLocalPosition)
+            {
+                OnValueChanged(EventPayload());
+                CheckPressEvents();
+                previousLocalPosition = transform.localPosition;
+            }
+
+            if (!stayPressed && pressedDown)
+            {
+                controlRigidbody.constraints = RigidbodyConstraints.FreezeRotation;
+            }
+
+            SetTargetPosition();
+        }
+
+        protected override void OnDrawGizmosSelected()
+        {
+            base.OnDrawGizmosSelected();
+            Vector3 objectHalf = AxisDirection(true) * (transform.localScale[(int)operateAxis] * 0.5f);
+            Vector3 initialPoint = transform.position + (objectHalf * PressedDirection());
+            Vector3 destinationPoint = initialPoint + (AxisDirection(true) * pressedDistance);
+            Gizmos.DrawLine(initialPoint, destinationPoint);
+            Gizmos.DrawSphere(destinationPoint, 0.01f);
+        }
+
+        protected override void ConfigueRigidbody()
+        {
+            controlRigidbody.useGravity = false;
+            controlRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+            controlRigidbody.constraints = RigidbodyConstraints.FreezeRotation;
+        }
+
+        protected virtual void ForceLocalPosition()
+        {
+            float xPos = (operateAxis == OperatingAxis.xAxis ? transform.localPosition.x : originalLocalPosition.x);
+            float yPos = (operateAxis == OperatingAxis.yAxis ? transform.localPosition.y : originalLocalPosition.y);
+            float zPos = (operateAxis == OperatingAxis.zAxis ? transform.localPosition.z : originalLocalPosition.z);
+            transform.localPosition = new Vector3(xPos, yPos, zPos);
+        }
+
+        protected virtual void SetTargetPosition()
+        {
+            if (controlJoint != null)
+            {
+                controlJoint.targetPosition = (AxisDirection() * PressedDirection()) * Mathf.Lerp(controlJoint.linearLimit.limit, -controlJoint.linearLimit.limit, positionTarget);
+            }
+        }
+
+        protected virtual Vector3 PressedPosition()
+        {
+            return originalLocalPosition + (AxisDirection() * pressedDistance);
+        }
+
+        protected virtual void SetupJoint()
+        {
+            //move transform towards activation distance
+            transform.localPosition += AxisDirection() * (pressedDistance * 0.5f);
+
+            controlJoint = GetComponent<ConfigurableJoint>();
+            createCustomJoint = false;
+            if (controlJoint == null)
+            {
+                controlJoint = gameObject.AddComponent<ConfigurableJoint>();
+                createCustomJoint = true;
+
+                controlJoint.angularXMotion = ConfigurableJointMotion.Locked;
+                controlJoint.angularYMotion = ConfigurableJointMotion.Locked;
+                controlJoint.angularZMotion = ConfigurableJointMotion.Locked;
+
+                controlJoint.xMotion = (operateAxis == OperatingAxis.xAxis ? ConfigurableJointMotion.Limited : ConfigurableJointMotion.Locked);
+                controlJoint.yMotion = (operateAxis == OperatingAxis.yAxis ? ConfigurableJointMotion.Limited : ConfigurableJointMotion.Locked);
+                controlJoint.zMotion = (operateAxis == OperatingAxis.zAxis ? ConfigurableJointMotion.Limited : ConfigurableJointMotion.Locked);
+
+                JointDrive snapDriver = new JointDrive();
+                snapDriver.positionSpring = 1000f;
+                snapDriver.positionDamper = 10f;
+                snapDriver.maximumForce = targetForce;
+
+                controlJoint.xDrive = snapDriver;
+                controlJoint.yDrive = snapDriver;
+                controlJoint.zDrive = snapDriver;
+
+                SoftJointLimit linearLimit = new SoftJointLimit();
+                linearLimit.limit = Mathf.Abs(pressedDistance * 0.5f);
+                controlJoint.linearLimit = linearLimit;
+                controlJoint.connectedBody = connectedTo;
+            }
+        }
+
+        protected virtual float PressedDirection()
+        {
+            return (pressedDistance > 0f ? 1f : -1f);
+        }
+
+        protected virtual void CheckPressEvents()
+        {
+            float currentPosition = GetNormalizedValue();
+            ControllableEventArgs payload = EventPayload();
+            if (currentPosition >= (1f - pressedThreshold) && !AtMaxLimit())
+            {
+                atMaxLimit = true;
+                OnMaxLimitReached(payload);
+                StickOnPressed();
+            }
+            else if (currentPosition <= (0f + pressedThreshold) && !AtMinLimit())
+            {
+                atMinLimit = true;
+                OnMinLimitReached(payload);
+            }
+            else if (currentPosition > pressedThreshold && currentPosition < (1f - pressedThreshold))
+            {
+                if (AtMinLimit())
+                {
+                    OnMinLimitExited(payload);
+                }
+                if (AtMaxLimit())
+                {
+                    OnMaxLimitExited(payload);
+                }
+
+                atMinLimit = false;
+                atMaxLimit = false;
+            }
+        }
+
+        protected virtual void StickOnPressed()
+        {
+            if (stayPressed && controlRigidbody != null)
+            {
+                controlRigidbody.constraints = RigidbodyConstraints.FreezeAll;
+                pressedDown = true;
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_Button.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_Button.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: cd828872d92c3a94090d23b7b719f1e7
-timeCreated: 1507322273
+guid: cc0ebd99abd5f2547ba8276283f08b75
+timeCreated: 1507300084
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9392d92117790dd45b98c0a5a516b274, type: 3}
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/VRTK_BaseControllable.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/VRTK_BaseControllable.cs
@@ -1,0 +1,250 @@
+﻿// Base Controllable|Controllables|101010
+namespace VRTK.Controllables
+{
+    using UnityEngine;
+    using System.Collections;
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="interactingObject">The GameObject that is performing the interaction (e.g. a controller).</param>
+    /// <param name="value">The current value being reported by the controllable.</param>
+    /// <param name="normalizedValue">The normalized value being reported by the controllable.</param>
+    public struct ControllableEventArgs
+    {
+        public GameObject interactingObject;
+        public float value;
+        public float normalizedValue;
+    }
+
+    /// <summary>
+    /// Event Payload
+    /// </summary>
+    /// <param name="sender">this object</param>
+    /// <param name="e"><see cref="ControllableEventArgs"/></param>
+    public delegate void ControllableEventHandler(object sender, ControllableEventArgs e);
+
+    /// <summary>
+    /// Provides a base that all Controllables can inherit from.
+    /// </summary>
+    /// <remarks>
+    /// **Script Usage:**
+    ///   > This is an abstract class that is to be inherited to a concrete class that provides controllable functionality, therefore this script should not be directly used.
+    /// </remarks>
+    public abstract class VRTK_BaseControllable : MonoBehaviour
+    {
+        /// <summary>
+        /// The local axis that the Controllable will be operated through.
+        /// </summary>
+        public enum OperatingAxis
+        {
+            /// <summary>
+            /// The local x axis.
+            /// </summary>
+            xAxis,
+            /// <summary>
+            /// The local y axis.
+            /// </summary>
+            yAxis,
+            /// <summary>
+            /// The local z axis.
+            /// </summary>
+            zAxis
+        }
+
+        [Header("Controllable Settings")]
+
+        [Tooltip("The local axis in which the Controllable will operate through.")]
+        public OperatingAxis operateAxis = OperatingAxis.yAxis;
+        [Tooltip("A collection of GameObjects to ignore collision events with.")]
+        public GameObject[] ignoreCollisionsWith = new GameObject[0];
+
+        /// <summary>
+        /// Emitted when the Controllable value has changed.
+        /// </summary>
+        public event ControllableEventHandler ValueChanged;
+        /// <summary>
+        /// Emitted when the Controllable value has reached it's minimum limit.
+        /// </summary>
+        public event ControllableEventHandler MinLimitReached;
+        /// <summary>
+        /// Emitted when the Controllable value has exited it's minimum limit.
+        /// </summary>
+        public event ControllableEventHandler MinLimitExited;
+        /// <summary>
+        /// Emitted when the Controllable value has reached it's maximum limit.
+        /// </summary>
+        public event ControllableEventHandler MaxLimitReached;
+        /// <summary>
+        /// Emitted when the Controllable value has exited it's maximum limit.
+        /// </summary>
+        public event ControllableEventHandler MaxLimitExited;
+
+        protected Vector3 originalLocalPosition;
+        protected Quaternion originalLocalRotation;
+        protected bool atMinLimit;
+        protected bool atMaxLimit;
+        protected GameObject interactingObject;
+        protected Collider[] controlColliders;
+        protected bool createCustomCollider;
+        protected Coroutine disableColliderRoutine;
+
+        public virtual void OnValueChanged(ControllableEventArgs e)
+        {
+            if (ValueChanged != null)
+            {
+                ValueChanged(this, e);
+            }
+        }
+
+        public virtual void OnMinLimitReached(ControllableEventArgs e)
+        {
+            if (MinLimitReached != null)
+            {
+                MinLimitReached(this, e);
+            }
+        }
+
+        public virtual void OnMinLimitExited(ControllableEventArgs e)
+        {
+            if (MinLimitExited != null)
+            {
+                MinLimitExited(this, e);
+            }
+        }
+
+        public virtual void OnMaxLimitReached(ControllableEventArgs e)
+        {
+            if (MaxLimitReached != null)
+            {
+                MaxLimitReached(this, e);
+            }
+        }
+
+        public virtual void OnMaxLimitExited(ControllableEventArgs e)
+        {
+            if (MaxLimitExited != null)
+            {
+                MaxLimitExited(this, e);
+            }
+        }
+
+        public abstract float GetValue();
+        public abstract float GetNormalizedValue();
+
+        /// <summary>
+        /// The AtMinLimit method returns whether the Controllable is currently at it's minimum limit.
+        /// </summary>
+        /// <returns>Returns `true` if the Controllable is at it's minimum limit.</returns>
+        public virtual bool AtMinLimit()
+        {
+            return atMinLimit;
+        }
+
+        /// <summary>
+        /// The AtMaxLimit method returns whether the Controllable is currently at it's maximum limit.
+        /// </summary>
+        /// <returns>Returns `true` if the Controllable is at it's maximum limit.</returns>
+        public virtual bool AtMaxLimit()
+        {
+            return atMaxLimit;
+        }
+
+        protected virtual void OnEnable()
+        {
+            atMinLimit = false;
+            atMaxLimit = false;
+            originalLocalPosition = transform.localPosition;
+            originalLocalRotation = transform.localRotation;
+            SetupCollider();
+            disableColliderRoutine = StartCoroutine(DisableCollidersAtEndOfFrame());
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (disableColliderRoutine != null)
+            {
+                StopCoroutine(disableColliderRoutine);
+            }
+            ManageCollisions(false);
+            if (createCustomCollider)
+            {
+                for (int i = 0; i < controlColliders.Length; i++)
+                {
+                    Destroy(controlColliders[i]);
+                }
+            }
+        }
+
+        protected virtual void OnDrawGizmosSelected()
+        {
+            Gizmos.color = Color.yellow;
+        }
+
+        protected virtual void OnCollisionEnter(Collision collision)
+        {
+            interactingObject = collision.gameObject;
+        }
+
+        protected virtual void OnCollisionExit(Collision collision)
+        {
+            interactingObject = null;
+        }
+
+        protected virtual void SetupCollider()
+        {
+            controlColliders = GetComponentsInChildren<Collider>();
+            createCustomCollider = false;
+            if (controlColliders.Length == 0)
+            {
+                controlColliders = new Collider[1] { gameObject.AddComponent<BoxCollider>() };
+                createCustomCollider = true;
+                ConfigureColliders();
+            }
+        }
+
+        protected virtual void ConfigureColliders()
+        {
+        }
+
+        protected virtual IEnumerator DisableCollidersAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            ManageCollisions(true);
+            disableColliderRoutine = null;
+        }
+
+        protected virtual void ManageCollisions(bool ignore)
+        {
+            for (int ignoredGameObjectColliderIndex = 0; ignoredGameObjectColliderIndex < ignoreCollisionsWith.Length; ignoredGameObjectColliderIndex++)
+            {
+                Collider[] ignoredGameObjectColliders = ignoreCollisionsWith[ignoredGameObjectColliderIndex].GetComponentsInChildren<Collider>();
+
+                for (int ignoredColliderIndex = 0; ignoredColliderIndex < ignoredGameObjectColliders.Length; ignoredColliderIndex++)
+                {
+                    for (int controlColliderIndex = 0; controlColliderIndex < controlColliders.Length; controlColliderIndex++)
+                    {
+                        if (ignoredGameObjectColliders[ignoredColliderIndex] != null && controlColliders[controlColliderIndex] != null)
+                        {
+                            Physics.IgnoreCollision(controlColliders[controlColliderIndex], ignoredGameObjectColliders[ignoredColliderIndex], ignore);
+                        }
+                    }
+                }
+            }
+        }
+
+        protected virtual Vector3 AxisDirection(bool local = false)
+        {
+            return VRTK_SharedMethods.AxisDirection((int)operateAxis, (local ? transform : null));
+        }
+
+        protected virtual ControllableEventArgs EventPayload()
+        {
+            ControllableEventArgs e;
+            e.interactingObject = interactingObject;
+            e.value = GetValue();
+            e.normalizedValue = GetNormalizedValue();
+            return e;
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/VRTK_BaseControllable.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/VRTK_BaseControllable.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: cd828872d92c3a94090d23b7b719f1e7
-timeCreated: 1507322273
+guid: 2140f0db4d5a3e34d98c1e632fa2641f
+timeCreated: 1507300072
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9392d92117790dd45b98c0a5a516b274, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_IgnoreInteractTouchColliders.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_IgnoreInteractTouchColliders.cs
@@ -1,0 +1,98 @@
+﻿// Ignore Interact Touch Colliders|Interactables|35060
+namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Ignores the collisions between the given Interact Touch colliders and the colliders on the GameObject this script is attached to.
+    /// </summary>
+    /// <remarks>
+    /// **Required Components:**
+    ///  * `Collider` - Unity Colliders on the current GameObject or child GameObjects to ignore collisions from the given Interact Touch colliders.
+    ///
+    /// **Script Usage:**
+    ///  * Place the `VRTK_IgnoreInteractTouchColliders` script on the GameObject with colliders to ignore collisions from the given Interact Touch colliders.
+    ///  * Increase the size of the `Interact Touch To Ignore` element list.
+    ///  * Add the appropriate GameObjects that have the `VRTK_InteractTouch` script attached to use when ignoring collisions with the colliders on GameObject the script is attached to.
+    /// </remarks>
+    public class VRTK_IgnoreInteractTouchColliders : VRTK_SDKControllerReady
+    {
+        public List<VRTK_InteractTouch> interactTouchToIgnore = new List<VRTK_InteractTouch>();
+
+        protected Collider[] localColliders = new Collider[0];
+        protected Coroutine disableAllCollidersRoutine;
+        protected Coroutine disableControllerCollidersRoutine;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            localColliders = GetComponentsInChildren<Collider>(true);
+            disableAllCollidersRoutine = StartCoroutine(DisableAllCollidersAtEndOfFrame());
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            if (disableAllCollidersRoutine != null)
+            {
+                StopCoroutine(disableAllCollidersRoutine);
+            }
+            if (disableControllerCollidersRoutine != null)
+            {
+                StopCoroutine(disableControllerCollidersRoutine);
+            }
+            ManageAllCollisions(false);
+            localColliders = new Collider[0];
+        }
+
+        protected virtual IEnumerator DisableAllCollidersAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            ManageAllCollisions(true);
+        }
+
+        protected virtual IEnumerator DisableControllerColliderAtEndOfFrame(VRTK_InteractTouch touchToIgnore)
+        {
+            yield return new WaitForEndOfFrame();
+            ManageTouchCollision(touchToIgnore, true);
+        }
+
+        protected override void ControllerReady(VRTK_ControllerReference controllerReference)
+        {
+            if (VRTK_ControllerReference.IsValid(controllerReference))
+            {
+                VRTK_InteractTouch foundTouch = controllerReference.scriptAlias.GetComponentInChildren<VRTK_InteractTouch>();
+                if (interactTouchToIgnore.Contains(foundTouch))
+                {
+                    disableControllerCollidersRoutine = StartCoroutine(DisableControllerColliderAtEndOfFrame(foundTouch));
+                }
+            }
+        }
+
+        protected virtual void ManageAllCollisions(bool ignore)
+        {
+            for (int touchToIgnoreIndex = 0; touchToIgnoreIndex < interactTouchToIgnore.Count; touchToIgnoreIndex++)
+            {
+                ManageTouchCollision(interactTouchToIgnore[touchToIgnoreIndex], ignore);
+            }
+        }
+
+        protected virtual void ManageTouchCollision(VRTK_InteractTouch touchToIgnore, bool ignore)
+        {
+            Collider[] interactTouchColliders = touchToIgnore.ControllerColliders();
+
+            for (int touchCollidersIndex = 0; touchCollidersIndex < interactTouchColliders.Length; touchCollidersIndex++)
+            {
+                for (int localCollidersIndex = 0; localCollidersIndex < localColliders.Length; localCollidersIndex++)
+                {
+                    if (localColliders[localCollidersIndex] != null && interactTouchColliders[touchCollidersIndex] != null)
+                    {
+                        Physics.IgnoreCollision(localColliders[localCollidersIndex], interactTouchColliders[touchCollidersIndex], ignore);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_IgnoreInteractTouchColliders.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_IgnoreInteractTouchColliders.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: cd828872d92c3a94090d23b7b719f1e7
-timeCreated: 1507322273
+guid: 8b5a07a74418159438f8997d129d41b5
+timeCreated: 1507533499
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9392d92117790dd45b98c0a5a516b274, type: 3}
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_BaseControllable_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_BaseControllable_UnityEvents.cs
@@ -1,0 +1,63 @@
+﻿namespace VRTK.UnityEventHelper
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using VRTK.Controllables;
+
+    [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_BaseControllable_UnityEvents")]
+    public sealed class VRTK_BaseControllable_UnityEvents : VRTK_UnityEvents<VRTK_BaseControllable>
+    {
+        [Serializable]
+        public sealed class BaseControllablEvent : UnityEvent<object, ControllableEventArgs> { }
+
+        public BaseControllablEvent OnValueChanged = new BaseControllablEvent();
+        public BaseControllablEvent OnMinLimitReached = new BaseControllablEvent();
+        public BaseControllablEvent OnMinLimitExited = new BaseControllablEvent();
+        public BaseControllablEvent OnMaxLimitReached = new BaseControllablEvent();
+        public BaseControllablEvent OnMaxLimitExited = new BaseControllablEvent();
+
+        protected override void AddListeners(VRTK_BaseControllable component)
+        {
+            component.ValueChanged += ValueChanged;
+            component.MinLimitReached += MinLimitReached;
+            component.MinLimitExited += MinLimitExited;
+            component.MaxLimitReached += MaxLimitReached;
+            component.MaxLimitExited += MaxLimitExited;
+        }
+
+        protected override void RemoveListeners(VRTK_BaseControllable component)
+        {
+            component.ValueChanged -= ValueChanged;
+            component.MinLimitReached -= MinLimitReached;
+            component.MinLimitExited -= MinLimitExited;
+            component.MaxLimitReached -= MaxLimitReached;
+            component.MaxLimitExited -= MaxLimitExited;
+        }
+
+        private void ValueChanged(object o, ControllableEventArgs e)
+        {
+            OnValueChanged.Invoke(o, e);
+        }
+
+        private void MinLimitReached(object o, ControllableEventArgs e)
+        {
+            OnMinLimitReached.Invoke(o, e);
+        }
+
+        private void MinLimitExited(object o, ControllableEventArgs e)
+        {
+            OnMinLimitExited.Invoke(o, e);
+        }
+
+        private void MaxLimitReached(object o, ControllableEventArgs e)
+        {
+            OnMaxLimitReached.Invoke(o, e);
+        }
+
+        private void MaxLimitExited(object o, ControllableEventArgs e)
+        {
+            OnMaxLimitExited.Invoke(o, e);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_BaseControllable_UnityEvents.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_BaseControllable_UnityEvents.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: cd828872d92c3a94090d23b7b719f1e7
-timeCreated: 1507322273
+guid: 3206cdad64122df49b8ad9f08881b9f6
+timeCreated: 1507310136
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 9392d92117790dd45b98c0a5a516b274, type: 3}
+  icon: {fileID: 2800000, guid: 9fc9cd059ece45b40827fa0850950687, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_Button_UnityEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/UnityEvents/VRTK_Button_UnityEvents.cs
@@ -5,6 +5,7 @@
     using System;
 
     [AddComponentMenu("VRTK/Scripts/Utilities/Unity Events/VRTK_Button_UnityEvents")]
+    [Obsolete("`VRTK_Button_UnityEvents` has been replaced with `VRTK_BaseControllable_UnityEvents`. This script will be removed in a future version of VRTK.")]
     public sealed class VRTK_Button_UnityEvents : VRTK_UnityEvents<VRTK_Button>
     {
         [Serializable]

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -414,6 +414,18 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The AxisDirection method returns the relevant direction Vector3 based on the axis index in relation to x,y,z.
+        /// </summary>
+        /// <param name="axisIndex">The axis index of the axis. `0 = x` `1 = y` `2 = z`</param>
+        /// <param name="givenTransform">An optional Transform to get the Axis Direction for. If this is `null` then the World directions will be used.</param>
+        /// <returns>The direction Vector3 based on the given axis index.</returns>
+        public static Vector3 AxisDirection(int axisIndex, Transform givenTransform = null)
+        {
+            Vector3[] worldDirections = (givenTransform != null ? new Vector3[] { givenTransform.right, givenTransform.up, givenTransform.forward } : new Vector3[] { Vector3.right, Vector3.up, Vector3.forward });
+            return worldDirections[(int)Mathf.Clamp(axisIndex, 0f, worldDirections.Length)];
+        }
+
+        /// <summary>
         /// The GetTypeUnknownAssembly method is used to find a Type without knowing the exact assembly it is in.
         /// </summary>
         /// <param name="typeName">The name of the type to get.</param>


### PR DESCRIPTION
The 3D Control button has now been deprecated in the first commit of
deprecating all of the existing 3D controls as they are being replaced
with the new Controllables controls. The new Controllable Button works
in a similar fashion to the original 3D Button but is more modular
and can be enabled/disabled at runtime and cleans up correctly.

The new Controllables are to be separated into two concepts of Physics
based and Artificial based, with Physics controls using the Unity
Physics system to move and the Artificial controls not using physics
and just simulating the concept of a control.