### PR TITLE
feat(Interaction): expose max distance delta parameter on track grab - fixes #1563

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -5410,6 +5410,7 @@ Applies velocity to the grabbed Interactable Object to ensure it tracks the posi
  * **Detach Distance:** The maximum distance the grabbing object is away from the Interactable Object before it is automatically dropped.
  * **Velocity Limit:** The maximum amount of velocity magnitude that can be applied to the Interactable Object. Lowering this can prevent physics glitches if Interactable Objects are moving too fast.
  * **Angular Velocity Limit:** The maximum amount of angular velocity magnitude that can be applied to the Interactable Object. Lowering this can prevent physics glitches if Interactable Objects are moving too fast.
+ * **Max Distance Delta:** The maximum difference in distance to the tracked position.
 
 ### Class Methods
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_TrackObjectGrabAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_TrackObjectGrabAttach.cs
@@ -28,6 +28,8 @@ namespace VRTK.GrabAttachMechanics
         public float velocityLimit = float.PositiveInfinity;
         [Tooltip("The maximum amount of angular velocity magnitude that can be applied to the Interactable Object. Lowering this can prevent physics glitches if Interactable Objects are moving too fast.")]
         public float angularVelocityLimit = float.PositiveInfinity;
+        [Tooltip("The maximum difference in distance to the tracked position.")]
+        public float maxDistanceDelta = 10f;
 
         protected bool isReleasable = true;
 
@@ -94,7 +96,6 @@ namespace VRTK.GrabAttachMechanics
                 return;
             }
 
-            float maxDistanceDelta = 10f;
             Vector3 positionDelta = trackPoint.position - (grabbedSnapHandle != null ? grabbedSnapHandle.position : grabbedObject.transform.position);
             Quaternion rotationDelta = trackPoint.rotation * Quaternion.Inverse((grabbedSnapHandle != null ? grabbedSnapHandle.rotation : grabbedObject.transform.rotation));
 


### PR DESCRIPTION
The Track Object Grab Mechanic had an internal parameter for the
Max Distance Delta used within the MoveTowards method. However, this
was always set to `10f` but on occasion it was prudent to change this
value to something else. The simplest solution is to just expose this
parameter to allow the user to set it to what they need it to be.