### PR TITLE
fix(Interaction): do not look for grab attach/action in children

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -1207,7 +1207,7 @@ namespace VRTK
         {
             if (isGrabbable && grabAttachMechanicScript == null)
             {
-                VRTK_BaseGrabAttach setGrabMechanic = GetComponentInChildren<VRTK_BaseGrabAttach>();
+                VRTK_BaseGrabAttach setGrabMechanic = GetComponent<VRTK_BaseGrabAttach>();
                 if (setGrabMechanic == null)
                 {
                     setGrabMechanic = gameObject.AddComponent<VRTK_FixedJointGrabAttach>();
@@ -1220,7 +1220,7 @@ namespace VRTK
         {
             if (isGrabbable && secondaryGrabActionScript == null)
             {
-                secondaryGrabActionScript = GetComponentInChildren<VRTK_BaseGrabAction>();
+                secondaryGrabActionScript = GetComponent<VRTK_BaseGrabAction>();
             }
         }
 


### PR DESCRIPTION
The Grab Attach or Action should only be found on the same GameObject
as the Interactable Object otherwise nested Interactable Object
Attach/Actions can be used incorrectly.