### PR TITLE
feat(Locomotion): apply play area parent position to teleporter - fixes #1559

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -2050,6 +2050,7 @@ Updates the `x/y/z` position of the SDK Camera Rig with an optional screen fade.
 ### Inspector Parameters
 
  * **Snap To Nearest Floor:** If this is checked, then the teleported Y position will snap to the nearest available below floor. If it is unchecked, then the teleported Y position will be where ever the destination Y position is.
+ * **Apply Playarea Parent Offset:** If this is checked then the teleported Y position will also be offset by the play area parent Transform Y position (if the play area has a parent).
  * **Custom Raycast:** A custom raycaster to use when raycasting to find floors.
 
 ### Example


### PR DESCRIPTION
The Height Adjust Teleport script now has a new option that will also
apply the play area parent position as an offset when teleporting.

This fixes issues with headsets that aren't room scale aware and
therefore cannot determine where the floor is so will always send the
HMD view to the point of teleport. This would cause the user to
be teleported into the floor.

This new feature allows for the play area camera rig to be placed
in a parent GameObject and that parent GameObject to have a Y position
set on it to be used as the default standing height of the HMD view.