### PR TITLE
fix(Internal): add editor datatypes and attributes to VRTK namespace - fixes #1590

### DIFF
--- a/Assets/VRTK/Source/Editor/Attributes/MinMaxRangeDrawer.cs
+++ b/Assets/VRTK/Source/Editor/Attributes/MinMaxRangeDrawer.cs
@@ -1,78 +1,80 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System.Globalization;
-using Supyrb;
-using VRTK;
-
-[CustomPropertyDrawer(typeof(MinMaxRangeAttribute))]
-class MinMaxRangeDrawer : PropertyDrawer
+﻿namespace VRTK
 {
-    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    using UnityEngine;
+    using UnityEditor;
+    using System.Globalization;
+    using Supyrb;
+
+    [CustomPropertyDrawer(typeof(MinMaxRangeAttribute))]
+    class MinMaxRangeDrawer : PropertyDrawer
     {
-        label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
-        bool foundGeneric = false;
-        bool valid = false;
-        try
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            Vector2 input = SerializedPropertyExtensions.GetValue<Limits2D>(property).AsVector2();
-            Vector2 output = BuildSlider(position, label, input, out valid);
-            if (valid)
+            label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
+            bool foundGeneric = false;
+            bool valid = false;
+            try
             {
-                SerializedPropertyExtensions.SetValue<Limits2D>(property, new Limits2D(output));
+                Vector2 input = SerializedPropertyExtensions.GetValue<Limits2D>(property).AsVector2();
+                Vector2 output = BuildSlider(position, label, input, out valid);
+                if (valid)
+                {
+                    SerializedPropertyExtensions.SetValue<Limits2D>(property, new Limits2D(output));
+                }
+                foundGeneric = true;
             }
-            foundGeneric = true;
-        }
-        catch (System.Exception)
-        {
-            Error(position, label);
-        }
-
-        if (!foundGeneric)
-        {
-            switch (property.propertyType)
+            catch (System.Exception)
             {
-                case SerializedPropertyType.Vector2:
-                    Vector2 input = property.vector2Value;
-                    Vector2 output = BuildSlider(position, label, input, out valid);
-                    if (valid)
-                    {
-                        property.vector2Value = output;
-                    }
-                    break;
-                default:
-                    Error(position, label);
-                    break;
+                Error(position, label);
+            }
+
+            if (!foundGeneric)
+            {
+                switch (property.propertyType)
+                {
+                    case SerializedPropertyType.Vector2:
+                        Vector2 input = property.vector2Value;
+                        Vector2 output = BuildSlider(position, label, input, out valid);
+                        if (valid)
+                        {
+                            property.vector2Value = output;
+                        }
+                        break;
+                    default:
+                        Error(position, label);
+                        break;
+                }
             }
         }
-    }
 
-    private Vector2 BuildSlider(Rect position, GUIContent label, Vector2 range, out bool valid)
-    {
-        float fieldWidth = GUI.skin.textField.CalcSize(new GUIContent(1.234f.ToString(CultureInfo.InvariantCulture))).x; ;
-        float fieldPadding = 5f;
-        float min = range.x;
-        float max = range.y;
-
-        MinMaxRangeAttribute attr = attribute as MinMaxRangeAttribute;
-        EditorGUI.BeginChangeCheck();
-        Rect updatedPosition = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
-        min = EditorGUI.FloatField(new Rect(updatedPosition.x, updatedPosition.y, fieldWidth, updatedPosition.height), Mathf.Clamp(min, attr.min, attr.max));
-        EditorGUI.MinMaxSlider(new Rect(updatedPosition.x + (fieldWidth + fieldPadding), updatedPosition.y, updatedPosition.width - ((fieldWidth + fieldPadding) * 2f), updatedPosition.height), ref min, ref max, attr.min, attr.max);
-        max = EditorGUI.FloatField(new Rect(updatedPosition.x + (updatedPosition.width - fieldWidth), updatedPosition.y, fieldWidth, updatedPosition.height), Mathf.Clamp(max, attr.min, attr.max));
-
-        if (EditorGUI.EndChangeCheck())
+        private Vector2 BuildSlider(Rect position, GUIContent label, Vector2 range, out bool valid)
         {
-            range.x = min;
-            range.y = max;
-            valid = true;
-            return range;
-        }
-        valid = false;
-        return Vector2.zero;
-    }
+            float fieldWidth = GUI.skin.textField.CalcSize(new GUIContent(1.23456f.ToString(CultureInfo.InvariantCulture))).x; ;
+            float fieldPadding = 5f;
+            float min = range.x;
+            float max = range.y;
 
-    private void Error(Rect position, GUIContent label)
-    {
-        EditorGUI.LabelField(position, label, new GUIContent("Use only with Vector2 or Limits2D"));
+            MinMaxRangeAttribute attr = attribute as MinMaxRangeAttribute;
+            EditorGUI.BeginChangeCheck();
+            Rect updatedPosition = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+            min = EditorGUI.FloatField(new Rect(updatedPosition.x, updatedPosition.y, fieldWidth, updatedPosition.height), Mathf.Clamp(min, attr.min, attr.max));
+            EditorGUI.MinMaxSlider(new Rect(updatedPosition.x + (fieldWidth + fieldPadding), updatedPosition.y, updatedPosition.width - ((fieldWidth + fieldPadding) * 2f), updatedPosition.height), ref min, ref max, attr.min, attr.max);
+            max = EditorGUI.FloatField(new Rect(updatedPosition.x + (updatedPosition.width - fieldWidth), updatedPosition.y, fieldWidth, updatedPosition.height), Mathf.Clamp(max, attr.min, attr.max));
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                range.x = min;
+                range.y = max;
+                valid = true;
+                return range;
+            }
+            valid = false;
+            return Vector2.zero;
+        }
+
+        private void Error(Rect position, GUIContent label)
+        {
+            EditorGUI.LabelField(position, label, new GUIContent("Use only with Vector2 or Limits2D"));
+        }
     }
 }

--- a/Assets/VRTK/Source/Editor/Attributes/SerializedPropertyExtensions.cs
+++ b/Assets/VRTK/Source/Editor/Attributes/SerializedPropertyExtensions.cs
@@ -8,15 +8,14 @@
 // </author>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Supyrb
+namespace VRTK.Supyrb
 {
     using System;
     using UnityEngine;
     using UnityEditor;
     using System.Reflection;
+    using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Extension class for SerializedProperties

--- a/Assets/VRTK/Source/Editor/DataTypes/Limits2DDrawer.cs
+++ b/Assets/VRTK/Source/Editor/DataTypes/Limits2DDrawer.cs
@@ -1,33 +1,35 @@
-﻿using UnityEngine;
-using UnityEditor;
-using VRTK;
-
-[CustomPropertyDrawer(typeof(Limits2D))]
-public class Limits2DDrawer : PropertyDrawer
+﻿namespace VRTK
 {
-    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    using UnityEngine;
+    using UnityEditor;
+
+    [CustomPropertyDrawer(typeof(Limits2D))]
+    public class Limits2DDrawer : PropertyDrawer
     {
-        label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
-        SerializedProperty minimum = property.FindPropertyRelative("minimum");
-        SerializedProperty maximum = property.FindPropertyRelative("maximum");
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
+            SerializedProperty minimum = property.FindPropertyRelative("minimum");
+            SerializedProperty maximum = property.FindPropertyRelative("maximum");
 
-        int indent = EditorGUI.indentLevel;
-        EditorGUI.indentLevel = 0;
-        position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
-        float updatePositionX = position.x;
-        float labelWidth = 30f;
-        float fieldWidth = (position.width / 3f) - labelWidth;
+            int indent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+            float updatePositionX = position.x;
+            float labelWidth = 30f;
+            float fieldWidth = (position.width / 3f) - labelWidth;
 
-        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Min");
-        updatePositionX += labelWidth;
-        minimum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), minimum.floatValue);
-        updatePositionX += fieldWidth;
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Min");
+            updatePositionX += labelWidth;
+            minimum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), minimum.floatValue);
+            updatePositionX += fieldWidth;
 
-        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Max");
-        updatePositionX += labelWidth;
-        maximum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), maximum.floatValue);
-        updatePositionX += fieldWidth;
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Max");
+            updatePositionX += labelWidth;
+            maximum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), maximum.floatValue);
+            updatePositionX += fieldWidth;
 
-        EditorGUI.indentLevel = indent;
+            EditorGUI.indentLevel = indent;
+        }
     }
 }

--- a/Assets/VRTK/Source/Editor/DataTypes/Vector3StateDrawer.cs
+++ b/Assets/VRTK/Source/Editor/DataTypes/Vector3StateDrawer.cs
@@ -1,39 +1,41 @@
-﻿using UnityEngine;
-using UnityEditor;
-using VRTK;
-
-[CustomPropertyDrawer(typeof(Vector3State))]
-public class Vector3StateDrawer : PropertyDrawer
+﻿namespace VRTK
 {
-    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    using UnityEngine;
+    using UnityEditor;
+
+    [CustomPropertyDrawer(typeof(Vector3State))]
+    public class Vector3StateDrawer : PropertyDrawer
     {
-        label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
-        SerializedProperty xState = property.FindPropertyRelative("xState");
-        SerializedProperty yState = property.FindPropertyRelative("yState");
-        SerializedProperty zState = property.FindPropertyRelative("zState");
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            label.tooltip = VRTK_EditorUtilities.GetTooltipAttribute(fieldInfo).tooltip;
+            SerializedProperty xState = property.FindPropertyRelative("xState");
+            SerializedProperty yState = property.FindPropertyRelative("yState");
+            SerializedProperty zState = property.FindPropertyRelative("zState");
 
-        int indent = EditorGUI.indentLevel;
-        EditorGUI.indentLevel = 0;
-        position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
-        float updatePositionX = position.x;
-        float labelWidth = 15f;
-        float fieldWidth = (position.width  / 3f) - labelWidth;
+            int indent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+            float updatePositionX = position.x;
+            float labelWidth = 15f;
+            float fieldWidth = (position.width / 3f) - labelWidth;
 
-        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "X");
-        updatePositionX += labelWidth;
-        xState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), xState.boolValue);
-        updatePositionX += fieldWidth;
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "X");
+            updatePositionX += labelWidth;
+            xState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), xState.boolValue);
+            updatePositionX += fieldWidth;
 
-        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Y");
-        updatePositionX += labelWidth;
-        yState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), yState.boolValue);
-        updatePositionX += fieldWidth;
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Y");
+            updatePositionX += labelWidth;
+            yState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), yState.boolValue);
+            updatePositionX += fieldWidth;
 
-        EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Z");
-        updatePositionX += labelWidth;
-        zState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), zState.boolValue);
-        updatePositionX += fieldWidth;
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Z");
+            updatePositionX += labelWidth;
+            zState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), zState.boolValue);
+            updatePositionX += fieldWidth;
 
-        EditorGUI.indentLevel = indent;
+            EditorGUI.indentLevel = indent;
+        }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Internal/Attributes/MinMaxRangeAttribute.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/Attributes/MinMaxRangeAttribute.cs
@@ -1,13 +1,16 @@
-﻿using UnityEngine;
-
-public class MinMaxRangeAttribute : PropertyAttribute
+﻿namespace VRTK
 {
-    public readonly float max;
-    public readonly float min;
+    using UnityEngine;
 
-    public MinMaxRangeAttribute(float min, float max)
+    public class MinMaxRangeAttribute : PropertyAttribute
     {
-        this.min = min;
-        this.max = max;
+        public readonly float max;
+        public readonly float min;
+
+        public MinMaxRangeAttribute(float min, float max)
+        {
+            this.min = min;
+            this.max = max;
+        }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/Limits2D.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/Limits2D.cs
@@ -1,38 +1,41 @@
-﻿using UnityEngine;
-
-[System.Serializable]
-public class Limits2D
+﻿namespace VRTK
 {
-    public float minimum;
-    public float maximum;
+    using UnityEngine;
 
-    public static Limits2D zero
+    [System.Serializable]
+    public class Limits2D
     {
-        get
+        public float minimum;
+        public float maximum;
+
+        public static Limits2D zero
         {
-            return new Limits2D(0f, 0f);
+            get
+            {
+                return new Limits2D(0f, 0f);
+            }
         }
-    }
 
-    public Limits2D(float min, float max)
-    {
-        minimum = min;
-        maximum = max;
-    }
+        public Limits2D(float min, float max)
+        {
+            minimum = min;
+            maximum = max;
+        }
 
-    public Limits2D(Vector2 limits)
-    {
-        minimum = limits.x;
-        maximum = limits.y;
-    }
+        public Limits2D(Vector2 limits)
+        {
+            minimum = limits.x;
+            maximum = limits.y;
+        }
 
-    public bool WithinLimits(float value)
-    {
-        return (value >= minimum && value <= maximum);
-    }
+        public bool WithinLimits(float value)
+        {
+            return (value >= minimum && value <= maximum);
+        }
 
-    public Vector2 AsVector2()
-    {
-        return new Vector2(minimum, maximum);
+        public Vector2 AsVector2()
+        {
+            return new Vector2(minimum, maximum);
+        }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Internal/DataTypes/Vector3State.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/DataTypes/Vector3State.cs
@@ -1,30 +1,33 @@
-﻿[System.Serializable]
-public class Vector3State
+﻿namespace VRTK
 {
-    public bool xState;
-    public bool yState;
-    public bool zState;
-
-    public static Vector3State False
+    [System.Serializable]
+    public class Vector3State
     {
-        get
+        public bool xState;
+        public bool yState;
+        public bool zState;
+
+        public static Vector3State False
         {
-            return new Vector3State(false, false, false);
+            get
+            {
+                return new Vector3State(false, false, false);
+            }
         }
-    }
 
-    public static Vector3State True
-    {
-        get
+        public static Vector3State True
         {
-            return new Vector3State(true, true, true);
+            get
+            {
+                return new Vector3State(true, true, true);
+            }
         }
-    }
 
-    public Vector3State(bool x, bool y, bool z)
-    {
-        xState = x;
-        yState = y;
-        zState = z;
+        public Vector3State(bool x, bool y, bool z)
+        {
+            xState = x;
+            yState = y;
+            zState = z;
+        }
     }
 }


### PR DESCRIPTION
To prevent name collisions with 3rd party scripts, the editor datatypes
and attributes used by VRTK are now within the VRTK namespace.

The Serialized Property Extensions script is also now included in the
VRTK namespace in case 3rd party scripts are also using this same
script causing it to be in the project twice.