### PR TITLE
feat(Avatar): allow custom model to be provided - resolves #1567

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -1109,6 +1109,7 @@ Provides a custom controller hand model with psuedo finger functionality.
  * **Touch Overrides:** Finger axis overrides on an Interact Touch event.
  * **Grab Overrides:** Finger axis overrides on an Interact Grab event.
  * **Use Overrides:** Finger axis overrides on an Interact Use event.
+ * **Hand Model:** The Transform that contains the avatar hand model. If this is left blank then a child GameObject named `Model` will be searched for to use as the Transform.
  * **Controller Events:** The controller to listen for the events on. If this is left blank as it will be auto populated by finding the Controller Events script on the parent GameObject.
  * **Interact Near Touch:** An optional Interact NearTouch to listen for near touch events on. If this is left blank as it will attempt to be auto populated by finding the Interact NearTouch script on the parent GameObject.
  * **Interact Touch:** An optional Interact Touch to listen for touch events on. If this is left blank as it will attempt to be auto populated by finding the Interact Touch script on the parent GameObject.

--- a/Assets/VRTK/Prefabs/AvatarHands/VRTK_AvatarHandController.cs
+++ b/Assets/VRTK/Prefabs/AvatarHands/VRTK_AvatarHandController.cs
@@ -166,6 +166,8 @@ namespace VRTK
 
         [Header("Custom Settings")]
 
+        [Tooltip("The Transform that contains the avatar hand model. If this is left blank then a child GameObject named `Model` will be searched for to use as the Transform.")]
+        public Transform handModel;
         [Tooltip("The controller to listen for the events on. If this is left blank as it will be auto populated by finding the Controller Events script on the parent GameObject.")]
         public VRTK_ControllerEvents controllerEvents;
         [Tooltip("An optional Interact NearTouch to listen for near touch events on. If this is left blank as it will attempt to be auto populated by finding the Interact NearTouch script on the parent GameObject.")]
@@ -703,7 +705,7 @@ namespace VRTK
 
         protected virtual void MirrorHand()
         {
-            Transform modelTransform = transform.Find("Model");
+            Transform modelTransform = (handModel != null ? handModel : transform.Find("Model"));
             if (modelTransform != null)
             {
                 modelTransform.localScale = new Vector3(modelTransform.localScale.x * -1f, modelTransform.localScale.y, modelTransform.localScale.z);


### PR DESCRIPTION
The Avatar Hand Controller script can now have a custom Model
Transform injected into the inspector component in case the
model is not a child called `Model`.