### PR TITLE
fix(TrackObjectGrabAttach): dropping objects early - fixes #1563

### DIFF
--- a/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_TrackObjectGrabAttach.cs
+++ b/Assets/VRTK/Scripts/Interactions/GrabAttachMechanics/VRTK_TrackObjectGrabAttach.cs
@@ -89,7 +89,7 @@ namespace VRTK.GrabAttachMechanics
                 return;
             }
 
-            float maxDistanceDelta = 10f;
+            float maxDistanceDelta = velocityLimit;
             Vector3 positionDelta = trackPoint.position - (grabbedSnapHandle != null ? grabbedSnapHandle.position : grabbedObject.transform.position);
             Quaternion rotationDelta = trackPoint.rotation * Quaternion.Inverse((grabbedSnapHandle != null ? grabbedSnapHandle.rotation : grabbedObject.transform.rotation));
 


### PR DESCRIPTION
maxDistanceDelta being a constant caused the magnitudes of the
calculated positional and angular velocities to not be limited properly.
This resulted in the held objects getting dropped prematurely without
properly detaching them: The objects were attached in theory but not
following the controller as intended.

The solution is to change the constant to the predefined velocity limit,
causing the magnitude to limit properly to fit the later if-statements.