### PR TITLE
fix(SDK): ensure deprecated event is only used in old unity version

### DIFF
--- a/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKSetupEditor.cs
@@ -402,7 +402,11 @@
             [InitializeOnLoadMethod]
             private static void ListenToPlayModeChanges()
             {
+#if UNITY_2017_2_OR_NEWER
                 EditorApplication.playModeStateChanged += (PlayModeStateChange state) =>
+#else
+                EditorApplication.playmodeStateChanged += () =>
+#endif
                 {
                     if (EditorApplication.isPlayingOrWillChangePlaymode && !EditorApplication.isPlaying)
                     {


### PR DESCRIPTION
The `playmodeStateChanged` event has been replaced in 2017.2 with
`playModeStateChanged` and there needs to be a platform dependent
define to ensure compatibility with both the 2017.2 version of Unity
and the older versions which use the older event name.