### PR TITLE
fix(Pointers): ensure visible renderers list is cleared correctly

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -411,8 +411,8 @@ namespace VRTK
             for (int i = 0; i < makeRendererVisible.Count; i++)
             {
                 ToggleRendererVisibility(makeRendererVisible[i], true);
-                makeRendererVisible.Remove(makeRendererVisible[i]);
             }
+            makeRendererVisible.Clear();
         }
 
         protected virtual void ToggleRendererVisibility(GameObject givenObject, bool state)


### PR DESCRIPTION
The `makeRendererVisible` list was being cleared during a loop within
the loop so it wasn't being cleared correctly.

The better approach is to simply clear the entire list after the loop
is done.