### PR TITLE
feat(SDK): add new headset types and move to base headset sdk

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -8323,14 +8323,6 @@ The Device Finder offers a collection of static methods that can be called to fi
    * `Headset` - The headset.
    * `LeftController` - The left hand controller.
    * `RightController` - The right hand controller.
- * `public enum Headsets` - Possible headsets
-   * `Unknown` - An unknown headset.
-   * `OculusRift` - A summary of all Oculus Rift headset versions.
-   * `OculusRiftCV1` - A specific version of the Oculus Rift headset, the Consumer Version 1.
-   * `Vive` - A summary of all HTC Vive headset versions.
-   * `ViveMV` - A specific version of the HTC Vive headset, the first consumer version.
-   * `ViveDVT` - A specific version of the HTC Vive headset, the first consumer version.
-   * `OculusRiftES07` - A specific version of the Oculus Rift headset, the rare ES07.
 
 ### Class Methods
 
@@ -8624,12 +8616,12 @@ The ResetHeadsetTypeCache resets the cache holding the current headset type valu
 
 #### GetHeadsetType/1
 
-  > `public static Headsets GetHeadsetType(bool summary = false)`
+  > `public static SDK_BaseHeadset.Headsets GetHeadsetType(bool summary = false)`
 
  * Parameters
    * `bool summary` - If this is `true`, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).
  * Returns
-   * `Headsets` - The Headset type that is connected.
+   * `SDK_BaseHeadset.Headsets` - The Headset type that is connected.
 
 The GetHeadsetType method returns the type of headset connected to the computer.
 
@@ -9753,6 +9745,26 @@ The ForceInterleavedReprojectionOn method determines whether Interleaved Reproje
 The Base Headset SDK script provides a bridge to SDK methods that deal with the VR Headset.
 
 This is an abstract class to implement the interface required by all implemented SDKs.
+
+### Class Variables
+
+ * `public enum Headsets` - SDK Headset types.
+   * `Unknown` - An unknown headset.
+   * `OculusRift` - A summary of all Oculus Rift headset versions.
+   * `OculusRiftCV1` - A specific version of the Oculus Rift headset, the Consumer Version 1.
+   * `Vive` - A summary of all HTC Vive headset versions.
+   * `ViveMV` - A specific version of the HTC Vive headset, the first consumer version.
+   * `ViveDVT` - A specific version of the HTC Vive headset, the first consumer version.
+   * `OculusRiftES07` - A specific version of the Oculus Rift headset, the rare ES07.
+   * `GearVR` - A summary of all GearVR headset versions.
+   * `GearVRGalaxyNote5` - A specific version of the GearVR headset running on a Samsung Galaxy Note 5.
+   * `GearVRGalaxyS6` - A specific version of the GearVR headset running on a Samsung Galaxy S6.
+   * `GearVRGalaxyS6Edge` - A specific version of the GearVR headset running on a Samsung Galaxy S6 Edge.
+   * `GearVRGalaxyS7` - A specific version of the GearVR headset running on a Samsung Galaxy S7.
+   * `GearVRGalaxyS7Edge` - A specific version of the GearVR headset running on a Samsung Galaxy S7 Edge.
+   * `GearVRGalaxyS8` - A specific version of the GearVR headset running on a Samsung Galaxy S8.
+   * `GoogleCardboard` - A summary of all Google Cardboard headset versions.
+   * `Daydream` - A summary of all Google Daydream headset versions.
 
 ### Class Methods
 

--- a/Assets/VRTK/Source/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Base/SDK_BaseHeadset.cs
@@ -12,6 +12,78 @@ namespace VRTK
     /// </remarks>
     public abstract class SDK_BaseHeadset : SDK_Base
     {
+
+        /// <summary>
+        /// SDK Headset types.
+        /// </summary>
+        public enum Headsets
+        {
+            /// <summary>
+            /// An unknown headset.
+            /// </summary>
+            Unknown,
+            /// <summary>
+            /// A summary of all Oculus Rift headset versions.
+            /// </summary>
+            OculusRift,
+            /// <summary>
+            /// A specific version of the Oculus Rift headset, the Consumer Version 1.
+            /// </summary>
+            OculusRiftCV1,
+            /// <summary>
+            /// A summary of all HTC Vive headset versions.
+            /// </summary>
+            Vive,
+            /// <summary>
+            /// A specific version of the HTC Vive headset, the first consumer version.
+            /// </summary>
+            ViveMV,
+            /// <summary>
+            /// A specific version of the HTC Vive headset, the first consumer version.
+            /// </summary>
+            ViveDVT,
+            /// <summary>
+            /// A specific version of the Oculus Rift headset, the rare ES07.
+            /// </summary>
+            OculusRiftES07,
+            /// <summary>
+            /// A summary of all GearVR headset versions.
+            /// </summary>
+            GearVR,
+            /// <summary>
+            /// A specific version of the GearVR headset running on a Samsung Galaxy Note 5.
+            /// </summary>
+            GearVRGalaxyNote5,
+            /// <summary>
+            /// A specific version of the GearVR headset running on a Samsung Galaxy S6.
+            /// </summary>
+            GearVRGalaxyS6,
+            /// <summary>
+            /// A specific version of the GearVR headset running on a Samsung Galaxy S6 Edge.
+            /// </summary>
+            GearVRGalaxyS6Edge,
+            /// <summary>
+            /// A specific version of the GearVR headset running on a Samsung Galaxy S7.
+            /// </summary>
+            GearVRGalaxyS7,
+            /// <summary>
+            /// A specific version of the GearVR headset running on a Samsung Galaxy S7 Edge.
+            /// </summary>
+            GearVRGalaxyS7Edge,
+            /// <summary>
+            /// A specific version of the GearVR headset running on a Samsung Galaxy S8.
+            /// </summary>
+            GearVRGalaxyS8,
+            /// <summary>
+            /// A summary of all Google Cardboard headset versions.
+            /// </summary>
+            GoogleCardboard,
+            /// <summary>
+            /// A summary of all Google Daydream headset versions.
+            /// </summary>
+            Daydream
+        }
+
         protected Transform cachedHeadset;
         protected Transform cachedHeadsetCamera;
 

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
@@ -83,9 +83,9 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     return GetSteamVRControllerType(controllerReference);
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return ControllerType.SteamVR_OculusTouch;
             }
             return ControllerType.Custom;
@@ -101,10 +101,10 @@ namespace VRTK
             string returnCollider = "ControllerColliders/Fallback";
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     returnCollider = (hand == ControllerHand.Left ? "ControllerColliders/SteamVROculusTouch_Left" : "ControllerColliders/SteamVROculusTouch_Right");
                     break;
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     switch (GetCurrentControllerType())
                     {
                         case ControllerType.SteamVR_ValveKnuckles:
@@ -225,7 +225,7 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     if (IsControllerLeftHand(parent) || IsControllerRightHand(parent))
                     {
                         GameObject generatedOrigin = new GameObject(parent.name + " _CustomPointerOrigin");
@@ -719,7 +719,7 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     switch (GetCurrentControllerType())
                     {
                         case ControllerType.SteamVR_ViveWand:
@@ -728,7 +728,7 @@ namespace VRTK
                             return "button_b" + suffix;
                     }
                     return null;
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return "grip" + suffix;
             }
             return null;
@@ -738,9 +738,9 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     return "trackpad" + suffix;
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return "thumbstick" + suffix;
             }
             return null;
@@ -750,9 +750,9 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     return null;
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return (hand == ControllerHand.Left ? "x_button" : "a_button") + suffix;
             }
             return null;
@@ -762,9 +762,9 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     return "button" + suffix;
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return (hand == ControllerHand.Left ? "y_button" : "b_button") + suffix;
             }
             return null;
@@ -774,9 +774,9 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     return "sys_button" + suffix;
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return (hand == ControllerHand.Left ? "enter_button" : "home_button") + suffix;
             }
             return null;
@@ -786,9 +786,9 @@ namespace VRTK
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))
             {
-                case VRTK_DeviceFinder.Headsets.Vive:
+                case SDK_BaseHeadset.Headsets.Vive:
                     return null;
-                case VRTK_DeviceFinder.Headsets.OculusRift:
+                case SDK_BaseHeadset.Headsets.OculusRift:
                     return (hand == ControllerHand.Left ? "enter_button" : "home_button") + suffix;
             }
             return null;

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -747,10 +747,10 @@ namespace VRTK
             {
                 switch (VRTK_DeviceFinder.GetHeadsetType(true))
                 {
-                    case VRTK_DeviceFinder.Headsets.Vive:
+                    case SDK_BaseHeadset.Headsets.Vive:
                         cachedControllerType = ControllerType.SteamVR_ViveWand;
                         break;
-                    case VRTK_DeviceFinder.Headsets.OculusRift:
+                    case SDK_BaseHeadset.Headsets.OculusRift:
                         cachedControllerType = ControllerType.SteamVR_OculusTouch;
                         break;
                 }

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -6,6 +6,7 @@ namespace VRTK
     using UnityEngine.XR;
 #else
     using XRDevice = UnityEngine.VR.VRDevice;
+    using XRSettings = UnityEngine.VR.VRSettings;
 #endif
 
     /// <summary>
@@ -32,42 +33,8 @@ namespace VRTK
             RightController,
         }
 
-        /// <summary>
-        /// Possible headsets
-        /// </summary>
-        public enum Headsets
-        {
-            /// <summary>
-            /// An unknown headset.
-            /// </summary>
-            Unknown,
-            /// <summary>
-            /// A summary of all Oculus Rift headset versions.
-            /// </summary>
-            OculusRift,
-            /// <summary>
-            /// A specific version of the Oculus Rift headset, the Consumer Version 1.
-            /// </summary>
-            OculusRiftCV1,
-            /// <summary>
-            /// A summary of all HTC Vive headset versions.
-            /// </summary>
-            Vive,
-            /// <summary>
-            /// A specific version of the HTC Vive headset, the first consumer version.
-            /// </summary>
-            ViveMV,
-            /// <summary>
-            /// A specific version of the HTC Vive headset, the first consumer version.
-            /// </summary>
-            ViveDVT,
-            /// <summary>
-            /// A specific version of the Oculus Rift headset, the rare ES07.
-            /// </summary>
-            OculusRiftES07
-        }
-
         private static string cachedHeadsetType = "";
+        private static string cachedLoadedDeviceName = "";
 
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
@@ -394,6 +361,7 @@ namespace VRTK
         public static void ResetHeadsetTypeCache()
         {
             cachedHeadsetType = "";
+            cachedLoadedDeviceName = "";
         }
 
         /// <summary>
@@ -401,27 +369,71 @@ namespace VRTK
         /// </summary>
         /// <param name="summary">If this is `true`, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).</param>
         /// <returns>The Headset type that is connected.</returns>
-        public static Headsets GetHeadsetType(bool summary = false)
+        public static SDK_BaseHeadset.Headsets GetHeadsetType(bool summary = false)
         {
-            Headsets returnValue = Headsets.Unknown;
-            cachedHeadsetType = (cachedHeadsetType == "" ? XRDevice.model.Replace(" ", "").Replace(".", "").ToLowerInvariant() : cachedHeadsetType);
+            SDK_BaseHeadset.Headsets returnValue = SDK_BaseHeadset.Headsets.Unknown;
+            cachedHeadsetType = (cachedHeadsetType == "" ? CleanModelString(XRDevice.model) : cachedHeadsetType);
+            cachedLoadedDeviceName = (cachedLoadedDeviceName == "" ? CleanModelString(XRSettings.loadedDeviceName) : cachedLoadedDeviceName);
             switch (cachedHeadsetType)
             {
                 case "oculusriftcv1":
-                    returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftCV1);
+                    returnValue = (summary ? SDK_BaseHeadset.Headsets.OculusRift : SDK_BaseHeadset.Headsets.OculusRiftCV1);
                     break;
                 case "oculusriftes07":
-                    returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftES07);
+                    returnValue = (summary ? SDK_BaseHeadset.Headsets.OculusRift : SDK_BaseHeadset.Headsets.OculusRiftES07);
                     break;
                 case "vivemv":
-                    returnValue = (summary ? Headsets.Vive : Headsets.ViveMV);
+                    returnValue = (summary ? SDK_BaseHeadset.Headsets.Vive : SDK_BaseHeadset.Headsets.ViveMV);
                     break;
                 case "vivedvt":
-                    returnValue = (summary ? Headsets.Vive : Headsets.ViveDVT);
+                    returnValue = (summary ? SDK_BaseHeadset.Headsets.Vive : SDK_BaseHeadset.Headsets.ViveDVT);
+                    break;
+                case "galaxynote5":
+                    if (cachedLoadedDeviceName == "oculus")
+                    {
+                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyNote5);
+                    }
+                    break;
+                case "galaxys6":
+                    if (cachedLoadedDeviceName == "oculus")
+                    {
+                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS6);
+                    }
+                    break;
+                case "galaxys6edge":
+                    if (cachedLoadedDeviceName == "oculus")
+                    {
+                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS6Edge);
+                    }
+                    break;
+                case "galaxys7":
+                    if (cachedLoadedDeviceName == "oculus")
+                    {
+                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS7);
+                    }
+                    break;
+                case "galaxys7Edge":
+                    if (cachedLoadedDeviceName == "oculus")
+                    {
+                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS7Edge);
+                    }
+                    break;
+                case "galaxys8":
+                case "galaxys8+":
+                    if (cachedLoadedDeviceName == "oculus")
+                    {
+                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS8);
+                    }
+                    break;
+                case "googleinc-daydreamview":
+                    returnValue = SDK_BaseHeadset.Headsets.Daydream;
+                    break;
+                case "googleinc-defaultcardboard":
+                    returnValue = SDK_BaseHeadset.Headsets.GoogleCardboard;
                     break;
             }
 
-            if (returnValue == Headsets.Unknown)
+            if (returnValue == SDK_BaseHeadset.Headsets.Unknown)
             {
                 VRTK_Logger.Warn(
                     string.Format("Your headset is of type '{0}' which VRTK doesn't know about yet. Please report this headset type to the maintainers of VRTK."
@@ -433,11 +445,11 @@ namespace VRTK
                 {
                     if (cachedHeadsetType.Contains("rift"))
                     {
-                        return Headsets.OculusRift;
+                        return SDK_BaseHeadset.Headsets.OculusRift;
                     }
                     if (cachedHeadsetType.Contains("vive"))
                     {
-                        return Headsets.Vive;
+                        return SDK_BaseHeadset.Headsets.Vive;
                     }
                 }
             }
@@ -452,6 +464,11 @@ namespace VRTK
         public static Transform PlayAreaTransform()
         {
             return VRTK_SDK_Bridge.GetPlayArea();
+        }
+
+        private static string CleanModelString(string inputString)
+        {
+            return inputString.Replace(" ", "").Replace(".", "").Replace(",", "").ToLowerInvariant();
         }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
@@ -26,7 +26,7 @@ namespace VRTK
         [Tooltip("If the currently loaded SDK Setup matches the one provided here then the `Target` state will be set to the desired `Object State`.")]
         public VRTK_SDKSetup loadedSDKSetup = null;
         [Tooltip("If the attached headset type matches the selected headset then the `Target` state will be set to the desired `Object State`.")]
-        public VRTK_DeviceFinder.Headsets headsetType = VRTK_DeviceFinder.Headsets.Unknown;
+        public SDK_BaseHeadset.Headsets headsetType = SDK_BaseHeadset.Headsets.Unknown;
         [Tooltip("If the current controller type matches the selected controller type then the `Target` state will be set to the desired `Object State`.")]
         public SDK_BaseController.ControllerType controllerType = SDK_BaseController.ControllerType.Undefined;
 
@@ -91,7 +91,7 @@ namespace VRTK
 
         protected virtual void ToggleOnHeadset()
         {
-            if (headsetType != VRTK_DeviceFinder.Headsets.Unknown && headsetType == VRTK_DeviceFinder.GetHeadsetType(true))
+            if (headsetType != SDK_BaseHeadset.Headsets.Unknown && headsetType == VRTK_DeviceFinder.GetHeadsetType(true))
             {
                 ToggleObject();
             }


### PR DESCRIPTION
The Headsets enum has been moved from the DeviceFinder to the
SDK BaseHeadset script to keep in line with the controllers enum
being in the SDK BaseController script.

Additional Headset types have been added for GearVR supported devices
and for Daydream and Cardboard. As Google devices don't report
differences between the devices the summary and detail both return
the same response of `Daydream` or `GoogleCardboard`.