### PR TITLE
fix(Pointer): update pointer position in fixed update

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -9354,6 +9354,7 @@ Changes one game object's transform to follow another game object's transform.
 ### Class Variables
 
  * `public enum FollowMoment` - The moment at which to follow.
+   * `OnFixedUpdate` - Follow in the FixedUpdate method.
    * `OnUpdate` - Follow in the Update method.
    * `OnLateUpdate` - Follow in the LateUpdate method.
    * `OnPreRender` - Follow in the OnPreRender method. (This script doesn't have to be attached to a camera).

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -578,6 +578,7 @@ namespace VRTK
             pointerOriginTransformFollowGameObject = new GameObject(VRTK_SharedMethods.GenerateVRTKObjectName(true, gameObject.name, "BasePointerRenderer_Origin_Smoothed"));
             pointerOriginTransformFollow = pointerOriginTransformFollowGameObject.AddComponent<VRTK_TransformFollow>();
             pointerOriginTransformFollow.enabled = false;
+            pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnFixedUpdate;
             pointerOriginTransformFollow.followsScale = false;
         }
 

--- a/Assets/VRTK/Source/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/ObjectFollow/VRTK_TransformFollow.cs
@@ -15,6 +15,10 @@ namespace VRTK
         public enum FollowMoment
         {
             /// <summary>
+            /// Follow in the FixedUpdate method.
+            /// </summary>
+            OnFixedUpdate,
+            /// <summary>
             /// Follow in the Update method.
             /// </summary>
             OnUpdate,
@@ -103,6 +107,14 @@ namespace VRTK
             transformToChange = null;
             Camera.onPreRender -= OnCamPreRender;
             Camera.onPreCull -= OnCamPreCull;
+        }
+
+        protected void FixedUpdate()
+        {
+            if (moment == FollowMoment.OnFixedUpdate)
+            {
+                Follow();
+            }
         }
 
         protected void Update()


### PR DESCRIPTION
The Straight Pointer Renderer position was being updated using the
Transform Follow script and this was defaulting to using the
OnPreRender moment to update position. This had a knock on effect
that the pointer Object Interactor position was being updated in a
Fixed Update but this meant that the Object Interactor position was
not correctly updated to the correct pointer position as the pointer
position was always slightly slower due to being on the OnPreRender
setting.

The solution is to ensure the Pointer position is updated via
FixedUpdate as well to ensure the position of the pointer is correct
for when the Object Interactor is updated in the Fixed Update routine.