### PR TITLE
feat(Structure): provide custom data types to convey better meaning - fixes #1579

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -5618,9 +5618,9 @@ Moves the Transform of the Interactable Object towards the interacting object wi
  * **Force Kinematic On Grab:** If this is checked then it will force the rigidbody on the Interactable Object to be `Kinematic` when the grab occurs.
  * **Release Deceleration Damper:** The damper in which to slow the Interactable Object down when released to simulate continued momentum. The higher the number, the faster the Interactable Object will come to a complete stop on release.
  * **Reset To Orign On Release Speed:** The speed in which the Interactable Object returns to it's origin position when released. If the `Reset To Orign On Release Speed` is `0f` then the position will not be reset.
- * **X Axis Limits:** The minimum (`x`) and maximum (`y`) limits the Interactable Object can be moved along the x axis.
- * **Y Axis Limits:** The minimum (`x`) and maximum (`y`) limits the Interactable Object can be moved along the y axis.
- * **Z Axis Limits:** The minimum (`x`) and maximum (`y`) limits the Interactable Object can be moved along the z axis.
+ * **X Axis Limits:** The minimum and maximum limits the Interactable Object can be moved along the x axis.
+ * **Y Axis Limits:** The minimum and maximum limits the Interactable Object can be moved along the y axis.
+ * **Z Axis Limits:** The minimum and maximum limits the Interactable Object can be moved along the z axis.
  * **Min Max Threshold:** The threshold the position value needs to be within to register a min or max position value.
  * **Min Max Normalized Threshold:** The threshold the normalized position value needs to be within to register a min or max normalized position value.
 
@@ -5778,12 +5778,12 @@ The ResetPosition method will move the Interactable Object back to the origin po
 
 #### GetWorldLimits/0
 
-  > `public virtual Vector2[] GetWorldLimits()`
+  > `public virtual Limits2D[] GetWorldLimits()`
 
  * Parameters
    * _none_
  * Returns
-   * `Vector2[]` - An array of axis limits in world space.
+   * `Limits2D[]` - An array of axis limits in world space.
 
 The GetWorldLimits method returns an array of minimum and maximum axis limits for the Interactable Object in world space.
 
@@ -5812,7 +5812,7 @@ Rotates the Transform of the Interactable Object around a specified transform lo
  * **Rotation Friction:** The amount of friction to apply when rotating, simulates a tougher rotation.
  * **Release Deceleration Damper:** The damper in which to slow the Interactable Object's rotation down when released to simulate continued momentum. The higher the number, the faster the Interactable Object will come to a complete stop on release.
  * **Reset To Orign On Release Speed:** The speed in which the Interactable Object returns to it's origin rotation when released. If the `Reset To Orign On Release Speed` is `0f` then the rotation will not be reset.
- * **Angle Limits:** The negative `(x)` and positive `(y)` limits the axis can be rotated to.
+ * **Angle Limits:** The negative and positive limits the axis can be rotated to.
  * **Min Max Threshold:** The threshold the rotation value needs to be within to register a min or max rotation value.
  * **Min Max Normalized Threshold:** The threshold the normalized rotation value needs to be within to register a min or max normalized rotation value.
 
@@ -6083,9 +6083,7 @@ Scales the grabbed Interactable Object along the given axes based on the positio
 ### Inspector Parameters
 
  * **Ungrab Distance:** The distance the secondary grabbing object must move away from the original grab position before the secondary grabbing object auto ungrabs the Interactable Object.
- * **Lock X Axis:** If checked the current X Axis of the Interactable Object won't be scaled
- * **Lock Y Axis:** If checked the current Y Axis of the Interactable Object won't be scaled
- * **Lock Z Axis:** If checked the current Z Axis of the Interactable Object won't be scaled
+ * **Lock Axis:** Locks the specified checked axes so they won't be scaled
  * **Uniform Scaling:** If checked all the axes will be scaled together (unless locked)
 
 ### Class Methods
@@ -6506,14 +6504,13 @@ A physics based rotatable object.
 ### Inspector Parameters
 
  * **Hinge Point:** A Transform that denotes the position where the rotator hinge will be created.
- * **Minimum Angle:** The minimum angle the rotator can rotate to.
- * **Maximum Angle:** The maximum angle the rotator can rotate to.
+ * **Angle Limits:** The minimum and maximum angle the rotator can rotate to.
  * **Min Max Threshold Angle:** The angle at which the rotator rotation can be within the minimum or maximum angle before the minimum or maximum angles are considered reached.
  * **Resting Angle:** The angle at which will be considered as the resting position of the rotator.
  * **Force Resting Angle Threshold:** The threshold angle from the `Resting Angle` that the current angle of the rotator needs to be within to snap the rotator back to the `Resting Angle`.
  * **Angle Target:** The target angle to rotate the rotator to.
  * **Is Locked:** If this is checked then the rotator Rigidbody will have all rotations frozen.
- * **Step Value Range:** The minimum `(x)` and the maximum `(y)` step values for the rotator to register along the `Operate Axis`.
+ * **Step Value Range:** The minimum and the maximum step values for the rotator to register along the `Operate Axis`.
  * **Step Size:** The increments the rotator value will change in between the `Step Value Range`.
  * **Use Step As Value:** If this is checked then the value for the rotator will be the step value and not the absolute rotation of the rotator Transform.
  * **Snap To Step:** If this is checked then the rotator will snap to the angle of the nearest step along the value range.
@@ -6662,7 +6659,7 @@ A physics based slider.
  * **Position Target:** The target position to move the slider towards given in a normalized value of `0f` (start point) to `1f` (end point).
  * **Resting Position:** The position the slider when it is at the default resting point given in a normalized value of `0f` (start point) to `1f` (end point).
  * **Force Resting Position Threshold:** The normalized threshold value the slider has to be within the `Resting Position` before the slider is forced back to the `Resting Position` if it is not grabbed.
- * **Step Value Range:** The minimum `(x)` and the maximum `(y)` step values for the slider to register along the `Operate Axis`.
+ * **Step Value Range:** The minimum and the maximum step values for the slider to register along the `Operate Axis`.
  * **Step Size:** The increments the slider value will change in between the `Step Value Range`.
  * **Use Step As Value:** If this is checked then the value for the slider will be the step value and not the absolute position of the slider Transform.
  * **Snap To Step:** If this is checked then the slider will snap to the position of the nearest step along the value range.
@@ -6888,13 +6885,12 @@ A artificially simulated openable rotator.
 ### Inspector Parameters
 
  * **Hinge Point:** A Transform that denotes the position where the rotator will rotate around.
- * **Minimum Angle:** The minimum angle the rotator can rotate to.
- * **Maximum Angle:** The maximum angle the rotator can rotate to.
+ * **Angle Limits:** The minimum and maximum angle the rotator can rotate to.
  * **Min Max Threshold Angle:** The angle at which the rotator rotation can be within the minimum or maximum angle before the minimum or maximum angles are considered reached.
  * **Resting Angle:** The angle at which will be considered as the resting position of the rotator.
  * **Force Resting Angle Threshold:** The threshold angle from the `Resting Angle` that the current angle of the rotator needs to be within to snap the rotator back to the `Resting Angle`.
  * **Is Locked:** If this is checked then the rotator Rigidbody will have all rotations frozen.
- * **Step Value Range:** The minimum `(x)` and the maximum `(y)` step values for the rotator to register along the `Operate Axis`.
+ * **Step Value Range:** The minimum and the maximum step values for the rotator to register along the `Operate Axis`.
  * **Step Size:** The increments the rotator value will change in between the `Step Value Range`.
  * **Use Step As Value:** If this is checked then the value for the rotator will be the step value and not the absolute rotation of the rotator Transform.
  * **Snap To Step:** If this is checked then the rotator will snap to the angle of the nearest step along the value range.
@@ -7042,7 +7038,7 @@ A artificially simulated slider.
  * **Min Max Threshold:** The normalized position the slider can be within the minimum or maximum slider positions before the minimum or maximum positions are considered reached.
  * **Resting Position:** The position the slider when it is at the default resting point given in a normalized value of `0f` (start point) to `1f` (end point).
  * **Force Resting Position Threshold:** The normalized threshold value the slider has to be within the `Resting Position` before the slider is forced back to the `Resting Position` if it is not grabbed.
- * **Step Value Range:** The minimum `(x)` and the maximum `(y)` step values for the slider to register along the `Operate Axis`.
+ * **Step Value Range:** The minimum and the maximum step values for the slider to register along the `Operate Axis`.
  * **Step Size:** The increments the slider value will change in between the `Step Value Range`.
  * **Use Step As Value:** If this is checked then the value for the slider will be the step value and not the absolute position of the slider Transform.
  * **Snap To Step:** If this is checked then the slider will snap to the position of the nearest step along the value range.
@@ -9275,8 +9271,7 @@ In more detail:
       * `-msaa X`: Set MSAA level to X
  * **Msaa Level:** The MSAA level to use.
  * **Scale Render Viewport:** Toggles whether the render viewport scale is dynamically adjusted to maintain VR framerate. If unchecked, the renderer will render at the recommended resolution provided by the current `VRDevice`.
- * **Minimum Render Scale:** The minimum allowed render scale.
- * **Maximum Render Scale:** The maximum allowed render scale.
+ * **Render Scale Limits:** The minimum and maximum allowed render scale.
  * **Maximum Render Target Dimension:** The maximum allowed render target dimension. This puts an upper limit on the size of the render target regardless of the maximum render scale.
  * **Render Scale Fill Rate Step Size In Percent:** The fill rate step size in percent by which the render scale levels will be calculated.
  * **Scale Render Target Resolution:** Toggles whether the render target resolution is dynamically adjusted to maintain VR framerate. If unchecked, the renderer will use the maximum target resolution specified by `maximumRenderScale`.

--- a/Assets/VRTK/Source/Editor/Attributes.meta
+++ b/Assets/VRTK/Source/Editor/Attributes.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: afb2e9e7f408b84449c9294d13a5455d
+folderAsset: yes
+timeCreated: 1509657351
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Editor/Attributes/MinMaxRangeDrawer.cs
+++ b/Assets/VRTK/Source/Editor/Attributes/MinMaxRangeDrawer.cs
@@ -1,0 +1,78 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.Globalization;
+using Supyrb;
+using VRTK;
+
+[CustomPropertyDrawer(typeof(MinMaxRangeAttribute))]
+class MinMaxRangeDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
+        bool foundGeneric = false;
+        bool valid = false;
+        try
+        {
+            Vector2 input = SerializedPropertyExtensions.GetValue<Limits2D>(property).AsVector2();
+            Vector2 output = BuildSlider(position, label, input, out valid);
+            if (valid)
+            {
+                SerializedPropertyExtensions.SetValue<Limits2D>(property, new Limits2D(output));
+            }
+            foundGeneric = true;
+        }
+        catch (System.Exception)
+        {
+            Error(position, label);
+        }
+
+        if (!foundGeneric)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Vector2:
+                    Vector2 input = property.vector2Value;
+                    Vector2 output = BuildSlider(position, label, input, out valid);
+                    if (valid)
+                    {
+                        property.vector2Value = output;
+                    }
+                    break;
+                default:
+                    Error(position, label);
+                    break;
+            }
+        }
+    }
+
+    private Vector2 BuildSlider(Rect position, GUIContent label, Vector2 range, out bool valid)
+    {
+        float fieldWidth = GUI.skin.textField.CalcSize(new GUIContent(1.234f.ToString(CultureInfo.InvariantCulture))).x; ;
+        float fieldPadding = 5f;
+        float min = range.x;
+        float max = range.y;
+
+        MinMaxRangeAttribute attr = attribute as MinMaxRangeAttribute;
+        EditorGUI.BeginChangeCheck();
+        Rect updatedPosition = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+        min = EditorGUI.FloatField(new Rect(updatedPosition.x, updatedPosition.y, fieldWidth, updatedPosition.height), Mathf.Clamp(min, attr.min, attr.max));
+        EditorGUI.MinMaxSlider(new Rect(updatedPosition.x + (fieldWidth + fieldPadding), updatedPosition.y, updatedPosition.width - ((fieldWidth + fieldPadding) * 2f), updatedPosition.height), ref min, ref max, attr.min, attr.max);
+        max = EditorGUI.FloatField(new Rect(updatedPosition.x + (updatedPosition.width - fieldWidth), updatedPosition.y, fieldWidth, updatedPosition.height), Mathf.Clamp(max, attr.min, attr.max));
+
+        if (EditorGUI.EndChangeCheck())
+        {
+            range.x = min;
+            range.y = max;
+            valid = true;
+            return range;
+        }
+        valid = false;
+        return Vector2.zero;
+    }
+
+    private void Error(Rect position, GUIContent label)
+    {
+        EditorGUI.LabelField(position, label, new GUIContent("Use only with Vector2 or Limits2D"));
+    }
+}

--- a/Assets/VRTK/Source/Editor/Attributes/MinMaxRangeDrawer.cs.meta
+++ b/Assets/VRTK/Source/Editor/Attributes/MinMaxRangeDrawer.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: bbef415ca4404081ab7abdd88f0a7f2e
-timeCreated: 1509690241
+guid: 272bf9002407b7b408de44167d67deac
+timeCreated: 1509663126
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 27d721ae718e0424a8bdcfb6f4708f3c, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Editor/DataTypes/Limits2DDrawer.cs
+++ b/Assets/VRTK/Source/Editor/DataTypes/Limits2DDrawer.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+using UnityEditor;
+using VRTK;
+
+[CustomPropertyDrawer(typeof(Limits2D))]
+public class Limits2DDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
+        SerializedProperty minimum = property.FindPropertyRelative("minimum");
+        SerializedProperty maximum = property.FindPropertyRelative("maximum");
+
+        int indent = EditorGUI.indentLevel;
+        EditorGUI.indentLevel = 0;
+        position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+        float updatePositionX = position.x;
+        float labelWidth = 30f;
+        float fieldWidth = (position.width / 3f) - labelWidth;
+
+        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Min");
+        updatePositionX += labelWidth;
+        minimum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), minimum.floatValue);
+        updatePositionX += fieldWidth;
+
+        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Max");
+        updatePositionX += labelWidth;
+        maximum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), maximum.floatValue);
+        updatePositionX += fieldWidth;
+
+        EditorGUI.indentLevel = indent;
+    }
+}

--- a/Assets/VRTK/Source/Editor/DataTypes/Limits2DDrawer.cs.meta
+++ b/Assets/VRTK/Source/Editor/DataTypes/Limits2DDrawer.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: bbef415ca4404081ab7abdd88f0a7f2e
-timeCreated: 1509690241
+guid: c6f2df835e699a3459f8f940822b7dd6
+timeCreated: 1509649432
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 27d721ae718e0424a8bdcfb6f4708f3c, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Editor/DataTypes/Vector3StateDrawer.cs
+++ b/Assets/VRTK/Source/Editor/DataTypes/Vector3StateDrawer.cs
@@ -1,11 +1,13 @@
 ﻿using UnityEngine;
 using UnityEditor;
+using VRTK;
 
 [CustomPropertyDrawer(typeof(Vector3State))]
 public class Vector3StateDrawer : PropertyDrawer
 {
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
+        label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
         SerializedProperty xState = property.FindPropertyRelative("xState");
         SerializedProperty yState = property.FindPropertyRelative("yState");
         SerializedProperty zState = property.FindPropertyRelative("zState");

--- a/Assets/VRTK/Source/Editor/VRTK_AdaptiveQualityEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_AdaptiveQualityEditor.cs
@@ -1,8 +1,7 @@
-#if (UNITY_5_4_OR_NEWER)
+﻿#if (UNITY_5_4_OR_NEWER)
 namespace VRTK
 {
     using System;
-    using System.Globalization;
     using UnityEditor;
     using UnityEngine;
 
@@ -29,7 +28,7 @@ namespace VRTK
         {
             serializedObject.Update();
 
-            var adaptiveQuality = (VRTK_AdaptiveQuality)target;
+            VRTK_AdaptiveQuality adaptiveQuality = (VRTK_AdaptiveQuality)target;
 
             EditorGUILayout.HelpBox(DontDisableHelpBoxText, adaptiveQuality.enabled ? MessageType.Warning : MessageType.Error);
             EditorGUILayout.Space();
@@ -44,38 +43,10 @@ namespace VRTK
                 EditorGUILayout.BeginToggleGroup(VRTK_EditorUtilities.BuildGUIContent<VRTK_AdaptiveQuality>("scaleRenderViewport"),
                                                  adaptiveQuality.scaleRenderViewport);
             {
-                float minimumRenderScale = adaptiveQuality.minimumRenderScale;
-                float maximumRenderScale = adaptiveQuality.maximumRenderScale;
+                Limits2D renderScaleLimits = adaptiveQuality.renderScaleLimits;
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("renderScaleLimits"));
 
-                EditorGUILayout.BeginHorizontal();
-                {
-                    var fieldInfo = adaptiveQuality.GetType().GetField("minimumRenderScale");
-                    var rangeAttribute = (RangeAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(RangeAttribute));
-
-                    EditorGUI.BeginChangeCheck();
-                    {
-                        float maxFloatWidth = GUI.skin.textField.CalcSize(new GUIContent(1.23f.ToString(CultureInfo.InvariantCulture))).x;
-                        minimumRenderScale = EditorGUILayout.FloatField(minimumRenderScale, GUILayout.MaxWidth(maxFloatWidth));
-
-                        EditorGUILayout.MinMaxSlider(
-                            ref minimumRenderScale,
-                            ref maximumRenderScale,
-                            rangeAttribute.min,
-                            rangeAttribute.max);
-
-                        maximumRenderScale = EditorGUILayout.FloatField(maximumRenderScale, GUILayout.MaxWidth(maxFloatWidth));
-                    }
-                    if (EditorGUI.EndChangeCheck())
-                    {
-                        serializedObject.FindProperty("minimumRenderScale").floatValue =
-                            Mathf.Clamp((float)Math.Round(minimumRenderScale, 2), rangeAttribute.min, rangeAttribute.max);
-                        serializedObject.FindProperty("maximumRenderScale").floatValue =
-                            Mathf.Clamp((float)Math.Round(maximumRenderScale, 2), rangeAttribute.min, rangeAttribute.max);
-                    }
-                }
-                EditorGUILayout.EndHorizontal();
-
-                if (maximumRenderScale > adaptiveQuality.BiggestAllowedMaximumRenderScale())
+                if (renderScaleLimits.maximum > adaptiveQuality.BiggestAllowedMaximumRenderScale())
                 {
                     EditorGUILayout.HelpBox(MaximumRenderScaleTooBigHelpBoxText, MessageType.Error);
                 }

--- a/Assets/VRTK/Source/Editor/VRTK_EditorUtilities.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_EditorUtilities.cs
@@ -7,11 +7,16 @@
 
     public static class VRTK_EditorUtilities
     {
+        public static TooltipAttribute GetTooltipAttribute(FieldInfo fieldInfo)
+        {
+            return (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
+        }
+
         public static GUIContent BuildGUIContent<T>(string fieldName, string displayOverride = null)
         {
             string displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
             FieldInfo fieldInfo = typeof(T).GetField(fieldName);
-            TooltipAttribute tooltipAttribute = (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
+            TooltipAttribute tooltipAttribute = GetTooltipAttribute(fieldInfo);
             return (tooltipAttribute == null ? new GUIContent(displayName) : new GUIContent(displayName, tooltipAttribute.tooltip));
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialSlider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialSlider.cs
@@ -41,8 +41,8 @@ namespace VRTK.Controllables.ArtificialBased
 
         [Header("Value Step Settings")]
 
-        [Tooltip("The minimum `(x)` and the maximum `(y)` step values for the slider to register along the `Operate Axis`.")]
-        public Vector2 stepValueRange = new Vector3(0f, 1f);
+        [Tooltip("The minimum and the maximum step values for the slider to register along the `Operate Axis`.")]
+        public Limits2D stepValueRange = new Limits2D(0f, 1f);
         [Tooltip("The increments the slider value will change in between the `Step Value Range`.")]
         public float stepSize = 0.1f;
         [Tooltip("If this is checked then the value for the slider will be the step value and not the absolute position of the slider Transform.")]
@@ -72,7 +72,7 @@ namespace VRTK.Controllables.ArtificialBased
         protected VRTK_MoveTransformGrabAttach controlGrabAttach;
         protected VRTK_SwapControllerGrabAction controlSecondaryGrabAction;
         protected bool createInteractableObject;
-        protected Vector2 axisLimits;
+        protected Limits2D axisLimits;
         protected Vector3 previousLocalPosition;
         protected Coroutine setPositionTargetAtEndOfFrameRoutine;
         protected bool stillResting;
@@ -102,7 +102,7 @@ namespace VRTK.Controllables.ArtificialBased
         /// <returns>The current Step Value based on the slider position.</returns>
         public virtual float GetStepValue(float currentValue)
         {
-            return Mathf.Round((stepValueRange.x + Mathf.Clamp01(currentValue / maximumLength) * (stepValueRange.y - stepValueRange.x)) / stepSize) * stepSize;
+            return Mathf.Round((stepValueRange.minimum + Mathf.Clamp01(currentValue / maximumLength) * (stepValueRange.maximum - stepValueRange.minimum)) / stepSize) * stepSize;
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace VRTK.Controllables.ArtificialBased
         /// <param name="speed">The speed to move to the new position target.</param>
         public virtual void SetPositionTargetWithStepValue(float givenStepValue, float speed)
         {
-            SetPositionTarget(VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.x, stepValueRange.y), speed);
+            SetPositionTarget(VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.minimum, stepValueRange.maximum), speed);
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace VRTK.Controllables.ArtificialBased
         /// <param name="givenStepValue">The step value within the `Step Value Range` to set the `Resting Position` parameter to.</param>
         public virtual void SetRestingPositionWithStepValue(float givenStepValue)
         {
-            restingPosition = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.x, stepValueRange.y);
+            restingPosition = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.minimum, stepValueRange.maximum);
         }
 
         /// <summary>
@@ -142,8 +142,8 @@ namespace VRTK.Controllables.ArtificialBased
         /// <returns>The position the slider would be at based on the given step value.</returns>
         public virtual float GetPositionFromStepValue(float givenStepValue)
         {
-            float normalizedStepValue = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.x, stepValueRange.y);
-            return Mathf.Lerp(axisLimits.x, axisLimits.y, Mathf.Clamp01(normalizedStepValue));
+            float normalizedStepValue = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.minimum, stepValueRange.maximum);
+            return Mathf.Lerp(axisLimits.minimum, axisLimits.maximum, Mathf.Clamp01(normalizedStepValue));
         }
 
         /// <summary>
@@ -297,7 +297,7 @@ namespace VRTK.Controllables.ArtificialBased
             {
                 controlGrabAttach.precisionGrab = precisionGrab;
                 controlGrabAttach.releaseDecelerationDamper = releaseFriction;
-                axisLimits = new Vector2(originalLocalPosition[(int)operateAxis], MaximumLength()[(int)operateAxis]);
+                axisLimits = new Limits2D(originalLocalPosition[(int)operateAxis], MaximumLength()[(int)operateAxis]);
                 switch (operateAxis)
                 {
                     case OperatingAxis.xAxis:
@@ -331,7 +331,7 @@ namespace VRTK.Controllables.ArtificialBased
 
         protected virtual void SetPositionWithNormalizedValue(float givenTargetPosition, float speed)
         {
-            float positionOnAxis = Mathf.Lerp(axisLimits.x, axisLimits.y, Mathf.Clamp01(givenTargetPosition));
+            float positionOnAxis = Mathf.Lerp(axisLimits.minimum, axisLimits.maximum, Mathf.Clamp01(givenTargetPosition));
             SnapToPosition(positionOnAxis, speed);
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsSlider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsSlider.cs
@@ -43,8 +43,8 @@ namespace VRTK.Controllables.PhysicsBased
 
         [Header("Value Step Settings")]
 
-        [Tooltip("The minimum `(x)` and the maximum `(y)` step values for the slider to register along the `Operate Axis`.")]
-        public Vector2 stepValueRange = new Vector3(0f, 1f);
+        [Tooltip("The minimum and the maximum step values for the slider to register along the `Operate Axis`.")]
+        public Limits2D stepValueRange = new Limits2D(0f, 1f);
         [Tooltip("The increments the slider value will change in between the `Step Value Range`.")]
         public float stepSize = 0.1f;
         [Tooltip("If this is checked then the value for the slider will be the step value and not the absolute position of the slider Transform.")]
@@ -103,7 +103,7 @@ namespace VRTK.Controllables.PhysicsBased
         /// <returns>The current Step Value based on the slider position.</returns>
         public virtual float GetStepValue(float currentValue)
         {
-            return Mathf.Round((stepValueRange.x + Mathf.Clamp01(currentValue / maximumLength) * (stepValueRange.y - stepValueRange.x)) / stepSize) * stepSize;
+            return Mathf.Round((stepValueRange.minimum + Mathf.Clamp01(currentValue / maximumLength) * (stepValueRange.maximum - stepValueRange.minimum)) / stepSize) * stepSize;
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace VRTK.Controllables.PhysicsBased
         /// <param name="givenStepValue">The step value within the `Step Value Range` to set the `Position Target` parameter to.</param>
         public virtual void SetPositionTargetWithStepValue(float givenStepValue)
         {
-            positionTarget = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.x, stepValueRange.y);
+            positionTarget = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.minimum, stepValueRange.maximum);
             SetPositionWithNormalizedValue(positionTarget);
         }
 
@@ -122,7 +122,7 @@ namespace VRTK.Controllables.PhysicsBased
         /// <param name="givenStepValue">The step value within the `Step Value Range` to set the `Resting Position` parameter to.</param>
         public virtual void SetRestingPositionWithStepValue(float givenStepValue)
         {
-            restingPosition = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.x, stepValueRange.y);
+            restingPosition = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.minimum, stepValueRange.maximum);
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace VRTK.Controllables.PhysicsBased
         /// <returns>The position the slider would be at based on the given step value.</returns>
         public virtual float GetPositionFromStepValue(float givenStepValue)
         {
-            float normalizedStepValue = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.x, stepValueRange.y);
+            float normalizedStepValue = VRTK_SharedMethods.NormalizeValue(givenStepValue, stepValueRange.minimum, stepValueRange.maximum);
             return Mathf.Lerp(controlJoint.linearLimit.limit, -controlJoint.linearLimit.limit, Mathf.Clamp01(normalizedStepValue));
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_MoveTransformGrabAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_MoveTransformGrabAttach.cs
@@ -58,12 +58,12 @@ namespace VRTK.GrabAttachMechanics
 
         [Header("Position Limit Settings")]
 
-        [Tooltip("The minimum (`x`) and maximum (`y`) limits the Interactable Object can be moved along the x axis.")]
-        public Vector2 xAxisLimits = Vector2.zero;
-        [Tooltip("The minimum (`x`) and maximum (`y`) limits the Interactable Object can be moved along the y axis.")]
-        public Vector2 yAxisLimits = Vector2.zero;
-        [Tooltip("The minimum (`x`) and maximum (`y`) limits the Interactable Object can be moved along the z axis.")]
-        public Vector2 zAxisLimits = Vector2.zero;
+        [Tooltip("The minimum and maximum limits the Interactable Object can be moved along the x axis.")]
+        public Limits2D xAxisLimits = Limits2D.zero;
+        [Tooltip("The minimum and maximum limits the Interactable Object can be moved along the y axis.")]
+        public Limits2D yAxisLimits = Limits2D.zero;
+        [Tooltip("The minimum and maximum limits the Interactable Object can be moved along the z axis.")]
+        public Limits2D zAxisLimits = Limits2D.zero;
         [Tooltip("The threshold the position value needs to be within to register a min or max position value.")]
         public float minMaxThreshold = 0.01f;
         [Tooltip("The threshold the normalized position value needs to be within to register a min or max normalized position value.")]
@@ -131,9 +131,9 @@ namespace VRTK.GrabAttachMechanics
 
         protected bool previousKinematicState;
         protected bool[] limitsReached = new bool[6];
-        protected Vector2 xOriginLimits;
-        protected Vector2 yOriginLimits;
-        protected Vector2 zOriginLimits;
+        protected Limits2D xOriginLimits;
+        protected Limits2D yOriginLimits;
+        protected Limits2D zOriginLimits;
         protected Vector3 previousPosition;
         protected Vector3 movementVelocity;
         protected Coroutine resetPositionRoutine;
@@ -397,9 +397,9 @@ namespace VRTK.GrabAttachMechanics
         /// The GetWorldLimits method returns an array of minimum and maximum axis limits for the Interactable Object in world space.
         /// </summary>
         /// <returns>An array of axis limits in world space.</returns>
-        public virtual Vector2[] GetWorldLimits()
+        public virtual Limits2D[] GetWorldLimits()
         {
-            return new Vector2[] { xOriginLimits, yOriginLimits, zOriginLimits };
+            return new Limits2D[] { xOriginLimits, yOriginLimits, zOriginLimits };
         }
 
         protected virtual void OnEnable()
@@ -425,17 +425,17 @@ namespace VRTK.GrabAttachMechanics
         {
             CheckAxisLimits();
             localOrigin = transform.localPosition;
-            xOriginLimits = new Vector2(localOrigin.x + xAxisLimits.x, localOrigin.x + xAxisLimits.y);
-            yOriginLimits = new Vector2(localOrigin.y + yAxisLimits.x, localOrigin.y + yAxisLimits.y);
-            zOriginLimits = new Vector2(localOrigin.z + zAxisLimits.x, localOrigin.z + zAxisLimits.y);
+            xOriginLimits = new Limits2D(localOrigin.x + xAxisLimits.minimum, localOrigin.x + xAxisLimits.maximum);
+            yOriginLimits = new Limits2D(localOrigin.y + yAxisLimits.minimum, localOrigin.y + yAxisLimits.maximum);
+            zOriginLimits = new Limits2D(localOrigin.z + zAxisLimits.minimum, localOrigin.z + zAxisLimits.maximum);
             previousPosition = localOrigin;
         }
 
-        protected virtual float ClampAxis(Vector2 limits, float axisValue)
+        protected virtual float ClampAxis(Limits2D limits, float axisValue)
         {
-            axisValue = (axisValue < limits.x + minMaxThreshold ? limits.x : axisValue);
-            axisValue = (axisValue > limits.y - minMaxThreshold ? limits.y : axisValue);
-            return Mathf.Clamp(axisValue, limits.x, limits.y);
+            axisValue = (axisValue < limits.minimum + minMaxThreshold ? limits.minimum : axisValue);
+            axisValue = (axisValue > limits.maximum - minMaxThreshold ? limits.maximum : axisValue);
+            return Mathf.Clamp(axisValue, limits.minimum, limits.maximum);
         }
 
         protected virtual void ClampPosition()
@@ -446,9 +446,9 @@ namespace VRTK.GrabAttachMechanics
         protected virtual Vector3 NormalizePosition(Vector3 givenHeading)
         {
             return new Vector3(
-                VRTK_SharedMethods.NormalizeValue(givenHeading.x, xAxisLimits.x, xAxisLimits.y, minMaxNormalizedThreshold),
-                VRTK_SharedMethods.NormalizeValue(givenHeading.y, yAxisLimits.x, yAxisLimits.y, minMaxNormalizedThreshold),
-                VRTK_SharedMethods.NormalizeValue(givenHeading.z, zAxisLimits.x, zAxisLimits.y, minMaxNormalizedThreshold)
+                VRTK_SharedMethods.NormalizeValue(givenHeading.x, xAxisLimits.minimum, xAxisLimits.maximum, minMaxNormalizedThreshold),
+                VRTK_SharedMethods.NormalizeValue(givenHeading.y, yAxisLimits.minimum, yAxisLimits.maximum, minMaxNormalizedThreshold),
+                VRTK_SharedMethods.NormalizeValue(givenHeading.z, zAxisLimits.minimum, zAxisLimits.maximum, minMaxNormalizedThreshold)
             );
         }
 
@@ -506,10 +506,10 @@ namespace VRTK.GrabAttachMechanics
             zAxisLimits = FixAxisLimits(zAxisLimits);
         }
 
-        protected virtual Vector2 FixAxisLimits(Vector2 givenLimits)
+        protected virtual Limits2D FixAxisLimits(Limits2D givenLimits)
         {
-            givenLimits.x = (givenLimits.x > 0f ? givenLimits.x * -1f : givenLimits.x);
-            givenLimits.y = (givenLimits.y < 0f ? givenLimits.y * -1f : givenLimits.y);
+            givenLimits.minimum = (givenLimits.minimum > 0f ? givenLimits.minimum * -1f : givenLimits.minimum);
+            givenLimits.maximum = (givenLimits.maximum < 0f ? givenLimits.maximum * -1f : givenLimits.maximum);
             return givenLimits;
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_RotateTransformGrabAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_RotateTransformGrabAttach.cs
@@ -105,8 +105,8 @@ namespace VRTK.GrabAttachMechanics
 
         [Header("Rotation Limits")]
 
-        [Tooltip("The negative `(x)` and positive `(y)` limits the axis can be rotated to.")]
-        public Vector2 angleLimits = new Vector2(-180, 180);
+        [Tooltip("The negative and positive limits the axis can be rotated to.")]
+        public Limits2D angleLimits = new Limits2D(-180f, 180f);
         [Tooltip("The threshold the rotation value needs to be within to register a min or max rotation value.")]
         public float minMaxThreshold = 1f;
         [Tooltip("The threshold the normalized rotation value needs to be within to register a min or max normalized rotation value.")]
@@ -256,7 +256,7 @@ namespace VRTK.GrabAttachMechanics
         /// <param name="transitionTime">The time in which the entire rotation operation will take place.</param>
         public virtual void SetRotation(float newAngle, float transitionTime = 0f)
         {
-            newAngle = Mathf.Clamp(newAngle, angleLimits.x, angleLimits.y);
+            newAngle = Mathf.Clamp(newAngle, angleLimits.minimum, angleLimits.maximum);
             Vector3 newCurrentRotation = currentRotation;
             switch (rotateAround)
             {
@@ -327,7 +327,7 @@ namespace VRTK.GrabAttachMechanics
         /// <returns>The normalized rotated angle. Will return `0f` if either limit is set to `infinity`.</returns>
         public virtual float GetNormalizedAngle()
         {
-            return (angleLimits.x > float.MinValue && angleLimits.y < float.MaxValue ? VRTK_SharedMethods.NormalizeValue(GetAngle(), angleLimits.x, angleLimits.y, minMaxNormalizedThreshold) : 0f);
+            return (angleLimits.minimum > float.MinValue && angleLimits.maximum < float.MaxValue ? VRTK_SharedMethods.NormalizeValue(GetAngle(), angleLimits.minimum, angleLimits.maximum, minMaxNormalizedThreshold) : 0f);
         }
 
         /// <summary>
@@ -422,11 +422,11 @@ namespace VRTK.GrabAttachMechanics
             switch (rotateAround)
             {
                 case RotationAxis.xAxis:
-                    return (rotationCheck.x >= angleLimits.x && rotationCheck.x <= angleLimits.y);
+                    return angleLimits.WithinLimits(rotationCheck.x);
                 case RotationAxis.yAxis:
-                    return (rotationCheck.y >= angleLimits.x && rotationCheck.y <= angleLimits.y);
+                    return angleLimits.WithinLimits(rotationCheck.y);
                 case RotationAxis.zAxis:
-                    return (rotationCheck.z >= angleLimits.x && rotationCheck.z <= angleLimits.y);
+                    return angleLimits.WithinLimits(rotationCheck.z);
             }
             return false;
         }
@@ -490,16 +490,16 @@ namespace VRTK.GrabAttachMechanics
 
         protected virtual void CheckAngleLimits()
         {
-            angleLimits.x = (angleLimits.x > 0f ? angleLimits.x * -1f : angleLimits.x);
-            angleLimits.y = (angleLimits.y < 0f ? angleLimits.y * -1f : angleLimits.y);
+            angleLimits.minimum = (angleLimits.minimum > 0f ? angleLimits.minimum * -1f : angleLimits.minimum);
+            angleLimits.maximum = (angleLimits.maximum < 0f ? angleLimits.maximum * -1f : angleLimits.maximum);
         }
 
         protected virtual void EmitEvents()
         {
             OnAngleChanged(SetEventPayload());
             float angle = GetAngle();
-            float minAngle = angleLimits.x + minMaxThreshold;
-            float maxAngle = angleLimits.y - minMaxThreshold;
+            float minAngle = angleLimits.minimum + minMaxThreshold;
+            float maxAngle = angleLimits.maximum - minMaxThreshold;
             if (angle <= minAngle && !limitsReached[0])
             {
                 limitsReached[0] = true;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
@@ -20,11 +20,16 @@ namespace VRTK.SecondaryControllerGrabActions
     {
         [Tooltip("The distance the secondary grabbing object must move away from the original grab position before the secondary grabbing object auto ungrabs the Interactable Object.")]
         public float ungrabDistance = 1f;
-        [Tooltip("If checked the current X Axis of the Interactable Object won't be scaled")]
+        [Tooltip("Locks the specified checked axes so they won't be scaled")]
+        public Vector3State lockAxis = Vector3State.False;
+        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockXAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
+        [HideInInspector]
         public bool lockXAxis = false;
-        [Tooltip("If checked the current Y Axis of the Interactable Object won't be scaled")]
+        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockYAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
+        [HideInInspector]
         public bool lockYAxis = false;
-        [Tooltip("If checked the current Z Axis of the Interactable Object won't be scaled")]
+        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockZAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
+        [HideInInspector]
         public bool lockZAxis = false;
         [Tooltip("If checked all the axes will be scaled together (unless locked)")]
         public bool uniformScaling = false;
@@ -47,6 +52,13 @@ namespace VRTK.SecondaryControllerGrabActions
             initialScale = currentGrabbdObject.transform.localScale;
             initalLength = (grabbedObject.transform.position - secondaryGrabbingObject.transform.position).magnitude;
             initialScaleFactor = currentGrabbdObject.transform.localScale.x / initalLength;
+
+#pragma warning disable 618
+            if ((lockXAxis || lockYAxis || lockZAxis) && lockAxis == Vector3State.False)
+            {
+                lockAxis = new Vector3State(lockXAxis, lockYAxis, lockZAxis);
+            }
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -81,9 +93,9 @@ namespace VRTK.SecondaryControllerGrabActions
         {
             Vector3 existingScale = grabbedObject.transform.localScale;
 
-            float finalScaleX = (lockXAxis ? existingScale.x : newScale.x);
-            float finalScaleY = (lockYAxis ? existingScale.y : newScale.y);
-            float finalScaleZ = (lockZAxis ? existingScale.z : newScale.z);
+            float finalScaleX = (lockAxis.xState ? existingScale.x : newScale.x);
+            float finalScaleY = (lockAxis.yState ? existingScale.y : newScale.y);
+            float finalScaleZ = (lockAxis.zState ? existingScale.z : newScale.z);
 
             if (finalScaleX > 0 && finalScaleY > 0 && finalScaleZ > 0)
             {

--- a/Assets/VRTK/Source/Scripts/Internal/Attributes.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/Attributes.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 76dc88186c148e247a89c6dd752756f0
+folderAsset: yes
+timeCreated: 1509657288
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/Attributes/MinMaxRangeAttribute.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/Attributes/MinMaxRangeAttribute.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+public class MinMaxRangeAttribute : PropertyAttribute
+{
+    public readonly float max;
+    public readonly float min;
+
+    public MinMaxRangeAttribute(float min, float max)
+    {
+        this.min = min;
+        this.max = max;
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/Attributes/MinMaxRangeAttribute.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/Attributes/MinMaxRangeAttribute.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: bbef415ca4404081ab7abdd88f0a7f2e
-timeCreated: 1509690241
+guid: e8d56dcdff7b8004fa76e8604ffc3f62
+timeCreated: 1509663139
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 27d721ae718e0424a8bdcfb6f4708f3c, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/Limits2D.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/Limits2D.cs
@@ -1,0 +1,38 @@
+﻿using UnityEngine;
+
+[System.Serializable]
+public class Limits2D
+{
+    public float minimum;
+    public float maximum;
+
+    public static Limits2D zero
+    {
+        get
+        {
+            return new Limits2D(0f, 0f);
+        }
+    }
+
+    public Limits2D(float min, float max)
+    {
+        minimum = min;
+        maximum = max;
+    }
+
+    public Limits2D(Vector2 limits)
+    {
+        minimum = limits.x;
+        maximum = limits.y;
+    }
+
+    public bool WithinLimits(float value)
+    {
+        return (value >= minimum && value <= maximum);
+    }
+
+    public Vector2 AsVector2()
+    {
+        return new Vector2(minimum, maximum);
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/Limits2D.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/Limits2D.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: bbef415ca4404081ab7abdd88f0a7f2e
-timeCreated: 1509690241
+guid: b5c7ebd091e378d4ea2b7de8657554d4
+timeCreated: 1509663150
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 27d721ae718e0424a8bdcfb6f4708f3c, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/SerializedPropertyExtensions.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/SerializedPropertyExtensions.cs
@@ -1,0 +1,187 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <author>
+//   HiddenMonk
+//   http://answers.unity3d.com/users/496850/hiddenmonk.html
+//   
+//   Johannes Deml
+//   send@johannesdeml.com
+// </author>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Supyrb
+{
+    using System;
+    using UnityEngine;
+    using UnityEditor;
+    using System.Reflection;
+
+    /// <summary>
+    /// Extension class for SerializedProperties
+    /// See also: http://answers.unity3d.com/questions/627090/convert-serializedproperty-to-custom-class.html
+    /// </summary>
+    public static class SerializedPropertyExtensions
+    {
+        /// <summary>
+        /// Get the object the serialized property holds by using reflection
+        /// </summary>
+        /// <typeparam name="T">The object type that the property contains</typeparam>
+        /// <param name="property"></param>
+        /// <returns>Returns the object type T if it is the type the property actually contains</returns>
+        public static T GetValue<T>(this SerializedProperty property)
+        {
+            return GetNestedObject<T>(property.propertyPath, GetSerializedPropertyRootComponent(property));
+        }
+
+        /// <summary>
+        /// Set the value of a field of the property with the type T
+        /// </summary>
+        /// <typeparam name="T">The type of the field that is set</typeparam>
+        /// <param name="property">The serialized property that should be set</param>
+        /// <param name="value">The new value for the specified property</param>
+        /// <returns>Returns if the operation was successful or failed</returns>
+        public static bool SetValue<T>(this SerializedProperty property, T value)
+        {
+
+            object obj = GetSerializedPropertyRootComponent(property);
+            //Iterate to parent object of the value, necessary if it is a nested object
+            string[] fieldStructure = property.propertyPath.Split('.');
+            for (int i = 0; i < fieldStructure.Length - 1; i++)
+            {
+                obj = GetFieldOrPropertyValue<object>(fieldStructure[i], obj);
+            }
+            string fieldName = fieldStructure.Last();
+
+            return SetFieldOrPropertyValue(fieldName, obj, value);
+
+        }
+
+        /// <summary>
+        /// Get the component of a serialized property
+        /// </summary>
+        /// <param name="property">The property that is part of the component</param>
+        /// <returns>The root component of the property</returns>
+        public static Component GetSerializedPropertyRootComponent(SerializedProperty property)
+        {
+            return (Component)property.serializedObject.targetObject;
+        }
+
+        /// <summary>
+        /// Iterates through objects to handle objects that are nested in the root object
+        /// </summary>
+        /// <typeparam name="T">The type of the nested object</typeparam>
+        /// <param name="path">Path to the object through other properties e.g. PlayerInformation.Health</param>
+        /// <param name="obj">The root object from which this path leads to the property</param>
+        /// <param name="includeAllBases">Include base classes and interfaces as well</param>
+        /// <returns>Returns the nested object casted to the type T</returns>
+        public static T GetNestedObject<T>(string path, object obj, bool includeAllBases = false)
+        {
+            foreach (string part in path.Split('.'))
+            {
+                obj = GetFieldOrPropertyValue<object>(part, obj, includeAllBases);
+            }
+            return (T)obj;
+        }
+
+        public static T GetFieldOrPropertyValue<T>(string fieldName, object obj, bool includeAllBases = false, BindingFlags bindings = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+        {
+            FieldInfo field = obj.GetType().GetField(fieldName, bindings);
+            if (field != null)
+            {
+                return (T)field.GetValue(obj);
+            }
+
+            PropertyInfo property = obj.GetType().GetProperty(fieldName, bindings);
+            if (property != null)
+            {
+                return (T)property.GetValue(obj, null);
+            }
+
+            if (includeAllBases)
+            {
+                foreach (Type type in GetBaseClassesAndInterfaces(obj.GetType()))
+                {
+                    field = type.GetField(fieldName, bindings);
+                    if (field != null)
+                    {
+                        return (T)field.GetValue(obj);
+                    }
+
+                    property = type.GetProperty(fieldName, bindings);
+                    if (property != null)
+                    {
+                        return (T)property.GetValue(obj, null);
+                    }
+                }
+            }
+
+            return default(T);
+        }
+
+        public static bool SetFieldOrPropertyValue(string fieldName, object obj, object value, bool includeAllBases = false, BindingFlags bindings = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+        {
+            FieldInfo field = obj.GetType().GetField(fieldName, bindings);
+            if (field != null)
+            {
+                field.SetValue(obj, value);
+                return true;
+            }
+
+            PropertyInfo property = obj.GetType().GetProperty(fieldName, bindings);
+            if (property != null)
+            {
+                property.SetValue(obj, value, null);
+                return true;
+            }
+
+            if (includeAllBases)
+            {
+                foreach (Type type in GetBaseClassesAndInterfaces(obj.GetType()))
+                {
+                    field = type.GetField(fieldName, bindings);
+                    if (field != null)
+                    {
+                        field.SetValue(obj, value);
+                        return true;
+                    }
+
+                    property = type.GetProperty(fieldName, bindings);
+                    if (property != null)
+                    {
+                        property.SetValue(obj, value, null);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public static IEnumerable<Type> GetBaseClassesAndInterfaces(this Type type, bool includeSelf = false)
+        {
+            List<Type> allTypes = new List<Type>();
+
+            if (includeSelf)
+            {
+                allTypes.Add(type);
+            }
+
+            if (type.BaseType == typeof(object))
+            {
+                allTypes.AddRange(type.GetInterfaces());
+            }
+            else
+            {
+                allTypes.AddRange(
+                        Enumerable
+                        .Repeat(type.BaseType, 1)
+                        .Concat(type.GetInterfaces())
+                        .Concat(type.BaseType.GetBaseClassesAndInterfaces())
+                        .Distinct());
+            }
+
+            return allTypes;
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/SerializedPropertyExtensions.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/SerializedPropertyExtensions.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: bbef415ca4404081ab7abdd88f0a7f2e
-timeCreated: 1509690241
+guid: 81116a06f56153049b5220431b7ec784
+timeCreated: 1509663163
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 27d721ae718e0424a8bdcfb6f4708f3c, type: 3}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/Vector3State.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/Vector3State.cs
@@ -5,6 +5,22 @@ public class Vector3State
     public bool yState;
     public bool zState;
 
+    public static Vector3State False
+    {
+        get
+        {
+            return new Vector3State(false, false, false);
+        }
+    }
+
+    public static Vector3State True
+    {
+        get
+        {
+            return new Vector3State(true, true, true);
+        }
+    }
+
     public Vector3State(bool x, bool y, bool z)
     {
         xState = x;

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/Vector3State.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/Vector3State.cs.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
 guid: dba44c46fcdbdab4589d21cc98c72cf2
-timeCreated: 1509460103
+timeCreated: 1509663174
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
  > **Breaking Changes**

In a number of scripts, standard data types were being used but created
confusion in meaning, such as using a `Vector2` for a min/max range as
this would then display in the editor as `x` and `y` values, with `x`
being minimum and the `y` being maximum.

This has now been replaced with a new `Limits2D` data type that
displays the same 2 float input boxes as a `Vector2` but instead uses
the labels of `min` and `max` which makes a lot more sense.

The `Limits2D` data type can also have a new custom attribute applied
to it called `[MinMaxRange]` which works in a similar way to `[Range]`
but it provides 2 slider points that can be dragged to set a minimum
and maximum value for the control. It should also work with a Vector2
if required.

The Axis Scale Grab Action has also been updated to use the new
Vector3State data type when determining which axes should be locked
for scaling. This is in place of the previous 3 separate boolean
parameters.