### PR TITLE
fix(SDK): let SDKManager work with Unity versions prior to 2017.1

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -181,7 +181,12 @@ namespace VRTK
         [Tooltip("The list of SDK Setups to choose from.")]
         public VRTK_SDKSetup[] setups = new VRTK_SDKSetup[0];
         [Tooltip("The list of Build Target Groups to exclude.")]
-        public BuildTargetGroup[] excludeTargetGroups = new BuildTargetGroup[] { BuildTargetGroup.Switch, BuildTargetGroup.Facebook };
+        public BuildTargetGroup[] excludeTargetGroups = new BuildTargetGroup[] {
+#if UNITY_2017_1_OR_NEWER
+            BuildTargetGroup.Switch,
+            BuildTargetGroup.Facebook
+#endif
+        };
 
         /// <summary>
         /// The loaded SDK Setup. `null` if no setup is currently loaded.


### PR DESCRIPTION
Add a check in `VRTK_SDKManager` on Unity version when initializing 
`excludeTargetGroups` to avoid the error `'UnityEditor.BuildTargetGroup'
 does not contain a definition for 'Switch'`.