### PR TITLE
fix(SnapDropZone): ensure valid object check is done at correct point

### DIFF
--- a/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
@@ -401,10 +401,10 @@ namespace VRTK
 
         protected virtual void CheckCanSnap(VRTK_InteractableObject interactableObjectCheck)
         {
-            if (interactableObjectCheck != null)
+            if (interactableObjectCheck != null && ValidSnapObject(interactableObjectCheck, true))
             {
                 AddCurrentValidSnapObject(interactableObjectCheck);
-                if (!isSnapped && ValidSnapObject(interactableObjectCheck, true))
+                if (!isSnapped)
                 {
                     ToggleHighlight(interactableObjectCheck, true);
                     interactableObjectCheck.SetSnapDropZoneHover(this, true);


### PR DESCRIPTION
The valid object check was being done after a touched object was added
to the valid snap object list, meaning that any object that was not
valid but touching the object would cause the highlighter to display
even if the object was not valid.