### PR TITLE
feat(SDK): add WindowsMR support for SteamVR

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -3179,7 +3179,7 @@ A relationship to a physical VR controller and emits events based on the inputs 
  * `public bool gripAxisChanged` - This will be true if the grip has been squeezed more or less. Default: `false`
  * `public bool touchpadPressed` - This will be true if the touchpad is held down. Default: `false`
  * `public bool touchpadTouched` - This will be true if the touchpad is being touched. Default: `false`
- * `public bool touchpadAxisChanged` - This will be true if the touchpad touch position has changed. Default: `false`
+ * `public bool touchpadAxisChanged` - This will be true if the touchpad position has changed. Default: `false`
  * `public bool touchpadSenseAxisChanged` - This will be true if the touchpad sense is being touched more or less. Default: `false`
  * `public bool buttonOnePressed` - This will be true if button one is held down. Default: `false`
  * `public bool buttonOneTouched` - This will be true if button one is being touched. Default: `false`
@@ -3218,6 +3218,7 @@ A relationship to a physical VR controller and emits events based on the inputs 
  * `TouchpadTouchEnd` - Emitted when the touchpad is no longer being touched.
  * `TouchpadAxisChanged` - Emitted when the touchpad is being touched in a different location.
  * `TouchpadSenseAxisChanged` - Emitted when the amount of touch on the touchpad sense changes.
+ * `TouchpadTwoAxisChanged` - Emitted when the touchpad two is being touched in a different location.
  * `ButtonOneTouchStart` - Emitted when button one is touched.
  * `ButtonOneTouchEnd` - Emitted when button one is no longer being touched.
  * `ButtonOnePressed` - Emitted when button one is pressed.
@@ -3250,6 +3251,8 @@ Adding the `VRTK_ControllerEvents_UnityEvents` component to `VRTK_ControllerEven
  * `float buttonPressure` - The amount of pressure being applied to the button pressed. `0f` to `1f`.
  * `Vector2 touchpadAxis` - The position the touchpad is touched at. `(0,0)` to `(1,1)`.
  * `float touchpadAngle` - The rotational position the touchpad is being touched at, 0 being top, 180 being bottom and all other angles accordingly. `0f` to `360f`.
+ * `Vector2 touchpadTwoAxis` - The position the touchpad two is touched at. `(0,0)` to `(1,1)`.
+ * `float touchpadTwoAngle` - The rotational position the touchpad two is being touched at, 0 being top, 180 being bottom and all other angles accordingly. `0f` to `360f`.
 
 ### Class Methods
 
@@ -3309,6 +3312,28 @@ The GetTouchpadAxis method returns the coordinates of where the touchpad is bein
    * `float` - A float representing the angle of where the touchpad is being touched. `0f` to `360f`.
 
 The GetTouchpadAxisAngle method returns the angle of where the touchpad is currently being touched with the top of the touchpad being `0` degrees and the bottom of the touchpad being `180` degrees.
+
+#### GetTouchpadTwoAxis/0
+
+  > `public virtual Vector2 GetTouchpadTwoAxis()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `Vector2` - A two dimensional vector containing the `x` and `y` position of where the touchpad two is being touched. `(0,0)` to `(1,1)`.
+
+The GetTouchpadTwoAxis method returns the coordinates of where the touchpad two is being touched and can be used for directional input via the touchpad two. The `x` value is the horizontal touch plane and the `y` value is the vertical touch plane.
+
+#### GetTouchpadTwoAxisAngle/0
+
+  > `public virtual float GetTouchpadTwoAxisAngle()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `float` - A float representing the angle of where the touchpad two is being touched. `0f` to `360f`.
+
+The GetTouchpadTwoAxisAngle method returns the angle of where the touchpad two is currently being touched with the top of the touchpad two being `0` degrees and the bottom of the touchpad two being `180` degrees.
 
 #### GetTriggerAxis/0
 
@@ -9927,6 +9952,7 @@ This is an abstract class to implement the interface required by all implemented
    * `GoogleDaydream` - The Google Daydream headset.
    * `GoogleCardboard` - The Google Cardboard headset.
    * `HyperealVR` - The HyperealVR headset.
+   * `WindowsMixedReality` - The Windows Mixed Reality headset.
 
 ### Class Methods
 
@@ -10064,6 +10090,7 @@ This is an abstract class to implement the interface required by all implemented
    * `Trigger` - Trigger on the controller.
    * `TriggerHairline` - Trigger Hairline on the controller.
    * `Touchpad` - Touchpad on the controller.
+   * `TouchpadTwo` - Touchpad Two on the controller.
    * `MiddleFinger` - Middle Finger on the controller.
    * `RingFinger` - Ring Finger on the controller.
    * `PinkyFinger` - Pinky Finger on the controller.
@@ -10103,6 +10130,8 @@ This is an abstract class to implement the interface required by all implemented
    * `Oculus_OculusRemote` - The Oculus Remote for Oculus Utilities.
    * `Oculus_GearVRHMD` - The Oculus GearVR HMD controls for Oculus Utilities.
    * `Oculus_GearVRController` - The Oculus GearVR controller for Oculus Utilities.
+   * `WindowsMR_MotionController` - The Windows Mixed Reality Motion Controller for Windows Mixed Reality.
+   * `SteamVR_WindowsMRController` - The Windows Mixed Reality Motion Controller for SteamVR.
 
 ### Class Methods
 

--- a/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
+++ b/Assets/VRTK/Examples/ExampleResources/Scripts/VRTK_ControllerEvents_ListenerExample.cs
@@ -32,6 +32,7 @@
         public bool triggerAxisEvents = true;
         public bool gripAxisEvents = true;
         public bool touchpadAxisEvents = true;
+        public bool touchpadTwoAxisEvents = true;
 
         [Header("Sense Axis Events Debug")]
 
@@ -79,6 +80,7 @@
             controllerEvents.TouchpadTouchStart += DoTouchpadTouchStart;
             controllerEvents.TouchpadTouchEnd += DoTouchpadTouchEnd;
             controllerEvents.TouchpadAxisChanged += DoTouchpadAxisChanged;
+            controllerEvents.TouchpadTwoAxisChanged += DoTouchpadTwoAxisChanged;
             controllerEvents.TouchpadSenseAxisChanged += DoTouchpadSenseAxisChanged;
 
             controllerEvents.ButtonOnePressed += DoButtonOnePressed;
@@ -133,6 +135,7 @@
                 controllerEvents.TouchpadTouchStart -= DoTouchpadTouchStart;
                 controllerEvents.TouchpadTouchEnd -= DoTouchpadTouchEnd;
                 controllerEvents.TouchpadAxisChanged -= DoTouchpadAxisChanged;
+                controllerEvents.TouchpadTwoAxisChanged -= DoTouchpadTwoAxisChanged;
                 controllerEvents.TouchpadSenseAxisChanged -= DoTouchpadSenseAxisChanged;
 
                 controllerEvents.ButtonOnePressed -= DoButtonOnePressed;
@@ -173,6 +176,7 @@
                     triggerAxisEvents = false;
                     gripAxisEvents = false;
                     touchpadAxisEvents = false;
+                    touchpadTwoAxisEvents = false;
 
                     triggerSenseAxisEvents = false;
                     touchpadSenseAxisEvents = false;
@@ -191,6 +195,7 @@
                     triggerAxisEvents = true;
                     gripAxisEvents = true;
                     touchpadAxisEvents = true;
+                    touchpadTwoAxisEvents = true;
 
                     triggerSenseAxisEvents = true;
                     touchpadSenseAxisEvents = true;
@@ -209,6 +214,7 @@
                     triggerAxisEvents = false;
                     gripAxisEvents = false;
                     touchpadAxisEvents = false;
+                    touchpadTwoAxisEvents = false;
 
                     triggerSenseAxisEvents = false;
                     touchpadSenseAxisEvents = false;
@@ -227,6 +233,7 @@
                     triggerAxisEvents = true;
                     gripAxisEvents = true;
                     touchpadAxisEvents = true;
+                    touchpadTwoAxisEvents = true;
 
                     triggerSenseAxisEvents = false;
                     touchpadSenseAxisEvents = false;
@@ -245,6 +252,7 @@
                     triggerAxisEvents = false;
                     gripAxisEvents = false;
                     touchpadAxisEvents = false;
+                    touchpadTwoAxisEvents = false;
 
                     triggerSenseAxisEvents = true;
                     touchpadSenseAxisEvents = true;
@@ -258,7 +266,7 @@
         private void DebugLogger(uint index, string button, string action, ControllerInteractionEventArgs e)
         {
             string debugString = "Controller on index '" + index + "' " + button + " has been " + action
-                                 + " with a pressure of " + e.buttonPressure + " / trackpad axis at: " + e.touchpadAxis + " (" + e.touchpadAngle + " degrees)";
+                                 + " with a pressure of " + e.buttonPressure + " / Primary Touchpad axis at: " + e.touchpadAxis + " (" + e.touchpadAngle + " degrees)" + " / Secondary Touchpad axis at: " + e.touchpadTwoAxis + " (" + e.touchpadTwoAngle + " degrees)";
             VRTK_Logger.Info(debugString);
         }
 
@@ -451,6 +459,14 @@
             if (touchpadAxisEvents)
             {
                 DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPAD", "axis changed", e);
+            }
+        }
+
+        private void DoTouchpadTwoAxisChanged(object sender, ControllerInteractionEventArgs e)
+        {
+            if (touchpadTwoAxisEvents)
+            {
+                DebugLogger(VRTK_ControllerReference.GetRealIndex(e.controllerReference), "TOUCHPADTWO", "axis changed", e);
             }
         }
 

--- a/Assets/VRTK/Source/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/Source/SDK/Base/SDK_BaseController.cs
@@ -57,6 +57,10 @@ namespace VRTK
             /// </summary>
             Touchpad,
             /// <summary>
+            /// Touchpad Two on the controller.
+            /// </summary>
+            TouchpadTwo,
+            /// <summary>
             /// Middle Finger on the controller.
             /// </summary>
             MiddleFinger,
@@ -223,7 +227,15 @@ namespace VRTK
             /// <summary>
             /// The Oculus GearVR controller for Oculus Utilities.
             /// </summary>
-            Oculus_GearVRController
+            Oculus_GearVRController,
+            /// <summary>
+            /// The Windows Mixed Reality Motion Controller for Windows Mixed Reality.
+            /// </summary>
+            WindowsMR_MotionController,
+            /// <summary>
+            /// The Windows Mixed Reality Motion Controller for SteamVR.
+            /// </summary>
+            SteamVR_WindowsMRController
         }
 
         public event VRTKSDKBaseControllerEventHandler LeftControllerReady;

--- a/Assets/VRTK/Source/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Base/SDK_BaseHeadset.cs
@@ -62,7 +62,11 @@ namespace VRTK
             /// <summary>
             /// The HyperealVR headset.
             /// </summary>
-            HyperealVR
+            HyperealVR,
+            /// <summary>
+            /// The Windows Mixed Reality headset.
+            /// </summary>
+            WindowsMixedReality
         }
         protected Transform cachedHeadset;
         protected Transform cachedHeadsetCamera;
@@ -173,6 +177,8 @@ namespace VRTK
                     return CleanPropertyString("oculusriftdk1");
                 case "oculusriftdk2":
                     return CleanPropertyString("oculusriftdk2");
+                case "acermixedreality":
+                    return CleanPropertyString("windowsmixedreality");
             }
             return "";
         }

--- a/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Left.prefab
+++ b/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Left.prefab
@@ -1,0 +1,167 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1805105596151796}
+  m_IsPrefabParent: 1
+--- !u!1 &1163059137402462
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4634959441698716}
+  - component: {fileID: 65413977482132114}
+  m_Layer: 2
+  m_Name: Base
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1585718090538648
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4903707612555398}
+  - component: {fileID: 65649659134166324}
+  m_Layer: 2
+  m_Name: Control
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1802764293196244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4758714197176870}
+  - component: {fileID: 65524988675747006}
+  m_Layer: 2
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1805105596151796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4399346002321846}
+  m_Layer: 2
+  m_Name: SteamVRWindowsMRController_Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4399346002321846
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1805105596151796}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4758714197176870}
+  - {fileID: 4903707612555398}
+  - {fileID: 4634959441698716}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4634959441698716
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1163059137402462}
+  m_LocalRotation: {x: -0.043526012, y: 0.0028528469, z: 0.065340914, w: 0.99690926}
+  m_LocalPosition: {x: 0.002, y: -0.0022, z: -0.1233}
+  m_LocalScale: {x: 0.025, y: 0.025, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 4399346002321846}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -5, y: 0, z: 7.5}
+--- !u!4 &4758714197176870
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802764293196244}
+  m_LocalRotation: {x: 0.25660488, y: 0.12607859, z: -0.03378266, w: 0.9576622}
+  m_LocalPosition: {x: 0.0137, y: -0.034, z: -0.0311}
+  m_LocalScale: {x: 0.11, y: 0.11, z: 0.025}
+  m_Children: []
+  m_Father: {fileID: 4399346002321846}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 30, y: 15, z: 0}
+--- !u!4 &4903707612555398
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1585718090538648}
+  m_LocalRotation: {x: 0.25660488, y: 0.12607859, z: -0.03378266, w: 0.9576622}
+  m_LocalPosition: {x: 0.0148, y: -0.0042, z: -0.0599}
+  m_LocalScale: {x: 0.06, y: 0.025, z: 0.05}
+  m_Children: []
+  m_Father: {fileID: 4399346002321846}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 30, y: 15, z: 0}
+--- !u!65 &65413977482132114
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1163059137402462}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65524988675747006
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802764293196244}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65649659134166324
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1585718090538648}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Left.prefab.meta
+++ b/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Left.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b4435fc1f9184eb4aab479f919638e37
+timeCreated: 1510910764
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Right.prefab
+++ b/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Right.prefab
@@ -1,0 +1,167 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1243566030420360}
+  m_IsPrefabParent: 1
+--- !u!1 &1241241857267984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4615955307722442}
+  - component: {fileID: 65704996705224844}
+  m_Layer: 2
+  m_Name: Control
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1243566030420360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4548229111229410}
+  m_Layer: 2
+  m_Name: SteamVRWindowsMRController_Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1513773763499222
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4921868843142342}
+  - component: {fileID: 65151074624365328}
+  m_Layer: 2
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1578900873207386
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4147588243666780}
+  - component: {fileID: 65168390248647472}
+  m_Layer: 2
+  m_Name: Base
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4147588243666780
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1578900873207386}
+  m_LocalRotation: {x: -0.043526012, y: -0.0028528424, z: -0.06534082, w: 0.99690926}
+  m_LocalPosition: {x: -0.002, y: -0.0022, z: -0.1233}
+  m_LocalScale: {x: 0.025, y: 0.025, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 4548229111229410}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -5, y: 0, z: -7.5}
+--- !u!4 &4548229111229410
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1243566030420360}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4921868843142342}
+  - {fileID: 4615955307722442}
+  - {fileID: 4147588243666780}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4615955307722442
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1241241857267984}
+  m_LocalRotation: {x: 0.25660488, y: -0.12607868, z: 0.033782687, w: 0.9576622}
+  m_LocalPosition: {x: -0.0148, y: -0.0042, z: -0.0599}
+  m_LocalScale: {x: 0.06, y: 0.025, z: 0.05}
+  m_Children: []
+  m_Father: {fileID: 4548229111229410}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 30, y: -15, z: 0}
+--- !u!4 &4921868843142342
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1513773763499222}
+  m_LocalRotation: {x: 0.25660488, y: -0.12607868, z: 0.033782687, w: 0.9576622}
+  m_LocalPosition: {x: -0.0137, y: -0.034, z: -0.0311}
+  m_LocalScale: {x: 0.11, y: 0.11, z: 0.025}
+  m_Children: []
+  m_Father: {fileID: 4548229111229410}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 30, y: -15, z: 0}
+--- !u!65 &65151074624365328
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1513773763499222}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65168390248647472
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1578900873207386}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65704996705224844
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1241241857267984}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Right.prefab.meta
+++ b/Assets/VRTK/Source/SDK/SteamVR/Resources/ControllerColliders/SteamVRWindowsMRController_Right.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: e6cfb3c52310b174f9d2f2e34127d1ce
+timeCreated: 1510910358
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
@@ -116,12 +116,14 @@ namespace VRTK
         {
             switch (GetCurrentControllerType())
             {
+                case ControllerType.SteamVR_ViveWand:
+                    return "ControllerColliders/HTCVive";
                 case ControllerType.SteamVR_OculusTouch:
                     return (hand == ControllerHand.Left ? "ControllerColliders/SteamVROculusTouch_Left" : "ControllerColliders/SteamVROculusTouch_Right");
                 case ControllerType.SteamVR_ValveKnuckles:
                     return (hand == ControllerHand.Left ? "ControllerColliders/ValveKnuckles_Left" : "ControllerColliders/ValveKnuckles_Right");
-                case ControllerType.SteamVR_ViveWand:
-                    return "ControllerColliders/HTCVive";
+                case ControllerType.SteamVR_WindowsMRController:
+                    return (hand == ControllerHand.Left ? "ControllerColliders/SteamVRWindowsMRController_Left" : "ControllerColliders/SteamVRWindowsMRController_Right");
                 default:
                     return "ControllerColliders/Fallback";
             }
@@ -489,6 +491,13 @@ namespace VRTK
             {
                 case ButtonTypes.Touchpad:
                     return device.GetAxis();
+                case ButtonTypes.TouchpadTwo:
+                    switch (VRTK_DeviceFinder.GetHeadsetType())
+                    {
+                        case SDK_BaseHeadset.HeadsetType.WindowsMixedReality:
+                            return device.GetAxis(EVRButtonId.k_EButton_Axis2);
+                    }
+                    return Vector2.zero;
                 case ButtonTypes.Trigger:
                     return device.GetAxis(EVRButtonId.k_EButton_SteamVR_Trigger);
                 case ButtonTypes.Grip:
@@ -734,6 +743,8 @@ namespace VRTK
                     return "button_b" + suffix;
                 case ControllerType.SteamVR_OculusTouch:
                     return "grip" + suffix;
+                case ControllerType.SteamVR_WindowsMRController:
+                    return "handgrip" + suffix;
             }
             return null;
         }
@@ -744,6 +755,7 @@ namespace VRTK
             {
                 case ControllerType.SteamVR_ViveWand:
                 case ControllerType.SteamVR_ValveKnuckles:
+                case ControllerType.SteamVR_WindowsMRController:
                     return "trackpad" + suffix;
                 case ControllerType.SteamVR_OculusTouch:
                     return "thumbstick" + suffix;
@@ -767,6 +779,7 @@ namespace VRTK
             {
                 case ControllerType.SteamVR_ViveWand:
                 case ControllerType.SteamVR_ValveKnuckles:
+                case ControllerType.SteamVR_WindowsMRController:
                     return "button" + suffix;
                 case ControllerType.SteamVR_OculusTouch:
                     return (hand == ControllerHand.Left ? "y_button" : "b_button") + suffix;
@@ -810,6 +823,8 @@ namespace VRTK
                 case "oculus rift cv1 (right controller)":
                 case "oculus rift cv1 (left controller)":
                     return ControllerType.SteamVR_OculusTouch;
+                case "windowsmr: 0x045e/0x065b/0/2":
+                    return ControllerType.SteamVR_WindowsMRController;
             }
             return FuzzyMatchControllerTypeByString(controllerModelNumber);
         }
@@ -828,6 +843,10 @@ namespace VRTK
             else if (controllerModelNumber.Contains("oculus rift"))
             {
                 return ControllerType.SteamVR_OculusTouch;
+            }
+            else if (controllerModelNumber.Contains("windowsmr"))
+            {
+                return ControllerType.SteamVR_WindowsMRController;
             }
 
             return ControllerType.Undefined;

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -97,6 +97,8 @@ namespace VRTK
                         break;
                     case "oculus":
                         return "oculusrift";
+                    case "windowsmr":
+                        return "windowsmixedreality";
                 }
 
                 //If no model check required then just return manufacturer

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -503,6 +503,8 @@ namespace VRTK
                     return SDK_BaseHeadset.HeadsetType.OculusRiftDK1;
                 case "oculusriftdk2":
                     return SDK_BaseHeadset.HeadsetType.OculusRiftDK2;
+                case "windowsmixedreality":
+                    return SDK_BaseHeadset.HeadsetType.WindowsMixedReality;
             }
             return SDK_BaseHeadset.HeadsetType.Undefined;
         }


### PR DESCRIPTION
The SteamVR SDK also supports Windows Mixed Reality devices but again
has some slight differences such as controller collider shapes and
controller orientations.

The Windows Mixed Reality controller also has an additional thumbstick
as well as a touchpad. The thumbstick is now referred to as
`TouchpadTwo` but only has axis change events as the button press is
reserved as a system event in SteamVR and there is no touch sensing
available.