### PR TITLE
fix(Internal): ensure controller ready registration is always done

### DIFF
--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs
@@ -29,26 +29,25 @@
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
-            RegisterLeftControllerReady();
-            RegisterRightControllerReady();
             CheckControllersReady();
             previousControllerSDK = VRTK_SDK_Bridge.GetControllerSDK();
         }
 
         protected virtual void CheckControllersReady()
         {
+            RegisterLeftControllerReady();
+            RegisterRightControllerReady();
+
             VRTK_ControllerReference leftRef = VRTK_DeviceFinder.GetControllerReferenceLeftHand();
             VRTK_ControllerReference rightRef = VRTK_DeviceFinder.GetControllerReferenceRightHand();
 
             if (VRTK_ControllerReference.IsValid(leftRef))
             {
-                RegisterLeftControllerReady();
                 ControllerReady(leftRef);
             }
 
             if (VRTK_ControllerReference.IsValid(rightRef))
             {
-                RegisterRightControllerReady();
                 ControllerReady(rightRef);
             }
         }


### PR DESCRIPTION
The SDK Controller Ready script was only attempting to register the
controller ready check if a valid controller reference was found.

However, with SteamVR and possibly other SDKs the controller is not
actually ready at start up and takes a few moments before it's ready
meaning the controller reference is not valid.

The registration of the controller ready checks should always be
done anyway and not only if a valid controller is ready as the
SDK event is emitted when the actual SDK reports the controller as
being ready.