### PR TITLE
fix(Interaction): ensure interactable helpers get reference to object

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -4142,6 +4142,7 @@ The ClearPreviousClone method resets the previous cloned Interactable Object to 
 A collection of scripts that provide the ability denote objects as being interactable and providing functionality when an object is interected with.
 
  * [Interactable Object](#interactable-object-vrtk_interactableobject)
+ * [Interactable Listener](#interactable-listener-vrtk_interactablelistener)
  * [Interact Haptics](#interact-haptics-vrtk_interacthaptics)
  * [Interact Object Appearance](#interact-object-appearance-vrtk_interactobjectappearance)
  * [Interact Object Highlighter](#interact-object-highlighter-vrtk_interactobjecthighlighter)
@@ -4746,7 +4747,19 @@ The GetSecondaryAttachPoint returns the Transform that determines where the seco
 
 ---
 
+## Interactable Listener (VRTK_InteractableListener)
+
+### Overview
+
+Provides a base that classes which require to subscribe to the interaction events of an Interactable Object can inherit from.
+
+**Script Usage:**
+  > This is an abstract class that is to be inherited to a concrete class that provides interaction event listener functionality, therefore this script should not be directly used.
+
+---
+
 ## Interact Haptics (VRTK_InteractHaptics)
+ > extends [VRTK_InteractableListener](#interactable-listener-vrtk_interactablelistener)
 
 ### Overview
 
@@ -4861,6 +4874,7 @@ The HapticsOnUse method triggers the haptic feedback on the given controller for
 ---
 
 ## Interact Object Appearance (VRTK_InteractObjectAppearance)
+ > extends [VRTK_InteractableListener](#interactable-listener-vrtk_interactablelistener)
 
 ### Overview
 
@@ -4936,6 +4950,7 @@ Adding the `VRTK_InteractObjectAppearance_UnityEvents` component to `VRTK_Intera
 ---
 
 ## Interact Object Highlighter (VRTK_InteractObjectHighlighter)
+ > extends [VRTK_InteractableListener](#interactable-listener-vrtk_interactablelistener)
 
 ### Overview
 
@@ -4989,6 +5004,7 @@ The GetCurrentHighlightColor returns the colour that the Interactable Object is 
 ---
 
 ## Object Touch Auto Interact (VRTK_ObjectTouchAutoInteract)
+ > extends [VRTK_InteractableListener](#interactable-listener-vrtk_interactablelistener)
 
 ### Overview
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractHaptics.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractHaptics.cs
@@ -32,7 +32,7 @@ namespace VRTK
     ///    * Any other scene GameObject and provide a valid `VRTK_InteractableObject` component to the `Object To Affect` parameter of this script.
     /// </remarks>
     [AddComponentMenu("VRTK/Scripts/Interactions/Interactables/VRTK_InteractHaptics")]
-    public class VRTK_InteractHaptics : MonoBehaviour
+    public class VRTK_InteractHaptics : VRTK_InteractableListener
     {
         [Header("Haptics On Near Touch Settings")]
 
@@ -241,8 +241,17 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
+            EnableListeners();
+        }
 
+        protected virtual void OnDisable()
+        {
+            DisableListeners();
+        }
+
+        protected override bool SetupListeners(bool throwError)
+        {
+            objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
             if (objectToAffect != null)
             {
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearUntouch, CancelNearTouchHaptics);
@@ -254,14 +263,16 @@ namespace VRTK
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Touch, TouchHaptics);
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Grab, GrabHaptics);
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Use, UseHaptics);
+                return true;
             }
-            else
+            else if (throwError)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_InteractHaptics", "VRTK_InteractableObject", "the same or parent"));
             }
+            return false;
         }
 
-        protected virtual void OnDisable()
+        protected override void TearDownListeners()
         {
             if (objectToAffect != null)
             {

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectHighlighter.cs
@@ -37,7 +37,7 @@ namespace VRTK
     /// </remarks>
 
     [AddComponentMenu("VRTK/Scripts/Interactions/Interactables/VRTK_InteractObjectHighlighter")]
-    public class VRTK_InteractObjectHighlighter : MonoBehaviour
+    public class VRTK_InteractObjectHighlighter : VRTK_InteractableListener
     {
         [Header("Object Interaction Settings")]
 
@@ -93,8 +93,17 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
+            EnableListeners();
+        }
 
+        protected virtual void OnDisable()
+        {
+            DisableListeners();
+        }
+
+        protected override bool SetupListeners(bool throwError)
+        {
+            objectToAffect = (objectToAffect != null ? objectToAffect : GetComponentInParent<VRTK_InteractableObject>());
             if (objectToAffect != null)
             {
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.NearTouch, NearTouchHighlightObject);
@@ -108,14 +117,16 @@ namespace VRTK
 
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Use, UseHighlightObject);
                 objectToAffect.SubscribeToInteractionEvent(VRTK_InteractableObject.InteractionType.Unuse, UseUnHighlightObject);
+                return true;
             }
-            else
+            else if (throwError)
             {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_InteractObjectHighlighter", "VRTK_InteractableObject", "the same or parent"));
             }
+            return false;
         }
 
-        protected virtual void OnDisable()
+        protected override void TearDownListeners()
         {
             if (objectToAffect != null)
             {

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableListener.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableListener.cs
@@ -1,0 +1,45 @@
+﻿// Interactable Listener|Interactables|35015
+namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections;
+
+    /// <summary>
+    /// Provides a base that classes which require to subscribe to the interaction events of an Interactable Object can inherit from.
+    /// </summary>
+    /// <remarks>
+    /// **Script Usage:**
+    ///   > This is an abstract class that is to be inherited to a concrete class that provides interaction event listener functionality, therefore this script should not be directly used.
+    /// </remarks>
+    public abstract class VRTK_InteractableListener : MonoBehaviour
+    {
+        protected Coroutine setupInteractableListenersRoutine;
+
+        protected abstract bool SetupListeners(bool throwError);
+        protected abstract void TearDownListeners();
+
+        protected virtual void EnableListeners()
+        {
+            if (!SetupListeners(false))
+            {
+                setupInteractableListenersRoutine = StartCoroutine(SetupListenersAtEndOfFrame());
+            }
+        }
+
+        protected virtual void DisableListeners()
+        {
+            if (setupInteractableListenersRoutine != null)
+            {
+                StopCoroutine(setupInteractableListenersRoutine);
+                setupInteractableListenersRoutine = null;
+            }
+            TearDownListeners();
+        }
+
+        protected virtual IEnumerator SetupListenersAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            SetupListeners(true);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableListener.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableListener.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 388d9bb7e8cc645489c50b08fcf9a547
+timeCreated: 1511260497
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract.cs
@@ -17,7 +17,7 @@ namespace VRTK
     ///    * Any other scene GameObject and provide a valid `VRTK_InteractableObject` component to the `Interactable Object` parameter of this script.
     /// </remarks>
     [AddComponentMenu("VRTK/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract")]
-    public class VRTK_ObjectTouchAutoInteract : MonoBehaviour
+    public class VRTK_ObjectTouchAutoInteract : VRTK_InteractableListener
     {
         /// <summary>
         /// Situation when auto interaction can occur.
@@ -70,27 +70,12 @@ namespace VRTK
             regrabTimer = 0f;
             reuseTimer = 0f;
             touchers = new List<GameObject>();
-
-            interactableObject = (interactableObject != null ? interactableObject : GetComponent<VRTK_InteractableObject>());
-
-            if (interactableObject != null)
-            {
-                interactableObject.InteractableObjectTouched += InteractableObjectTouched;
-                interactableObject.InteractableObjectUntouched += InteractableObjectUntouched;
-                interactableObject.InteractableObjectUngrabbed += InteractableObjectUngrabbed;
-                interactableObject.InteractableObjectUnused += InteractableObjectUnused;
-            }
+            EnableListeners();
         }
 
         protected virtual void OnDisable()
         {
-            if (interactableObject != null)
-            {
-                interactableObject.InteractableObjectTouched -= InteractableObjectTouched;
-                interactableObject.InteractableObjectUntouched -= InteractableObjectUntouched;
-                interactableObject.InteractableObjectUngrabbed -= InteractableObjectUngrabbed;
-                interactableObject.InteractableObjectUnused -= InteractableObjectUnused;
-            }
+            TearDownListeners();
         }
 
         protected virtual void Update()
@@ -108,6 +93,35 @@ namespace VRTK
                         CheckUse(touchers[i]);
                     }
                 }
+            }
+        }
+
+        protected override bool SetupListeners(bool throwError)
+        {
+            interactableObject = (interactableObject != null ? interactableObject : GetComponentInParent<VRTK_InteractableObject>());
+            if (interactableObject != null)
+            {
+                interactableObject.InteractableObjectTouched += InteractableObjectTouched;
+                interactableObject.InteractableObjectUntouched += InteractableObjectUntouched;
+                interactableObject.InteractableObjectUngrabbed += InteractableObjectUngrabbed;
+                interactableObject.InteractableObjectUnused += InteractableObjectUnused;
+                return true;
+            }
+            else if (throwError)
+            {
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_ObjectTouchAutoInteract", "VRTK_InteractableObject", "the same or parent"));
+            }
+            return false;
+        }
+
+        protected override void TearDownListeners()
+        {
+            if (interactableObject != null)
+            {
+                interactableObject.InteractableObjectTouched -= InteractableObjectTouched;
+                interactableObject.InteractableObjectUntouched -= InteractableObjectUntouched;
+                interactableObject.InteractableObjectUngrabbed -= InteractableObjectUngrabbed;
+                interactableObject.InteractableObjectUnused -= InteractableObjectUnused;
             }
         }
 


### PR DESCRIPTION
The collection of interactable helpers would fail if no Interactable
Object script was available on the GameObject at edit time because
they all attempted to register to the interaction events in the
`OnEnable` method.

This causes issues with other scripts (such as the controllables) if
the Interactable Object is set up at runtime in their `OnEnable`
method as the Interactable Object is not available until the next
frame.

This fix introduces a new base class called Interactable Listener
which provides an interface for how interactable helpers should
attempt to register the interaction events at in `OnEnable` but
if no Interactable Object is found then they will wait till the
end of the the frame and try again when the Interactable Object
should be present.