### PR TITLE
feat(SDK): utilise underlying sdk to retrieve headset type

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -8445,6 +8445,14 @@ The Device Finder offers a collection of static methods that can be called to fi
    * `Headset` - The headset.
    * `LeftController` - The left hand controller.
    * `RightController` - The right hand controller.
+ * `public enum Headsets` - Possible headsets
+   * `Unknown` - An unknown headset.
+   * `OculusRift` - A summary of all Oculus Rift headset versions.
+   * `OculusRiftCV1` - A specific version of the Oculus Rift headset, the Consumer Version 1.
+   * `Vive` - A summary of all HTC Vive headset versions.
+   * `ViveMV` - A specific version of the HTC Vive headset, the first consumer version.
+   * `ViveDVT` - A specific version of the HTC Vive headset, the first consumer version.
+   * `OculusRiftES07` - A specific version of the Oculus Rift headset, the rare ES07.
 
 ### Class Methods
 
@@ -8736,27 +8744,27 @@ The HeadsetTransform method is used to retrieve the transform for the VR Headset
 
 The HeadsetCamera method is used to retrieve the transform for the VR Camera in the scene.
 
-#### ResetHeadsetTypeCache/0
+#### GetHeadsetTypeAsString/0
 
-  > `public static void ResetHeadsetTypeCache()`
+  > `public static string GetHeadsetTypeAsString()`
 
  * Parameters
    * _none_
  * Returns
-   * _none_
+   * `string` - The string of the headset connected.
 
-The ResetHeadsetTypeCache resets the cache holding the current headset type value.
+The GetHeadsetTypeAsString method returns a string representing the type of headset connected.
 
-#### GetHeadsetType/1
+#### GetHeadsetType/0
 
-  > `public static SDK_BaseHeadset.Headsets GetHeadsetType(bool summary = false)`
+  > `public static SDK_BaseHeadset.HeadsetType GetHeadsetType()`
 
  * Parameters
-   * `bool summary` - If this is `true`, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).
+   * _none_
  * Returns
-   * `SDK_BaseHeadset.Headsets` - The Headset type that is connected.
+   * `SDK_BaseHeadset.HeadsetType` - The Headset type that is connected.
 
-The GetHeadsetType method returns the type of headset connected to the computer.
+The GetHeadsetType method returns the type of headset currently connected.
 
 #### PlayAreaTransform/0
 
@@ -9908,23 +9916,17 @@ This is an abstract class to implement the interface required by all implemented
 
 ### Class Variables
 
- * `public enum Headsets` - SDK Headset types.
-   * `Unknown` - An unknown headset.
-   * `OculusRift` - A summary of all Oculus Rift headset versions.
-   * `OculusRiftCV1` - A specific version of the Oculus Rift headset, the Consumer Version 1.
-   * `Vive` - A summary of all HTC Vive headset versions.
-   * `ViveMV` - A specific version of the HTC Vive headset, the first consumer version.
-   * `ViveDVT` - A specific version of the HTC Vive headset, the first consumer version.
-   * `OculusRiftES07` - A specific version of the Oculus Rift headset, the rare ES07.
-   * `GearVR` - A summary of all GearVR headset versions.
-   * `GearVRGalaxyNote5` - A specific version of the GearVR headset running on a Samsung Galaxy Note 5.
-   * `GearVRGalaxyS6` - A specific version of the GearVR headset running on a Samsung Galaxy S6.
-   * `GearVRGalaxyS6Edge` - A specific version of the GearVR headset running on a Samsung Galaxy S6 Edge.
-   * `GearVRGalaxyS7` - A specific version of the GearVR headset running on a Samsung Galaxy S7.
-   * `GearVRGalaxyS7Edge` - A specific version of the GearVR headset running on a Samsung Galaxy S7 Edge.
-   * `GearVRGalaxyS8` - A specific version of the GearVR headset running on a Samsung Galaxy S8.
-   * `GoogleCardboard` - A summary of all Google Cardboard headset versions.
-   * `Daydream` - A summary of all Google Daydream headset versions.
+ * `public enum HeadsetType` - The connected headset type
+   * `Undefined` - The headset connected is unknown.
+   * `Simulator` - The headset associated with the simulator.
+   * `HTCVive` - The HTC Vive headset.
+   * `OculusRiftDK1` - The Oculus Rift DK1 headset.
+   * `OculusRiftDK2` - The Oculus Rift DK2 headset.
+   * `OculusRift` - The Oculus Rift headset.
+   * `OculusGearVR` - The Oculus GearVR headset.
+   * `GoogleDaydream` - The Google Daydream headset.
+   * `GoogleCardboard` - The Google Cardboard headset.
+   * `HyperealVR` - The HyperealVR headset.
 
 ### Class Methods
 
@@ -9971,6 +9973,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
    * `Transform` - A transform of the object holding the headset camera in the scene.
 
 The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
+
+#### GetHeadsetType/0
+
+  > `public abstract string GetHeadsetType();`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
 
 #### GetHeadsetVelocity/0
 
@@ -10644,6 +10657,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
 
 The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
 
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
+
 #### GetHeadsetVelocity/0
 
   > `public override Vector3 GetHeadsetVelocity()`
@@ -11251,6 +11275,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
    * `Transform` - A transform of the object holding the headset camera in the scene.
 
 The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
+
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
 
 #### GetHeadsetVelocity/0
 
@@ -11883,6 +11918,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
 
 The GetHeadsetCamera/0 method returns the Transform of the object that is used to hold the headset camera in the scene.
 
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
+
 #### GetHeadsetVelocity/0
 
   > `public override Vector3 GetHeadsetVelocity()`
@@ -12495,6 +12541,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
    * `Transform` - A transform of the object holding the headset camera in the scene.
 
 The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
+
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
 
 #### GetHeadsetVelocity/0
 
@@ -13118,6 +13175,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
    * `Transform` - A transform of the object holding the headset camera in the scene.
 
 The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
+
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
 
 #### GetHeadsetVelocity/0
 
@@ -13752,6 +13820,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
 
 The GetHeadsetCamera/0 method returns the Transform of the object that is used to hold the headset camera in the scene.
 
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
+
 #### GetHeadsetVelocity/0
 
   > `public override Vector3 GetHeadsetVelocity()`
@@ -14340,6 +14419,17 @@ The ProcessUpdate method enables an SDK to run logic for every Unity Update
    * _none_
 
 The ProcessFixedUpdate method enables an SDK to run logic for every Unity FixedUpdate
+
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
 
 #### GetHeadsetVelocity/0
 
@@ -14973,6 +15063,17 @@ The GetHeadset method returns the Transform of the object that is used to repres
    * `Transform` - A transform of the object holding the headset camera in the scene.
 
 The GetHeadsetCamera method returns the Transform of the object that is used to hold the headset camera in the scene.
+
+#### GetHeadsetType/0
+
+  > `public override string GetHeadsetType()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `string` - The string of the headset connected.
+
+The GetHeadsetType method returns a string representing the type of headset connected.
 
 #### GetHeadsetVelocity/0
 

--- a/Assets/VRTK/Source/SDK/Base/SDK_BaseHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Base/SDK_BaseHeadset.cs
@@ -3,6 +3,12 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Collections.Generic;
+#if UNITY_2017_2_OR_NEWER
+    using UnityEngine.XR;
+#else
+    using XRDevice = UnityEngine.VR.VRDevice;
+    using XRSettings = UnityEngine.VR.VRSettings;
+#endif
 
     /// <summary>
     /// The Base Headset SDK script provides a bridge to SDK methods that deal with the VR Headset.
@@ -12,78 +18,52 @@ namespace VRTK
     /// </remarks>
     public abstract class SDK_BaseHeadset : SDK_Base
     {
-
         /// <summary>
-        /// SDK Headset types.
+        /// The connected headset type
         /// </summary>
-        public enum Headsets
+        public enum HeadsetType
         {
             /// <summary>
-            /// An unknown headset.
+            /// The headset connected is unknown.
             /// </summary>
-            Unknown,
+            Undefined,
             /// <summary>
-            /// A summary of all Oculus Rift headset versions.
+            /// The headset associated with the simulator.
+            /// </summary>
+            Simulator,
+            /// <summary>
+            /// The HTC Vive headset.
+            /// </summary>
+            HTCVive,
+            /// <summary>
+            /// The Oculus Rift DK1 headset.
+            /// </summary>
+            OculusRiftDK1,
+            /// <summary>
+            /// The Oculus Rift DK2 headset.
+            /// </summary>
+            OculusRiftDK2,
+            /// <summary>
+            /// The Oculus Rift headset.
             /// </summary>
             OculusRift,
             /// <summary>
-            /// A specific version of the Oculus Rift headset, the Consumer Version 1.
+            /// The Oculus GearVR headset.
             /// </summary>
-            OculusRiftCV1,
+            OculusGearVR,
             /// <summary>
-            /// A summary of all HTC Vive headset versions.
+            /// The Google Daydream headset.
             /// </summary>
-            Vive,
+            GoogleDaydream,
             /// <summary>
-            /// A specific version of the HTC Vive headset, the first consumer version.
-            /// </summary>
-            ViveMV,
-            /// <summary>
-            /// A specific version of the HTC Vive headset, the first consumer version.
-            /// </summary>
-            ViveDVT,
-            /// <summary>
-            /// A specific version of the Oculus Rift headset, the rare ES07.
-            /// </summary>
-            OculusRiftES07,
-            /// <summary>
-            /// A summary of all GearVR headset versions.
-            /// </summary>
-            GearVR,
-            /// <summary>
-            /// A specific version of the GearVR headset running on a Samsung Galaxy Note 5.
-            /// </summary>
-            GearVRGalaxyNote5,
-            /// <summary>
-            /// A specific version of the GearVR headset running on a Samsung Galaxy S6.
-            /// </summary>
-            GearVRGalaxyS6,
-            /// <summary>
-            /// A specific version of the GearVR headset running on a Samsung Galaxy S6 Edge.
-            /// </summary>
-            GearVRGalaxyS6Edge,
-            /// <summary>
-            /// A specific version of the GearVR headset running on a Samsung Galaxy S7.
-            /// </summary>
-            GearVRGalaxyS7,
-            /// <summary>
-            /// A specific version of the GearVR headset running on a Samsung Galaxy S7 Edge.
-            /// </summary>
-            GearVRGalaxyS7Edge,
-            /// <summary>
-            /// A specific version of the GearVR headset running on a Samsung Galaxy S8.
-            /// </summary>
-            GearVRGalaxyS8,
-            /// <summary>
-            /// A summary of all Google Cardboard headset versions.
+            /// The Google Cardboard headset.
             /// </summary>
             GoogleCardboard,
             /// <summary>
-            /// A summary of all Google Daydream headset versions.
+            /// The HyperealVR headset.
             /// </summary>
-            Daydream
+            HyperealVR
         }
-
         protected Transform cachedHeadset;
         protected Transform cachedHeadsetCamera;
 
@@ -110,6 +90,12 @@ namespace VRTK
         /// </summary>
         /// <returns>A transform of the object holding the headset camera in the scene.</returns>
         public abstract Transform GetHeadsetCamera();
+
+        /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public abstract string GetHeadsetType();
 
         /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
@@ -153,6 +139,47 @@ namespace VRTK
                 return cachedHeadset;
             }
             return null;
+        }
+
+        protected virtual string ScrapeHeadsetType()
+        {
+            string model = CleanPropertyString(XRDevice.model);
+            string deviceName = CleanPropertyString(XRSettings.loadedDeviceName);
+            switch (model)
+            {
+                case "oculusriftcv1":
+                case "oculusriftes07":
+                    return CleanPropertyString("oculusrift");
+                case "vivemv":
+                case "vivedvt":
+                    return CleanPropertyString("htcvive");
+                case "googleinc-daydreamview":
+                    return "googledaydream";
+                case "googleinc-defaultcardboard":
+                    return "googlecardboard";
+                case "galaxynote5":
+                case "galaxys6":
+                case "galaxys6edge":
+                case "galaxys7":
+                case "galaxys7edge":
+                case "galaxys8":
+                case "galaxys8+":
+                    if (deviceName == "oculus")
+                    {
+                        return "oculusgearvr";
+                    }
+                    break;
+                case "oculusriftdk1":
+                    return CleanPropertyString("oculusriftdk1");
+                case "oculusriftdk2":
+                    return CleanPropertyString("oculusriftdk2");
+            }
+            return "";
+        }
+
+        protected string CleanPropertyString(string inputString)
+        {
+            return inputString.Replace(" ", "").Replace(".", "").Replace(",", "").ToLowerInvariant();
         }
     }
 }

--- a/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamHeadset.cs
@@ -68,6 +68,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            return CleanPropertyString("googledaydream");
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/SDK/Fallback/SDK_FallbackHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Fallback/SDK_FallbackHeadset.cs
@@ -48,6 +48,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            return CleanPropertyString("");
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRHeadset.cs
+++ b/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRHeadset.cs
@@ -62,6 +62,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            return CleanPropertyString("hyperealvr");
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusHeadset.cs
@@ -66,6 +66,29 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            switch (OVRPlugin.GetSystemHeadsetType())
+            {
+                case OVRPlugin.SystemHeadset.Rift_CV1:
+                    return CleanPropertyString("oculusrift");
+                case OVRPlugin.SystemHeadset.GearVR_R320:
+                case OVRPlugin.SystemHeadset.GearVR_R321:
+                case OVRPlugin.SystemHeadset.GearVR_R322:
+                case OVRPlugin.SystemHeadset.GearVR_R323:
+                    return CleanPropertyString("oculusgearvr");
+                case OVRPlugin.SystemHeadset.Rift_DK1:
+                    return CleanPropertyString("oculusriftdk1");
+                case OVRPlugin.SystemHeadset.Rift_DK2:
+                    return CleanPropertyString("oculusriftdk2");
+            }
+            return CleanPropertyString("");
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/SDK/Simulator/SDK_SimHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_SimHeadset.cs
@@ -59,6 +59,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            return CleanPropertyString("simulator");
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -4,6 +4,7 @@ namespace VRTK
 #if VRTK_DEFINE_SDK_STEAMVR
     using UnityEngine;
     using System.Collections.Generic;
+    using Valve.VR;
 #endif
 
     /// <summary>
@@ -72,6 +73,36 @@ namespace VRTK
                 }
             }
             return cachedHeadsetCamera;
+        }
+
+        /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            if (SteamVR.instance != null)
+            {
+                string manufactuer = CleanPropertyString(SteamVR.instance.GetStringProperty(ETrackedDeviceProperty.Prop_ManufacturerName_String));
+                string model = CleanPropertyString(SteamVR.instance.GetStringProperty(ETrackedDeviceProperty.Prop_ModelNumber_String));
+
+                //Check for specific manufacturer models
+                switch (manufactuer)
+                {
+                    case "htc":
+                        if (model.Contains("vive"))
+                        {
+                            return "htcvive";
+                        }
+                        break;
+                    case "oculus":
+                        return "oculusrift";
+                }
+
+                //If no model check required then just return manufacturer
+                return CleanPropertyString(manufactuer);
+            }
+            return CleanPropertyString("");
         }
 
         /// <summary>

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -149,6 +149,7 @@ namespace VRTK
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
         public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
+            SetTrackedControllerCaches();
             return cachedControllerType;
         }
 
@@ -724,6 +725,19 @@ namespace VRTK
                 }
             }
 
+            //If the joystick isn't found then try and match on headset type
+            if (!joystickFound)
+            {
+                switch (VRTK_DeviceFinder.GetHeadsetType())
+                {
+                    case SDK_BaseHeadset.HeadsetType.GoogleDaydream:
+                        SetCachedControllerType("googledaydream");
+                        joystickFound = true;
+                        validJoystickIndex = 1;
+                        break;
+                }
+            }
+
             if (joystickFound)
             {
                 if (hand == ControllerHand.Right)
@@ -744,14 +758,23 @@ namespace VRTK
         protected virtual void SetCachedControllerType(string givenType)
         {
             givenType = givenType.ToLower();
+            //try direct matching
+            switch (givenType)
+            {
+                case "googledaydream":
+                    cachedControllerType = ControllerType.Daydream_Controller;
+                    return;
+            }
+
+            //fallback to fuzzy matching
             if (givenType.Contains("openvr controller"))
             {
-                switch (VRTK_DeviceFinder.GetHeadsetType(true))
+                switch (VRTK_DeviceFinder.GetHeadsetType())
                 {
-                    case SDK_BaseHeadset.Headsets.Vive:
+                    case SDK_BaseHeadset.HeadsetType.HTCVive:
                         cachedControllerType = ControllerType.SteamVR_ViveWand;
                         break;
-                    case SDK_BaseHeadset.Headsets.OculusRift:
+                    case SDK_BaseHeadset.HeadsetType.OculusRift:
                         cachedControllerType = ControllerType.SteamVR_OculusTouch;
                         break;
                 }

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityHeadset.cs
@@ -61,6 +61,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            return ScrapeHeadsetType();
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/SDK/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/Source/SDK/VRTK_SDK_Bridge.cs
@@ -204,6 +204,11 @@
             return GetHeadsetSDK().GetHeadsetCamera();
         }
 
+        public static string GetHeadsetType()
+        {
+            return GetHeadsetSDK().GetHeadsetType();
+        }
+
         public static Vector3 GetHeadsetVelocity()
         {
             return GetHeadsetSDK().GetHeadsetVelocity();

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseHeadset.cs
@@ -50,6 +50,15 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The GetHeadsetType method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public override string GetHeadsetType()
+        {
+            return ScrapeHeadsetType();
+        }
+
+        /// <summary>
         /// The GetHeadsetVelocity method is used to determine the current velocity of the headset.
         /// </summary>
         /// <returns>A Vector3 containing the current velocity of the headset.</returns>

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_DeviceFinder.cs
@@ -6,7 +6,6 @@ namespace VRTK
     using UnityEngine.XR;
 #else
     using XRDevice = UnityEngine.VR.VRDevice;
-    using XRSettings = UnityEngine.VR.VRSettings;
 #endif
 
     /// <summary>
@@ -33,8 +32,46 @@ namespace VRTK
             RightController,
         }
 
+        /// <summary>
+        /// Possible headsets
+        /// </summary>
+        [System.Obsolete("`VRTK_DeviceFinder.Headsets` has been deprecated and has been replaced with a manufacturer string. This enum will be removed in a future version of VRTK.")]
+        public enum Headsets
+        {
+            /// <summary>
+            /// An unknown headset.
+            /// </summary>
+            Unknown,
+            /// <summary>
+            /// A summary of all Oculus Rift headset versions.
+            /// </summary>
+            OculusRift,
+            /// <summary>
+            /// A specific version of the Oculus Rift headset, the Consumer Version 1.
+            /// </summary>
+            OculusRiftCV1,
+            /// <summary>
+            /// A summary of all HTC Vive headset versions.
+            /// </summary>
+            Vive,
+            /// <summary>
+            /// A specific version of the HTC Vive headset, the first consumer version.
+            /// </summary>
+            ViveMV,
+            /// <summary>
+            /// A specific version of the HTC Vive headset, the first consumer version.
+            /// </summary>
+            ViveDVT,
+            /// <summary>
+            /// A specific version of the Oculus Rift headset, the rare ES07.
+            /// </summary>
+            OculusRiftES07
+        }
+
+        /// <summary>
+        /// Obsolete
+        /// </summary>
         private static string cachedHeadsetType = "";
-        private static string cachedLoadedDeviceName = "";
 
         /// <summary>
         /// The GetCurrentControllerType method returns the current used ControllerType based on the SDK and headset being used.
@@ -375,10 +412,10 @@ namespace VRTK
         /// <summary>
         /// The ResetHeadsetTypeCache resets the cache holding the current headset type value.
         /// </summary>
+        [System.Obsolete("`VRTK_DeviceFinder.ResetHeadsetTypeCache()` has been deprecated. This method will be removed in a future version of VRTK.")]
         public static void ResetHeadsetTypeCache()
         {
             cachedHeadsetType = "";
-            cachedLoadedDeviceName = "";
         }
 
         /// <summary>
@@ -386,71 +423,28 @@ namespace VRTK
         /// </summary>
         /// <param name="summary">If this is `true`, then the generic name for the headset is returned not including the version type (e.g. OculusRift will be returned for DK2 and CV1).</param>
         /// <returns>The Headset type that is connected.</returns>
-        public static SDK_BaseHeadset.Headsets GetHeadsetType(bool summary = false)
+        [System.Obsolete("`VRTK_DeviceFinder.GetHeadsetType(summary) -> VRTK_DeviceFinder.Headsets` has been replaced with `VRTK_DeviceFinder.GetHeadsetType() -> SDK_BaseHeadset.HeadsetType`. This method will be removed in a future version of VRTK.")]
+        public static Headsets GetHeadsetType(bool summary = false)
         {
-            SDK_BaseHeadset.Headsets returnValue = SDK_BaseHeadset.Headsets.Unknown;
-            cachedHeadsetType = (cachedHeadsetType == "" ? CleanModelString(XRDevice.model) : cachedHeadsetType);
-            cachedLoadedDeviceName = (cachedLoadedDeviceName == "" ? CleanModelString(XRSettings.loadedDeviceName) : cachedLoadedDeviceName);
+            Headsets returnValue = Headsets.Unknown;
+            cachedHeadsetType = (cachedHeadsetType == "" ? XRDevice.model.Replace(" ", "").Replace(".", "").ToLowerInvariant() : cachedHeadsetType);
             switch (cachedHeadsetType)
             {
                 case "oculusriftcv1":
-                    returnValue = (summary ? SDK_BaseHeadset.Headsets.OculusRift : SDK_BaseHeadset.Headsets.OculusRiftCV1);
+                    returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftCV1);
                     break;
                 case "oculusriftes07":
-                    returnValue = (summary ? SDK_BaseHeadset.Headsets.OculusRift : SDK_BaseHeadset.Headsets.OculusRiftES07);
+                    returnValue = (summary ? Headsets.OculusRift : Headsets.OculusRiftES07);
                     break;
                 case "vivemv":
-                    returnValue = (summary ? SDK_BaseHeadset.Headsets.Vive : SDK_BaseHeadset.Headsets.ViveMV);
+                    returnValue = (summary ? Headsets.Vive : Headsets.ViveMV);
                     break;
                 case "vivedvt":
-                    returnValue = (summary ? SDK_BaseHeadset.Headsets.Vive : SDK_BaseHeadset.Headsets.ViveDVT);
-                    break;
-                case "galaxynote5":
-                    if (cachedLoadedDeviceName == "oculus")
-                    {
-                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyNote5);
-                    }
-                    break;
-                case "galaxys6":
-                    if (cachedLoadedDeviceName == "oculus")
-                    {
-                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS6);
-                    }
-                    break;
-                case "galaxys6edge":
-                    if (cachedLoadedDeviceName == "oculus")
-                    {
-                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS6Edge);
-                    }
-                    break;
-                case "galaxys7":
-                    if (cachedLoadedDeviceName == "oculus")
-                    {
-                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS7);
-                    }
-                    break;
-                case "galaxys7Edge":
-                    if (cachedLoadedDeviceName == "oculus")
-                    {
-                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS7Edge);
-                    }
-                    break;
-                case "galaxys8":
-                case "galaxys8+":
-                    if (cachedLoadedDeviceName == "oculus")
-                    {
-                        returnValue = (summary ? SDK_BaseHeadset.Headsets.GearVR : SDK_BaseHeadset.Headsets.GearVRGalaxyS8);
-                    }
-                    break;
-                case "googleinc-daydreamview":
-                    returnValue = SDK_BaseHeadset.Headsets.Daydream;
-                    break;
-                case "googleinc-defaultcardboard":
-                    returnValue = SDK_BaseHeadset.Headsets.GoogleCardboard;
+                    returnValue = (summary ? Headsets.Vive : Headsets.ViveDVT);
                     break;
             }
 
-            if (returnValue == SDK_BaseHeadset.Headsets.Unknown)
+            if (returnValue == Headsets.Unknown)
             {
                 VRTK_Logger.Warn(
                     string.Format("Your headset is of type '{0}' which VRTK doesn't know about yet. Please report this headset type to the maintainers of VRTK."
@@ -462,16 +456,55 @@ namespace VRTK
                 {
                     if (cachedHeadsetType.Contains("rift"))
                     {
-                        return SDK_BaseHeadset.Headsets.OculusRift;
+                        return Headsets.OculusRift;
                     }
                     if (cachedHeadsetType.Contains("vive"))
                     {
-                        return SDK_BaseHeadset.Headsets.Vive;
+                        return Headsets.Vive;
                     }
                 }
             }
 
             return returnValue;
+        }
+
+        /// <summary>
+        /// The GetHeadsetTypeAsString method returns a string representing the type of headset connected.
+        /// </summary>
+        /// <returns>The string of the headset connected.</returns>
+        public static string GetHeadsetTypeAsString()
+        {
+            return VRTK_SDK_Bridge.GetHeadsetType();
+        }
+
+        /// <summary>
+        /// The GetHeadsetType method returns the type of headset currently connected.
+        /// </summary>
+        /// <returns>The Headset type that is connected.</returns>
+        public static SDK_BaseHeadset.HeadsetType GetHeadsetType()
+        {
+            switch (GetHeadsetTypeAsString())
+            {
+                case "simulator":
+                    return SDK_BaseHeadset.HeadsetType.Simulator;
+                case "htcvive":
+                    return SDK_BaseHeadset.HeadsetType.HTCVive;
+                case "oculusrift":
+                    return SDK_BaseHeadset.HeadsetType.OculusRift;
+                case "oculusgearvr":
+                    return SDK_BaseHeadset.HeadsetType.OculusGearVR;
+                case "googledaydream":
+                    return SDK_BaseHeadset.HeadsetType.GoogleDaydream;
+                case "googlecardboard":
+                    return SDK_BaseHeadset.HeadsetType.GoogleCardboard;
+                case "hyperealvr":
+                    return SDK_BaseHeadset.HeadsetType.HyperealVR;
+                case "oculusriftdk1":
+                    return SDK_BaseHeadset.HeadsetType.OculusRiftDK1;
+                case "oculusriftdk2":
+                    return SDK_BaseHeadset.HeadsetType.OculusRiftDK2;
+            }
+            return SDK_BaseHeadset.HeadsetType.Undefined;
         }
 
         /// <summary>
@@ -481,11 +514,6 @@ namespace VRTK
         public static Transform PlayAreaTransform()
         {
             return VRTK_SDK_Bridge.GetPlayArea();
-        }
-
-        private static string CleanModelString(string inputString)
-        {
-            return inputString.Replace(" ", "").Replace(".", "").Replace(",", "").ToLowerInvariant();
         }
     }
 }

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
@@ -26,7 +26,7 @@ namespace VRTK
         [Tooltip("If the currently loaded SDK Setup matches the one provided here then the `Target` state will be set to the desired `Object State`.")]
         public VRTK_SDKSetup loadedSDKSetup = null;
         [Tooltip("If the attached headset type matches the selected headset then the `Target` state will be set to the desired `Object State`.")]
-        public SDK_BaseHeadset.Headsets headsetType = SDK_BaseHeadset.Headsets.Unknown;
+        public SDK_BaseHeadset.HeadsetType headsetType = SDK_BaseHeadset.HeadsetType.Undefined;
         [Tooltip("If the current controller type matches the selected controller type then the `Target` state will be set to the desired `Object State`.")]
         public SDK_BaseController.ControllerType controllerType = SDK_BaseController.ControllerType.Undefined;
 
@@ -91,7 +91,7 @@ namespace VRTK
 
         protected virtual void ToggleOnHeadset()
         {
-            if (headsetType != SDK_BaseHeadset.Headsets.Unknown && headsetType == VRTK_DeviceFinder.GetHeadsetType(true))
+            if (headsetType != SDK_BaseHeadset.HeadsetType.Undefined && headsetType == VRTK_DeviceFinder.GetHeadsetType())
             {
                 ToggleObject();
             }


### PR DESCRIPTION
Previously, the `VRTK_DeviceFinder.GetHeadsetType()` would rely on the
built in Unity methods for determining the headset type, however this
was unsustainable as it didn't report generic enough information and
would mean the list of headset types would grow and grow and ultimately
not provide useful information.

This has now been changed by each SDK now has a `GetHeadsetType` method
that reports a simpler to understand headset type string, so in the
case of the vive, it does not report all of the variants, just reports
"htcvive" and similarly with the rift.

This string is then used to return a new, cleaner enum from the
`VRTK_DeviceFinder.GetHeadsetType()` method and the enum is stored
in the SDK_BaseHeadset class as it's more appropriate.

The usage of `GetHeadsetType` to determine which controller is
connected in the SDK_SteamVRController class has been removed and
now the render model of the connected controller is used to determine
the controller type as this will always be accurate from what OpenVR
is reporting.

When using the Unity SDK, the headset is still retrieved in the old
way as Unity doesn't provide enough decent information about the
connected headset to know which device is actually connected. It
does this by scraping the model and device name.