### PR TITLE
fix(Utilities): fixed error for Unity versions prior to 5.6

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -356,7 +356,7 @@ namespace VRTK
             float gpuTimeLastFrame;
             return (XRStats.TryGetGPUTimeLastFrame(out gpuTimeLastFrame) ? gpuTimeLastFrame : 0f);
 #else
-            return VRStats.gpuTimeLastFrame;
+            return XRStats.gpuTimeLastFrame;
 #endif
         }
 


### PR DESCRIPTION
In Unity 5.5.4 you get this error:
`Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs(359,20):
 error CS0103: The name 'VRStats' does not exist in the current context`

The error disappears changing `VRStats` to `XRStats`.