### PR TITLE
feat(Locomotion): option to add skybox texture to tunnel overlay cage

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -2552,6 +2552,7 @@ Applys a tunnel overlay effect to the active VR camera when the play area is mov
  * **Minimum Speed:** Minimum movement speed for the effect to activate.
  * **Maximum Speed:** Maximum movement speed where the effect will have its max settings applied.
  * **Effect Color:** The color to use for the tunnel effect.
+ * **Effect Skybox:** An optional skybox texture to use for the tunnel effect.
  * **Initial Effect Size:** The initial amount of screen coverage the tunnel to consume without any movement.
  * **Maximum Effect Size:** Screen coverage at the maximum tracked values.
  * **Feather Size:** Feather effect size around the cut-off as fraction of screen.

--- a/Assets/VRTK/Internal/Materials/Resources/TunnelOverlay.mat
+++ b/Assets/VRTK/Internal/Materials/Resources/TunnelOverlay.mat
@@ -22,6 +22,10 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _SecondarySkyBox:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
     - _AngularVelocity: 0
     - _FeatherSize: 0.1


### PR DESCRIPTION
The view in which the Tunnel Overlay fades out to can now have a
Cubemap texture provided to display as a static skybox to provide a
better point of reference.

The Effect Color can also be used to tint the skybox texture if
required.

Thanks to @jwnjwn for the work on this!


Example Cubemap texture -> ![image](https://user-images.githubusercontent.com/1029673/32651257-78a009c2-c5f8-11e7-8af3-51da0a7230c6.png)