### PR TITLE
feat(Pointers): add max length option to ui pointer

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -7919,6 +7919,7 @@ Provides the ability to interact with UICanvas elements and the contained Unity 
  * **Click Method:** Determines when the UI Click event action should happen.
  * **Attempt Click On Deactivate:** Determines whether the UI click action should be triggered when the pointer is deactivated. If the pointer is hovering over a clickable element then it will invoke the click action on that element. Note: Only works with `Click Method =  Click_On_Button_Up`
  * **Click After Hover Duration:** The amount of time the pointer can be over the same UI element before it automatically attempts to click it. 0f means no click attempt will be made.
+ * **Maximum Length:** The maximum length the UI Raycast will reach.
  * **Attached To:** An optional GameObject that determines what the pointer is to be attached to. If this is left blank then the GameObject the script is on will be used.
  * **Controller Events:** The Controller Events that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
  * **Custom Origin:** A custom transform to use as the origin of the pointer. If no pointer origin transform is provided then the transform the script is attached to is used.

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -31,7 +31,7 @@
             }
 
             Ray ray = new Ray(eventData.pointerCurrentRaycast.worldPosition, eventData.pointerCurrentRaycast.worldNormal);
-            Raycast(canvas, eventCamera, ray, ref s_RaycastResults);
+            Raycast(canvas, eventCamera, eventData, ray, ref s_RaycastResults);
             SetNearestRaycast(ref eventData, ref resultAppendList, ref s_RaycastResults);
             s_RaycastResults.Clear();
         }
@@ -61,10 +61,8 @@
         }
 
         //[Pure]
-        protected virtual float GetHitDistance(Ray ray)
+        protected virtual float GetHitDistance(Ray ray, float hitDistance)
         {
-            float hitDistance = float.MaxValue;
-
             if (canvas.renderMode != RenderMode.ScreenSpaceOverlay && blockingObjects != BlockingObjects.None)
             {
                 float maxDistance = Vector3.Distance(ray.origin, canvas.transform.position);
@@ -73,7 +71,7 @@
                 {
                     RaycastHit hit;
                     Physics.Raycast(ray, out hit, maxDistance);
-                    if (hit.collider && !VRTK_PlayerObject.IsPlayerObject(hit.collider.gameObject))
+                    if (hit.collider != null && !VRTK_PlayerObject.IsPlayerObject(hit.collider.gameObject))
                     {
                         hitDistance = hit.distance;
                     }
@@ -93,9 +91,9 @@
         }
 
         //[Pure]
-        protected virtual void Raycast(Canvas canvas, Camera eventCamera, Ray ray, ref List<RaycastResult> results)
+        protected virtual void Raycast(Canvas canvas, Camera eventCamera, PointerEventData eventData, Ray ray, ref List<RaycastResult> results)
         {
-            float hitDistance = GetHitDistance(ray);
+            float hitDistance = GetHitDistance(ray, VRTK_UIPointer.pointerLengths[eventData.pointerId]);
             IList<Graphic> canvasGraphics = GraphicRegistry.GetGraphicsForCanvas(canvas);
             for (int i = 0; i < canvasGraphics.Count; ++i)
             {

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
@@ -3,6 +3,7 @@ namespace VRTK
 {
     using UnityEngine;
     using UnityEngine.EventSystems;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Event Payload
@@ -49,6 +50,8 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/UI/VRTK_UIPointer")]
     public class VRTK_UIPointer : MonoBehaviour
     {
+        public static Dictionary<int, float> pointerLengths = new Dictionary<int, float>();
+
         /// <summary>
         /// Methods of activation.
         /// </summary>
@@ -103,6 +106,8 @@ namespace VRTK
 
         [Header("Customisation Settings")]
 
+        [Tooltip("The maximum length the UI Raycast will reach.")]
+        public float maximumLength = float.PositiveInfinity;
         [Tooltip("An optional GameObject that determines what the pointer is to be attached to. If this is left blank then the GameObject the script is on will be used.")]
         public GameObject attachedTo;
         [Tooltip("The Controller Events that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.")]
@@ -470,6 +475,7 @@ namespace VRTK
             if (controllerEvents != null)
             {
                 pointerEventData.pointerId = (int)VRTK_ControllerReference.GetRealIndex(GetControllerReference());
+                pointerLengths[pointerEventData.pointerId] = maximumLength;
             }
             if (controllerRenderModel == null && VRTK_ControllerReference.IsValid(GetControllerReference()))
             {


### PR DESCRIPTION
The UI Pointer can now have it's raycast length limited by a script
parameter.

It stores the parameter against the pointer id in a static dictionary
that is then read by the Graphics Raycaster to determine the max
raycast length.