### PR TITLE
fix(Pointers): use appropriate tip for determining pointer origin

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -1249,7 +1249,8 @@ Provides a basis of being able to emit a pointer from a specified GameObject.
  * **Select After Hover Duration:** The amount of time the pointer can be over the same collider before it automatically attempts to select it. 0f means no selection attempt will be made.
  * **Interact With Objects:** If this is checked then the pointer will be an extension of the controller and able to interact with Interactable Objects.
  * **Grab To Pointer Tip:** If `Interact With Objects` is checked and this is checked then when an object is grabbed with the pointer touching it, the object will attach to the pointer tip and not snap to the controller.
- * **Controller:** An optional controller that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
+ * **Attached To:** An optional GameObject that determines what the pointer is to be attached to. If this is left blank then the GameObject the script is on will be used.
+ * **Controller Events:** An optional Controller Events that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
  * **Interact Use:** An optional InteractUse script that will be used when using interactable objects with pointer. If this is left blank then it will attempt to get the InteractUse script from the same GameObject and if it cannot find one then it will attempt to get it from the attached controller.
  * **Custom Origin:** A custom transform to use as the origin of the pointer. If no pointer origin transform is provided then the transform the script is attached to is used.
 
@@ -7864,8 +7865,9 @@ Provides the ability to interact with UICanvas elements and the contained Unity 
  * **Click Method:** Determines when the UI Click event action should happen.
  * **Attempt Click On Deactivate:** Determines whether the UI click action should be triggered when the pointer is deactivated. If the pointer is hovering over a clickable element then it will invoke the click action on that element. Note: Only works with `Click Method =  Click_On_Button_Up`
  * **Click After Hover Duration:** The amount of time the pointer can be over the same UI element before it automatically attempts to click it. 0f means no click attempt will be made.
- * **Controller:** The controller that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
- * **Pointer Origin Transform:** A custom transform to use as the origin of the pointer. If no pointer origin transform is provided then the transform the script is attached to is used.
+ * **Attached To:** An optional GameObject that determines what the pointer is to be attached to. If this is left blank then the GameObject the script is on will be used.
+ * **Controller Events:** The Controller Events that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
+ * **Custom Origin:** A custom transform to use as the origin of the pointer. If no pointer origin transform is provided then the transform the script is attached to is used.
 
 ### Class Variables
 
@@ -10075,17 +10077,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
 
 The GetControllerOrigin method returns the origin of the given controller.
 
-#### GenerateControllerPointerOrigin/1
-
-  > `public abstract Transform GenerateControllerPointerOrigin(GameObject parent);`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
-
 #### GetControllerLeftHand/1
 
   > `public abstract GameObject GetControllerLeftHand(bool actual = false);`
@@ -10707,17 +10698,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
 
 The GetControllerOrigin method returns the origin of the given controller.
 
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
-
 #### GetControllerLeftHand/1
 
   > `public override GameObject GetControllerLeftHand(bool actual = false)`
@@ -11323,17 +11303,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
    * `Transform` - A Transform containing the origin of the controller.
 
 The GetControllerOrigin method returns the origin of the given controller.
-
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
 
 #### GetControllerLeftHand/1
 
@@ -11966,17 +11935,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
 
 The GetControllerOrigin method returns the origin of the given controller.
 
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
-
 #### GetControllerLeftHand/1
 
   > `public override GameObject GetControllerLeftHand(bool actual = false)`
@@ -12599,17 +12557,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
    * `Transform` - A Transform containing the origin of the controller.
 
 The GetControllerOrigin method returns the origin of the given controller.
-
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
 
 #### GetControllerLeftHand/1
 
@@ -13234,17 +13181,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
 
 The GetControllerOrigin method returns the origin of the given controller.
 
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
-
 #### GetControllerLeftHand/1
 
   > `public override GameObject GetControllerLeftHand(bool actual = false)`
@@ -13867,17 +13803,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
 
 The GetControllerOrigin method returns the origin of the given controller.
 
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
-
 #### GetControllerLeftHand/1
 
   > `public override GameObject GetControllerLeftHand(bool actual = false)`
@@ -14489,17 +14414,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
 
 The GetControllerOrigin method returns the origin of the given controller.
 
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * _none_
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
-
 #### GetControllerLeftHand/1
 
   > `public override GameObject GetControllerLeftHand(bool actual = false)`
@@ -15110,17 +15024,6 @@ The GetControllerByIndex method returns the GameObject of a controller with a sp
    * `Transform` - A Transform containing the origin of the controller.
 
 The GetControllerOrigin method returns the origin of the given controller.
-
-#### GenerateControllerPointerOrigin/1
-
-  > `public override Transform GenerateControllerPointerOrigin(GameObject parent)`
-
- * Parameters
-   * `GameObject parent` - The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.
- * Returns
-   * `Transform` - A generated Transform that contains the custom pointer origin.
-
-The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
 
 #### GetControllerLeftHand/1
 

--- a/Assets/VRTK/Source/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/Source/SDK/Base/SDK_BaseController.cs
@@ -320,6 +320,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public abstract Transform GenerateControllerPointerOrigin(GameObject parent);
 
         /// <summary>

--- a/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamController.cs
@@ -137,6 +137,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/SDK/Fallback/SDK_FallbackController.cs
+++ b/Assets/VRTK/Source/SDK/Fallback/SDK_FallbackController.cs
@@ -99,6 +99,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRController.cs
+++ b/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRController.cs
@@ -133,6 +133,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
@@ -218,6 +218,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_SimController.cs
@@ -156,6 +156,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
@@ -221,6 +221,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             switch (VRTK_DeviceFinder.GetHeadsetType(true))

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -230,6 +230,7 @@ namespace VRTK
         /// </summary>
         /// <param name="parent">The GameObject that the origin will become parent of. If it is a controller then it will also be used to determine the hand if required.</param>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/Source/SDK/VRTK_SDK_Bridge.cs
@@ -52,6 +52,7 @@
             return GetControllerSDK().GetControllerOrigin(controllerReference);
         }
 
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public static Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return GetControllerSDK().GenerateControllerPointerOrigin(parent);

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -197,6 +197,7 @@ namespace VRTK
         /// The GenerateControllerPointerOrigin method can create a custom pointer origin Transform to represent the pointer position and forward.
         /// </summary>
         /// <returns>A generated Transform that contains the custom pointer origin.</returns>
+        [System.Obsolete("GenerateControllerPointerOrigin has been deprecated and will be removed in a future version of VRTK.")]
         public override Transform GenerateControllerPointerOrigin(GameObject parent)
         {
             return null;

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_VRInputModule.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_VRInputModule.cs
@@ -316,7 +316,7 @@
 
         protected virtual void Scroll(VRTK_UIPointer pointer, List<RaycastResult> results)
         {
-            pointer.pointerEventData.scrollDelta = (pointer.controller != null ? pointer.controller.GetTouchpadAxis() : Vector2.zero);
+            pointer.pointerEventData.scrollDelta = (pointer.controllerEvents != null ? pointer.controllerEvents.GetTouchpadAxis() : Vector2.zero);
             bool scrollWheelVisible = false;
             for (int i = 0; i < results.Count; i++)
             {


### PR DESCRIPTION
Previously the Pointer and UIPointer would use the transform of the
controller for the pointer origin and forward, but for SteamVR due
to different controllers being at different orientations it would
use a custom origin via the `GenerateControllerPointerOrigin` method.
This is not required as the `tip/attach` GameObject in a SteamVR
controller is already at the correct orientation for determining the
appropriate pointer origin.

This fix now ensures this tip is used for determining the pointer
origin and the `GenerateControllerPointerOrigin` class has been
deprecated as no other SDKs used it except for SteamVR and SteamVR
already has a built in mechanism for dealing with this complication.

The Pointer and UIPointer also have a new `Attached To` parameter
which can be used to determine which GameObject the pointer is actually
attached to, which helps when determining the pointer origin as if
the pointer is not attached to a controller.

The `Controller` parameter has also been deprecated and brought into
line with other scripts that correctly name it `Controller Events`.