### PR TITLE
fix(Pointers): ensure controller reference set when controller found - fixes #1610

### DIFF
--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
@@ -424,6 +424,7 @@ namespace VRTK
         protected virtual bool FindController()
         {
             controllerEvents = (controllerEvents == null ? GetComponentInParent<VRTK_ControllerEvents>() : controllerEvents);
+            controllerReference = VRTK_ControllerReference.GetControllerReference((controllerEvents != null ? controllerEvents.gameObject : null));
 
             if (ControllerRequired() && controllerEvents == null)
             {


### PR DESCRIPTION
The Controller Reference was only set when the activation button was
pressed which meant that the enter event would not emit until the
activation button was pressed. This caused an issue when the
`Activate On Enable` option was set as the Controller Reference
had not been set at that point.