### PR TITLE
fix(PointerRenderer): too large collider of the ObjectInteractor of the tip of the PointerRenderer

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -525,6 +525,7 @@ namespace VRTK
             objectInteractorCollider.transform.localPosition = Vector3.zero;
             objectInteractorCollider.layer = LayerMask.NameToLayer("Ignore Raycast");
             SphereCollider tmpCollider = objectInteractorCollider.AddComponent<SphereCollider>();
+            tmpCollider.radius = 0.025f;
             tmpCollider.isTrigger = true;
             VRTK_PlayerObject.SetPlayerObject(objectInteractorCollider, VRTK_PlayerObject.ObjectTypes.Pointer);
 


### PR DESCRIPTION
Way too large. It touches InteractableObjects which have no contact with the ray at all.
This is due to the fact that the default Sphere collider has a 0.5 radius. The correct value seems to be 0.025.