### PR TITLE
feat(SDK): add option to exclude target build platforms

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -8156,6 +8156,7 @@ A helper class that simply holds references to both the SDK_ScriptingDefineSymbo
  * **Auto Manage VR Settings:** Determines whether the VR settings of the Player Settings are automatically adjusted to allow for all the used SDKs in the SDK Setups list below.
  * **Auto Load Setup:** Determines whether the SDK Setups list below is used whenever the SDK Manager is enabled. The first loadable Setup is then loaded.
  * **Setups:** The list of SDK Setups to choose from.
+ * **Exclude Target Groups:** The list of Build Target Groups to exclude.
 
 ### Class Variables
 

--- a/Assets/VRTK/Source/Editor/VRTK_SDKManagerEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKManagerEditor.cs
@@ -408,6 +408,17 @@
                 }
             }
 
+            using (new EditorGUILayout.VerticalScope("Box"))
+            {
+                VRTK_EditorUtilities.AddHeader("Target Platform Group Exclusions", false);
+                SerializedProperty excludeTargetGroups = serializedObject.FindProperty("excludeTargetGroups");
+                excludeTargetGroups.arraySize = EditorGUILayout.IntField("Size", excludeTargetGroups.arraySize);
+                for (int i = 0; i < excludeTargetGroups.arraySize; i++)
+                {
+                    EditorGUILayout.PropertyField(excludeTargetGroups.GetArrayElementAtIndex(i));
+                }
+            }
+
             serializedObject.ApplyModifiedProperties();
         }
 

--- a/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
@@ -402,7 +402,7 @@
             [InitializeOnLoadMethod]
             private static void ListenToPlayModeChanges()
             {
-                EditorApplication.playmodeStateChanged += () =>
+                EditorApplication.playModeStateChanged += (PlayModeStateChange state) =>
                 {
                     if (EditorApplication.isPlayingOrWillChangePlaymode && !EditorApplication.isPlaying)
                     {

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -180,6 +180,9 @@ namespace VRTK
         public bool autoLoadSetup = true;
         [Tooltip("The list of SDK Setups to choose from.")]
         public VRTK_SDKSetup[] setups = new VRTK_SDKSetup[0];
+        [Tooltip("The list of Build Target Groups to exclude.")]
+        public BuildTargetGroup[] excludeTargetGroups = new BuildTargetGroup[] { BuildTargetGroup.Switch, BuildTargetGroup.Facebook };
+
         /// <summary>
         /// The loaded SDK Setup. `null` if no setup is currently loaded.
         /// </summary>
@@ -208,6 +211,7 @@ namespace VRTK
         private Coroutine checkLeftControllerReadyRoutine = null;
         private Coroutine checkRightControllerReadyRoutine = null;
         private float checkControllerReadyDelay = 1f;
+        private BuildTargetGroup[] targetGroupsToExclude;
 
         /// <summary>
         /// The event invoked whenever the loaded SDK Setup changes.
@@ -357,6 +361,10 @@ namespace VRTK
 
             foreach (BuildTargetGroup targetGroup in VRTK_SharedMethods.GetValidBuildTargetGroups())
             {
+                if (targetGroupsToExclude.Contains(targetGroup))
+                {
+                    continue;
+                }
                 string[] deviceNames;
                 deviceNamesByTargetGroup.TryGetValue(targetGroup, out deviceNames);
 
@@ -944,6 +952,7 @@ namespace VRTK
 
             if (instance != null && !instance.ManageScriptingDefineSymbols(false, false))
             {
+                instance.targetGroupsToExclude = instance.excludeTargetGroups;
                 instance.ManageVRSettings(false);
             }
         }


### PR DESCRIPTION
There was an issue with Unity 2017.2 where it would display a warning
when trying to manage the VR settings due to the Facebook and Switch
platform not being supported.

The new Target Platform Group Exclusions will allow for these two
platforms to be automatically excluded but also the array can be
updated with additional platforms if required.