### PR TITLE
fix(Pointers): ensure pointer id exists when checking ui pointer length

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -7967,6 +7967,17 @@ Adding the `VRTK_UIPointer_UnityEvents` component to `VRTK_UIPointer` object all
 
 ### Class Methods
 
+#### GetPointerLength/1
+
+  > `public static float GetPointerLength(int pointerId)`
+
+ * Parameters
+   * `int pointerId` - The pointer ID for the UI Pointer to recieve the length for.
+ * Returns
+   * `float` - The maximum length the UI Pointer will cast to.
+
+The GetPointerLength method retrieves the maximum UI Pointer length for the given pointer ID.
+
 #### SetEventSystem/1
 
   > `public virtual VRTK_VRInputModule SetEventSystem(EventSystem eventSystem)`

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -93,7 +93,7 @@
         //[Pure]
         protected virtual void Raycast(Canvas canvas, Camera eventCamera, PointerEventData eventData, Ray ray, ref List<RaycastResult> results)
         {
-            float hitDistance = GetHitDistance(ray, VRTK_UIPointer.pointerLengths[eventData.pointerId]);
+            float hitDistance = GetHitDistance(ray, VRTK_UIPointer.GetPointerLength(eventData.pointerId));
             IList<Graphic> canvasGraphics = GraphicRegistry.GetGraphicsForCanvas(canvas);
             for (int i = 0; i < canvasGraphics.Count; ++i)
             {

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
@@ -50,8 +50,6 @@ namespace VRTK
     [AddComponentMenu("VRTK/Scripts/UI/VRTK_UIPointer")]
     public class VRTK_UIPointer : MonoBehaviour
     {
-        public static Dictionary<int, float> pointerLengths = new Dictionary<int, float>();
-
         /// <summary>
         /// Methods of activation.
         /// </summary>
@@ -182,6 +180,7 @@ namespace VRTK
         /// </summary>
         public event UIPointerEventHandler UIPointerElementDragEnd;
 
+        protected static Dictionary<int, float> pointerLengths = new Dictionary<int, float>();
         protected bool pointerClicked = false;
         protected bool beamEnabledState = false;
         protected bool lastPointerPressState = false;
@@ -192,6 +191,21 @@ namespace VRTK
         protected Transform cachedPointerAttachPoint = null;
         protected EventSystem cachedEventSystem;
         protected VRTK_VRInputModule cachedVRInputModule;
+
+        /// <summary>
+        /// The GetPointerLength method retrieves the maximum UI Pointer length for the given pointer ID.
+        /// </summary>
+        /// <param name="pointerId">The pointer ID for the UI Pointer to recieve the length for.</param>
+        /// <returns>The maximum length the UI Pointer will cast to.</returns>
+        public static float GetPointerLength(int pointerId)
+        {
+            float maxLength;
+            if (!pointerLengths.TryGetValue(pointerId, out maxLength))
+            {
+                maxLength = float.MaxValue;
+            }
+            return maxLength;
+        }
 
         public virtual void OnUIPointerElementEnter(UIPointerEventArgs e)
         {


### PR DESCRIPTION
There was an issue where the pointerID didn't exist when checking the
UI Pointer length which would cause a crash.

This has been fixed by adding a check when retrieving the pointer max
length from the dictionary and making the dictionary protected whilst
providing a static public getter method.