### PR TITLE
refactor(Structure): provide helper methods for lists and dictionaries - fixes #1631

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -8472,32 +8472,32 @@ Holds all the info necessary to describe an SDK.
 
 ### Class Methods
 
-#### ActualType>/0
+#### Create<BaseType, FallbackType, ActualType>/0
 
   > `public static VRTK_SDKInfo[] Create<BaseType, FallbackType, ActualType>() where BaseType : SDK_Base where FallbackType : BaseType where ActualType : BaseType`
 
  * Type Params
-   * `FallbackType,` - The SDK base type. Must be a subclass of SDK_Base.
-   * `FallbackType,` - The SDK type to fall back on if problems occur. Must be a subclass of `BaseType`.
-   * `FallbackType,` - The SDK type to use. Must be a subclass of `BaseType`.
+   * `BaseType` - The SDK base type. Must be a subclass of SDK_Base.
+   * `FallbackType` - The SDK type to fall back on if problems occur. Must be a subclass of `BaseType`.
+   * `ActualType` - The SDK type to use. Must be a subclass of `BaseType`.
  * Parameters
    * _none_
  * Returns
-   * `FallbackType,` - Multiple newly created instances.
+   * `VRTK_SDKInfo[]` - Multiple newly created instances.
 
 Creates new SDK infos for a type that is known at compile time.
 
-#### FallbackType>/1
+#### Create<BaseType, FallbackType>/1
 
   > `public static VRTK_SDKInfo[] Create<BaseType, FallbackType>(Type actualType) where BaseType : SDK_Base where FallbackType : BaseType`
 
  * Type Params
-   * `Create<BaseType,` - The SDK base type. Must be a subclass of SDK_Base.
-   * `Create<BaseType,` - The SDK type to fall back on if problems occur. Must be a subclass of `BaseType.
+   * `BaseType` - The SDK base type. Must be a subclass of SDK_Base.
+   * `FallbackType` - The SDK type to fall back on if problems occur. Must be a subclass of `BaseType.
  * Parameters
    * `Type actualType` - The SDK type to use. Must be a subclass of `BaseType.
  * Returns
-   * `Create<BaseType,` - Multiple newly created instances.
+   * `VRTK_SDKInfo[]` - Multiple newly created instances.
 
 Creates new SDK infos for a type.
 
@@ -9006,7 +9006,7 @@ The Mod method is used to find the remainder of the sum a/b.
   > `public static GameObject FindEvenInactiveGameObject<T>(string gameObjectName = null) where T : Component`
 
  * Type Params
-   * `GameObject` - The component type that needs to be on an ancestor of the wanted GameObject. Must be a subclass of `Component`.
+   * `T` - The component type that needs to be on an ancestor of the wanted GameObject. Must be a subclass of `Component`.
  * Parameters
    * `string gameObjectName` - The name of the wanted GameObject. If it contains a '/' character, this method traverses the hierarchy like a path name, beginning on the game object that has a component of type `T`.
  * Returns
@@ -9019,7 +9019,7 @@ Finds the first GameObject with a given name and an ancestor that has a specific
   > `public static T[] FindEvenInactiveComponents<T>() where T : Component`
 
  * Type Params
-   * `T[]` - The component type to search for. Must be a subclass of `Component`.
+   * `T` - The component type to search for. Must be a subclass of `Component`.
  * Parameters
    * _none_
  * Returns
@@ -9173,6 +9173,73 @@ The NormalizeValue method takes a given value between a specified range and retu
    * `Vector3` - The direction Vector3 based on the given axis index.
 
 The AxisDirection method returns the relevant direction Vector3 based on the axis index in relation to x,y,z.
+
+#### AddListValue<TValue>/3
+
+  > `public static bool AddListValue<TValue>(List<TValue> list, TValue value, bool preventDuplicates = false)`
+
+ * Type Params
+   * `TValue` - The datatype for the list value.
+ * Parameters
+   * `List<TValue> list` - The list to retrieve the value from.
+   * `TValue value` - The value to attempt to add to the list.
+   * `bool preventDuplicates` - If this is `false` then the value provided will always be appended to the list. If this is `true` the value provided will only be added to the list if it doesn't already exist.
+ * Returns
+   * `bool` - Returns `true` if the given value was successfully added to the list. Returns `false` if the given value already existed in the list and `preventDuplicates` is `true`.
+
+The AddListValue method adds the given value to the given list. If `preventDuplicates` is `true` then the given value will only be added if it doesn't already exist in the given list.
+
+#### GetDictionaryValue<TKey, TValue>/4
+
+  > `public static TValue GetDictionaryValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue), bool setMissingKey = false)`
+
+ * Type Params
+   * `TKey` - The datatype for the dictionary key.
+   * `TValue` - The datatype for the dictionary value.
+ * Parameters
+   * `Dictionary<TKey, TValue> dictionary` - The dictionary to retrieve the value from.
+   * `TKey key` - The key to retrieve the value for.
+   * `TValue defaultValue` - The value to utilise when either setting the missing key (if `setMissingKey` is `true`) or the default value to return when no key is found (if `setMissingKey` is `false`).
+   * `bool setMissingKey` - If this is `true` and the given key is not present, then the dictionary value for the given key will be set to the `defaultValue` parameter. If this is `false` and the given key is not present then the `defaultValue` parameter will be returned as the value.
+ * Returns
+   * `TValue` - The found value for the given key in the given dictionary, or the default value if no key is found.
+
+The GetDictionaryValue method attempts to retrieve a value from a given dictionary for the given key. It removes the need for a double dictionary lookup to ensure the key is valid and has the option of also setting the missing key value to ensure the dictionary entry is valid.
+
+#### GetDictionaryValue<TKey, TValue>/5
+
+  > `public static TValue GetDictionaryValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, out bool keyExists, TValue defaultValue = default(TValue), bool setMissingKey = false)`
+
+ * Type Params
+   * `TKey` - The datatype for the dictionary key.
+   * `TValue` - The datatype for the dictionary value.
+ * Parameters
+   * `Dictionary<TKey, TValue> dictionary` - The dictionary to retrieve the value from.
+   * `TKey key` - The key to retrieve the value for.
+   * `out bool keyExists` - Sets the given parameter to `true` if the key exists in the given dictionary or sets to `false` if the key didn't existing in the given dictionary.
+   * `TValue defaultValue` - The value to utilise when either setting the missing key (if `setMissingKey` is `true`) or the default value to return when no key is found (if `setMissingKey` is `false`).
+   * `bool setMissingKey` - If this is `true` and the given key is not present, then the dictionary value for the given key will be set to the `defaultValue` parameter. If this is `false` and the given key is not present then the `defaultValue` parameter will be returned as the value.
+ * Returns
+   * `TValue` - The found value for the given key in the given dictionary, or the default value if no key is found.
+
+The GetDictionaryValue method attempts to retrieve a value from a given dictionary for the given key. It removes the need for a double dictionary lookup to ensure the key is valid and has the option of also setting the missing key value to ensure the dictionary entry is valid.
+
+#### AddDictionaryValue<TKey, TValue>/4
+
+  > `public static bool AddDictionaryValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue value, bool overwriteExisting = false)`
+
+ * Type Params
+   * `TKey` - The datatype for the dictionary key.
+   * `TValue` - The datatype for the dictionary value.
+ * Parameters
+   * `Dictionary<TKey, TValue> dictionary` - The dictionary to set the value for.
+   * `TKey key` - The key to set the value for.
+   * `TValue value` - The value to set at the given key in the given dictionary.
+   * `bool overwriteExisting` - If this is `true` then the value for the given key will always be set to the provided value. If this is `false` then the value for the given key will only be set if the given key is not found in the given dictionary.
+ * Returns
+   * `bool` - Returns `true` if the given value was successfully added to the dictionary at the given key. Returns `false` if the given key already existed in the dictionary and `overwriteExisting` is `false`.
+
+The AddDictionaryValue method attempts to add a value for the given key in the given dictionary if the key does not already exist. If `overwriteExisting` is `true` then it always set the value even if they key exists.
 
 #### GetTypeUnknownAssembly/1
 

--- a/Assets/VRTK/Prefabs/RadialMenu/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/RadialMenu/VRTK_IndependentRadialMenuController.cs
@@ -37,8 +37,8 @@ namespace VRTK
         [Tooltip("The object the RadialMenu should face towards. If left empty, it will automatically try to find the Headset Camera.")]
         public GameObject rotateTowards;
 
-        protected List<GameObject> interactingObjects; // Objects (controllers) that are either colliding with the menu or clicking the menu
-        protected List<GameObject> collidingObjects; // Just objects that are currently colliding with the menu or its parent
+        protected List<GameObject> interactingObjects = new List<GameObject>(); // Objects (controllers) that are either colliding with the menu or clicking the menu
+        protected HashSet<GameObject> collidingObjects = new HashSet<GameObject>(); // Just objects that are currently colliding with the menu or its parent
         protected SphereCollider menuCollider;
         protected Coroutine delayedSetColliderEnabledRoutine;
         protected Vector3 desiredColliderCenter;
@@ -87,8 +87,8 @@ namespace VRTK
             }
 
             // Reset variables
-            interactingObjects = new List<GameObject>();
-            collidingObjects = new List<GameObject>();
+            interactingObjects.Clear();
+            collidingObjects.Clear();
             if (delayedSetColliderEnabledRoutine != null)
             {
                 StopCoroutine(delayedSetColliderEnabledRoutine);
@@ -262,8 +262,7 @@ namespace VRTK
         {
             DoShowMenu(CalculateAngle(e.interactingObject), sender);
             collidingObjects.Add(e.interactingObject);
-
-            interactingObjects.Add(e.interactingObject);
+            VRTK_SharedMethods.AddListValue(interactingObjects, e.interactingObject, true);
             if (addMenuCollider && menuCollider != null)
             {
                 SetColliderState(true, e);
@@ -280,7 +279,6 @@ namespace VRTK
             if (((!menu.executeOnUnclick || !isClicked) && menu.hideOnRelease) || (Object)sender == this)
             {
                 DoHideMenu(hideAfterExecution, sender);
-
                 interactingObjects.Remove(e.interactingObject);
                 if (addMenuCollider && menuCollider != null)
                 {

--- a/Assets/VRTK/Prefabs/RadialMenu/VRTK_RadialMenu.cs
+++ b/Assets/VRTK/Prefabs/RadialMenu/VRTK_RadialMenu.cs
@@ -59,7 +59,7 @@ namespace VRTK
         }
 
         [Tooltip("An array of Buttons that define the interactive buttons required to be displayed as part of the radial menu.")]
-        public List<RadialMenuButton> buttons;
+        public List<RadialMenuButton> buttons = new List<RadialMenuButton>();
         [Tooltip("The base for each button in the menu, by default set to a dynamic circle arc that will fill up a portion of the menu.")]
         public GameObject buttonPrefab;
         [Tooltip("If checked, then the buttons will be auto generated on awake.")]
@@ -95,7 +95,7 @@ namespace VRTK
 
         //Has to be public to keep state from editor -> play mode?
         [Tooltip("The actual GameObjects that make up the radial menu.")]
-        public List<GameObject> menuButtons;
+        public List<GameObject> menuButtons = new List<GameObject>();
 
         protected int currentHover = -1;
         protected int currentPress = -1;
@@ -295,8 +295,7 @@ namespace VRTK
                         buttonIcon.transform.eulerAngles = GetComponentInParent<Canvas>().transform.eulerAngles;
                     }
                 }
-                menuButtons.Add(newButton);
-
+                VRTK_SharedMethods.AddListValue(menuButtons, newButton, true);
             }
         }
 
@@ -306,7 +305,7 @@ namespace VRTK
         /// <param name="newButton">The button to add.</param>
         public void AddButton(RadialMenuButton newButton)
         {
-            buttons.Add(newButton);
+            VRTK_SharedMethods.AddListValue(buttons, newButton, true);
             RegenerateButtons();
         }
 
@@ -437,15 +436,14 @@ namespace VRTK
 
         protected virtual void RemoveAllButtons()
         {
-            if (menuButtons == null)
+            if (menuButtons != null)
             {
-                menuButtons = new List<GameObject>();
+                for (int i = 0; i < menuButtons.Count; i++)
+                {
+                    DestroyImmediate(menuButtons[i]);
+                }
+                menuButtons.Clear();
             }
-            for (int i = 0; i < menuButtons.Count; i++)
-            {
-                DestroyImmediate(menuButtons[i]);
-            }
-            menuButtons = new List<GameObject>();
         }
     }
 }

--- a/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
@@ -284,7 +284,7 @@ namespace VRTK
             List<GameObject> returnList = new List<GameObject>();
             for (int i = 0; i < currentValidSnapInteractableObjects.Count; i++)
             {
-                returnList.Add(currentValidSnapInteractableObjects[i].gameObject);
+                VRTK_SharedMethods.AddListValue(returnList, currentValidSnapInteractableObjects[i].gameObject);
             }
             return returnList;
         }
@@ -847,11 +847,10 @@ namespace VRTK
         {
             if (givenObject != null)
             {
-                if (!currentValidSnapInteractableObjects.Contains(givenObject))
+                if (VRTK_SharedMethods.AddListValue(currentValidSnapInteractableObjects, givenObject, true))
                 {
                     givenObject.InteractableObjectGrabbed += InteractableObjectGrabbed;
                     givenObject.InteractableObjectUngrabbed += InteractableObjectUngrabbed;
-                    currentValidSnapInteractableObjects.Add(givenObject);
                 }
             }
         }
@@ -860,11 +859,10 @@ namespace VRTK
         {
             if (givenObject != null)
             {
-                if (currentValidSnapInteractableObjects.Contains(givenObject))
+                if (currentValidSnapInteractableObjects.Remove(givenObject))
                 {
                     givenObject.InteractableObjectGrabbed -= InteractableObjectGrabbed;
                     givenObject.InteractableObjectUngrabbed -= InteractableObjectUngrabbed;
-                    currentValidSnapInteractableObjects.Remove(givenObject);
                 }
             }
         }

--- a/Assets/VRTK/Source/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_SimController.cs
@@ -473,7 +473,7 @@ namespace VRTK
         /// <returns>whether or not the TouchModifier is active</returns>
         protected virtual bool IsTouchModifierPressed()
         {
-            return Input.GetKey(keyMappings["TouchModifier"]);
+            return Input.GetKey(VRTK_SharedMethods.GetDictionaryValue(keyMappings, "TouchModifier", KeyCode.None));
         }
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace VRTK
         /// <returns>whether or not the HairTouchModifier is active</returns>
         protected virtual bool IsHairTouchModifierPressed()
         {
-            return Input.GetKey(keyMappings["HairTouchModifier"]);
+            return Input.GetKey(VRTK_SharedMethods.GetDictionaryValue(keyMappings, "HairTouchModifier", KeyCode.None));
         }
 
         /// <summary>
@@ -518,29 +518,30 @@ namespace VRTK
         /// <returns>Returns true if the button state matches the given data.</returns>
         protected virtual bool GetControllerButtonState(uint index, string keyMapping, ButtonPressTypes pressType)
         {
+            KeyCode buttonCode = VRTK_SharedMethods.GetDictionaryValue(keyMappings, keyMapping, KeyCode.None);
             if (pressType == ButtonPressTypes.Touch)
             {
-                return IsButtonPressed(index, ButtonPressTypes.Press, keyMappings[keyMapping]);
+                return IsButtonPressed(index, ButtonPressTypes.Press, buttonCode);
             }
             else if (pressType == ButtonPressTypes.TouchDown)
             {
-                return IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings[keyMapping]);
+                return IsButtonPressed(index, ButtonPressTypes.PressDown, buttonCode);
             }
             else if (pressType == ButtonPressTypes.TouchUp)
             {
-                return IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings[keyMapping]);
+                return IsButtonPressed(index, ButtonPressTypes.PressUp, buttonCode);
             }
             else if (pressType == ButtonPressTypes.Press)
             {
-                return !IsButtonPressIgnored() && IsButtonPressed(index, ButtonPressTypes.Press, keyMappings[keyMapping]);
+                return !IsButtonPressIgnored() && IsButtonPressed(index, ButtonPressTypes.Press, buttonCode);
             }
             else if (pressType == ButtonPressTypes.PressDown)
             {
-                return !IsButtonPressIgnored() && IsButtonPressed(index, ButtonPressTypes.PressDown, keyMappings[keyMapping]);
+                return !IsButtonPressIgnored() && IsButtonPressed(index, ButtonPressTypes.PressDown, buttonCode);
             }
             else if (pressType == ButtonPressTypes.PressUp)
             {
-                return !IsButtonPressIgnored() && IsButtonPressed(index, ButtonPressTypes.PressUp, keyMappings[keyMapping]);
+                return !IsButtonPressIgnored() && IsButtonPressed(index, ButtonPressTypes.PressUp, buttonCode);
             }
             return false;
         }

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -529,8 +529,9 @@ namespace VRTK
             }
 
             bool isRightController = (controllerReference.hand == ControllerHand.Right);
-            KeyCode? touchButton = (isRightController ? rightControllerTouchKeyCodes[buttonType] : leftControllerTouchKeyCodes[buttonType]);
-            KeyCode? pressButton = (isRightController ? rightControllerPressKeyCodes[buttonType] : leftControllerPressKeyCodes[buttonType]);
+
+            KeyCode? touchButton = VRTK_SharedMethods.GetDictionaryValue((isRightController ? rightControllerTouchKeyCodes : leftControllerTouchKeyCodes), buttonType);
+            KeyCode? pressButton = VRTK_SharedMethods.GetDictionaryValue((isRightController ? rightControllerPressKeyCodes : leftControllerPressKeyCodes), buttonType);
 
             switch (buttonType)
             {
@@ -603,40 +604,29 @@ namespace VRTK
             return 0f;
         }
 
+        protected virtual bool IsAxisOnHandButtonPress(Dictionary<ButtonTypes, bool> axisHandState, ButtonTypes buttonType, ButtonPressTypes pressType, Vector2 axisValue)
+        {
+            bool previousAxisState = VRTK_SharedMethods.GetDictionaryValue(axisHandState, buttonType);
+            if (pressType == ButtonPressTypes.PressDown && !previousAxisState)
+            {
+                bool currentAxisState = GetAxisPressState(previousAxisState, axisValue.x);
+                VRTK_SharedMethods.AddDictionaryValue(axisHandState, buttonType, currentAxisState, true);
+                return currentAxisState;
+            }
+            if (pressType == ButtonPressTypes.PressUp && previousAxisState)
+            {
+                bool currentAxisState = GetAxisPressState(previousAxisState, axisValue.x);
+                VRTK_SharedMethods.AddDictionaryValue(axisHandState, buttonType, currentAxisState, true);
+                return !currentAxisState;
+            }
+            return false;
+        }
+
         protected virtual bool IsAxisButtonPress(VRTK_ControllerReference controllerReference, ButtonTypes buttonType, ButtonPressTypes pressType)
         {
             bool isRightController = (controllerReference.hand == ControllerHand.Right);
             Vector2 axisValue = GetButtonAxis(buttonType, controllerReference);
-
-            if (isRightController)
-            {
-                bool previousAxisState = rightAxisButtonPressState[buttonType];
-                if (pressType == ButtonPressTypes.PressDown && !previousAxisState)
-                {
-                    rightAxisButtonPressState[buttonType] = GetAxisPressState(rightAxisButtonPressState[buttonType], axisValue.x);
-                    return rightAxisButtonPressState[buttonType];
-                }
-                if (pressType == ButtonPressTypes.PressUp && previousAxisState)
-                {
-                    rightAxisButtonPressState[buttonType] = GetAxisPressState(rightAxisButtonPressState[buttonType], axisValue.x);
-                    return !rightAxisButtonPressState[buttonType];
-                }
-            }
-            else
-            {
-                bool previousAxisState = leftAxisButtonPressState[buttonType];
-                if (pressType == ButtonPressTypes.PressDown && !previousAxisState)
-                {
-                    leftAxisButtonPressState[buttonType] = GetAxisPressState(leftAxisButtonPressState[buttonType], axisValue.x);
-                    return leftAxisButtonPressState[buttonType];
-                }
-                if (pressType == ButtonPressTypes.PressUp && previousAxisState)
-                {
-                    leftAxisButtonPressState[buttonType] = GetAxisPressState(leftAxisButtonPressState[buttonType], axisValue.x);
-                    return !leftAxisButtonPressState[buttonType];
-                }
-            }
-            return false;
+            return IsAxisOnHandButtonPress((isRightController ? rightAxisButtonPressState : leftAxisButtonPressState), buttonType, pressType, axisValue);
         }
 
         protected virtual bool GetAxisPressState(bool currentState, float axisValue)
@@ -787,15 +777,15 @@ namespace VRTK
 
         protected virtual void SetControllerButtonValues(ref Dictionary<ButtonTypes, KeyCode?> touchKeyCodes, ref Dictionary<ButtonTypes, KeyCode?> pressKeyCodes, int joystickIndex, int[] touchCodes, int[] pressCodes)
         {
-            touchKeyCodes[ButtonTypes.Trigger] = StringToKeyCode(joystickIndex, touchCodes[0]);
-            touchKeyCodes[ButtonTypes.Touchpad] = StringToKeyCode(joystickIndex, touchCodes[1]);
-            touchKeyCodes[ButtonTypes.ButtonOne] = StringToKeyCode(joystickIndex, touchCodes[2]);
-            touchKeyCodes[ButtonTypes.ButtonTwo] = StringToKeyCode(joystickIndex, touchCodes[3]);
+            VRTK_SharedMethods.AddDictionaryValue(touchKeyCodes, ButtonTypes.Trigger, StringToKeyCode(joystickIndex, touchCodes[0]), true);
+            VRTK_SharedMethods.AddDictionaryValue(touchKeyCodes, ButtonTypes.Touchpad, StringToKeyCode(joystickIndex, touchCodes[1]), true);
+            VRTK_SharedMethods.AddDictionaryValue(touchKeyCodes, ButtonTypes.ButtonOne, StringToKeyCode(joystickIndex, touchCodes[2]), true);
+            VRTK_SharedMethods.AddDictionaryValue(touchKeyCodes, ButtonTypes.ButtonTwo, StringToKeyCode(joystickIndex, touchCodes[3]), true);
 
-            pressKeyCodes[ButtonTypes.Touchpad] = StringToKeyCode(joystickIndex, pressCodes[0]);
-            pressKeyCodes[ButtonTypes.ButtonOne] = StringToKeyCode(joystickIndex, pressCodes[1]);
-            pressKeyCodes[ButtonTypes.ButtonTwo] = StringToKeyCode(joystickIndex, pressCodes[2]);
-            pressKeyCodes[ButtonTypes.StartMenu] = StringToKeyCode(joystickIndex, pressCodes[3]);
+            VRTK_SharedMethods.AddDictionaryValue(pressKeyCodes, ButtonTypes.Touchpad, StringToKeyCode(joystickIndex, pressCodes[0]), true);
+            VRTK_SharedMethods.AddDictionaryValue(pressKeyCodes, ButtonTypes.ButtonOne, StringToKeyCode(joystickIndex, pressCodes[1]), true);
+            VRTK_SharedMethods.AddDictionaryValue(pressKeyCodes, ButtonTypes.ButtonTwo, StringToKeyCode(joystickIndex, pressCodes[2]), true);
+            VRTK_SharedMethods.AddDictionaryValue(pressKeyCodes, ButtonTypes.StartMenu, StringToKeyCode(joystickIndex, pressCodes[3]), true);
         }
 
         protected virtual KeyCode StringToKeyCode(int index, int code)

--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_BaseHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_BaseHighlighter.cs
@@ -57,11 +57,7 @@ namespace VRTK.Highlighters
         /// <returns>The value in the options at the given key returned in the provided system type.</returns>
         public virtual T GetOption<T>(Dictionary<string, object> options, string key)
         {
-            if (options != null && options.ContainsKey(key) && options[key] != null)
-            {
-                return (T)options[key];
-            }
-            return default(T);
+            return (T)VRTK_SharedMethods.GetDictionaryValue(options, key, default(T));
         }
 
         /// <summary>

--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -1,9 +1,10 @@
-// Outline Object Copy|Highlighters|40030
+﻿// Outline Object Copy|Highlighters|40030
 namespace VRTK.Highlighters
 {
     using UnityEngine;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Creates a mesh copy and applies an outline shader which is toggled on and off when highlighting the object.
@@ -262,8 +263,7 @@ namespace VRTK.Highlighters
             {
                 if (enableSubmeshHighlight)
                 {
-                    List<CombineInstance> combine = new List<CombineInstance>();
-
+                    HashSet<CombineInstance> combine = new HashSet<CombineInstance>();
                     for (int i = 0; i < copyMesh.mesh.subMeshCount; i++)
                     {
                         CombineInstance ci = new CombineInstance();

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_IgnoreInteractTouchColliders.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_IgnoreInteractTouchColliders.cs
@@ -99,9 +99,10 @@ namespace VRTK
         protected virtual void ManageTouchCollision(VRTK_InteractTouch touchToIgnore, bool ignore)
         {
             Collider[] interactTouchColliders = touchToIgnore.ControllerColliders();
-            if (VRTK_ObjectCache.registeredTrackedColliderToInteractTouches.ContainsKey(touchToIgnore) && VRTK_ObjectCache.registeredTrackedColliderToInteractTouches[touchToIgnore] != null)
+            VRTK_ControllerTrackedCollider trackedColliderValue = VRTK_SharedMethods.GetDictionaryValue(VRTK_ObjectCache.registeredTrackedColliderToInteractTouches, touchToIgnore);
+            if (trackedColliderValue != null)
             {
-                Collider[] trackedColliders = VRTK_ObjectCache.registeredTrackedColliderToInteractTouches[touchToIgnore].TrackedColliders();
+                Collider[] trackedColliders = trackedColliderValue.TrackedColliders();
                 interactTouchColliders = interactTouchColliders.Concat(trackedColliders).ToArray();
             }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectAppearance.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectAppearance.cs
@@ -159,8 +159,8 @@ namespace VRTK
         protected Dictionary<GameObject, bool> currentRenderStates = new Dictionary<GameObject, bool>();
         protected Dictionary<GameObject, bool> currentGameObjectStates = new Dictionary<GameObject, bool>();
         protected Dictionary<GameObject, Coroutine> affectingRoutines = new Dictionary<GameObject, Coroutine>();
-        protected List<GameObject> nearTouchingObjects = new List<GameObject>();
-        protected List<GameObject> touchingObjects = new List<GameObject>();
+        protected HashSet<GameObject> nearTouchingObjects = new HashSet<GameObject>();
+        protected HashSet<GameObject> touchingObjects = new HashSet<GameObject>();
 
         public virtual void OnGameObjectEnabled(InteractObjectAppearanceEventArgs e)
         {
@@ -268,14 +268,14 @@ namespace VRTK
         {
             if (objectToMonitor != null && objectToMonitor.IsTouched())
             {
-                for (int i = 0; i < touchingObjects.Count; i++)
+                foreach (GameObject touchingObject in touchingObjects)
                 {
-                    ToggleState(touchingObjects[i], gameObjectActiveByDefault, rendererVisibleByDefault, VRTK_InteractableObject.InteractionType.None);
+                    ToggleState(touchingObject, gameObjectActiveByDefault, rendererVisibleByDefault, VRTK_InteractableObject.InteractionType.None);
                 }
 
-                for (int i = 0; i < nearTouchingObjects.Count; i++)
+                foreach (GameObject nearTouchingObject in nearTouchingObjects)
                 {
-                    ToggleState(nearTouchingObjects[i], gameObjectActiveByDefault, rendererVisibleByDefault, VRTK_InteractableObject.InteractionType.None);
+                    ToggleState(nearTouchingObject, gameObjectActiveByDefault, rendererVisibleByDefault, VRTK_InteractableObject.InteractionType.None);
                 }
             }
         }
@@ -325,8 +325,8 @@ namespace VRTK
                     EmitGameObjectEvent(objectToToggle, gameObjectShow, interactionType);
                 }
 
-                currentRenderStates[objectToToggle] = rendererShow;
-                currentGameObjectStates[objectToToggle] = gameObjectShow;
+                VRTK_SharedMethods.AddDictionaryValue(currentRenderStates, objectToToggle, rendererShow, true);
+                VRTK_SharedMethods.AddDictionaryValue(currentGameObjectStates, objectToToggle, gameObjectShow, true);
             }
         }
 
@@ -340,9 +340,10 @@ namespace VRTK
         {
             if (currentAffectingObject != null)
             {
-                if (affectingRoutines.ContainsKey(currentAffectingObject) && affectingRoutines[currentAffectingObject] != null)
+                Coroutine currentAffectingRoutine = VRTK_SharedMethods.GetDictionaryValue(affectingRoutines, currentAffectingObject);
+                if (currentAffectingRoutine != null)
                 {
-                    StopCoroutine(affectingRoutines[currentAffectingObject]);
+                    StopCoroutine(currentAffectingRoutine);
                 }
             }
             else
@@ -406,11 +407,8 @@ namespace VRTK
             {
                 GameObject nearTouchAffectedObject = (objectToAffect == null ? GetActualController(e.interactingObject) : objectToAffect);
                 CancelRoutines(nearTouchAffectedObject);
-                if (!nearTouchingObjects.Contains(nearTouchAffectedObject))
-                {
-                    nearTouchingObjects.Add(nearTouchAffectedObject);
-                }
-                affectingRoutines[nearTouchAffectedObject] = StartCoroutine(ToggleStateAfterTime(nearTouchAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, nearTouchAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch));
+                nearTouchingObjects.Add(nearTouchAffectedObject);
+                VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, nearTouchAffectedObject, StartCoroutine(ToggleStateAfterTime(nearTouchAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, nearTouchAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch)), true);
             }
         }
 
@@ -420,11 +418,8 @@ namespace VRTK
             {
                 GameObject nearTouchAffectedObject = (objectToAffect == null ? GetActualController(e.interactingObject) : objectToAffect);
                 CancelRoutines(nearTouchAffectedObject);
-                if (nearTouchingObjects.Contains(nearTouchAffectedObject))
-                {
-                    nearTouchingObjects.Remove(nearTouchAffectedObject);
-                }
-                affectingRoutines[nearTouchAffectedObject] = StartCoroutine(ToggleStateAfterTime(nearTouchAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, nearUntouchAppearanceDelay, VRTK_InteractableObject.InteractionType.NearUntouch));
+                nearTouchingObjects.Remove(nearTouchAffectedObject);
+                VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, nearTouchAffectedObject, StartCoroutine(ToggleStateAfterTime(nearTouchAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, nearUntouchAppearanceDelay, VRTK_InteractableObject.InteractionType.NearUntouch)), true);
             }
         }
 
@@ -434,11 +429,8 @@ namespace VRTK
             {
                 GameObject touchAffectedObject = (objectToAffect == null ? GetActualController(e.interactingObject) : objectToAffect);
                 CancelRoutines(touchAffectedObject);
-                if (!touchingObjects.Contains(touchAffectedObject))
-                {
-                    touchingObjects.Add(touchAffectedObject);
-                }
-                affectingRoutines[touchAffectedObject] = StartCoroutine(ToggleStateAfterTime(touchAffectedObject, gameObjectActiveOnTouch, rendererVisibleOnTouch, touchAppearanceDelay, VRTK_InteractableObject.InteractionType.Touch));
+                touchingObjects.Add(touchAffectedObject);
+                VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, touchAffectedObject, StartCoroutine(ToggleStateAfterTime(touchAffectedObject, gameObjectActiveOnTouch, rendererVisibleOnTouch, touchAppearanceDelay, VRTK_InteractableObject.InteractionType.Touch)), true);
             }
         }
 
@@ -448,17 +440,14 @@ namespace VRTK
             {
                 GameObject touchAffectedObject = (objectToAffect == null ? GetActualController(e.interactingObject) : objectToAffect);
                 CancelRoutines(touchAffectedObject);
-                if (touchingObjects.Contains(touchAffectedObject))
-                {
-                    touchingObjects.Remove(touchAffectedObject);
-                }
+                touchingObjects.Remove(touchAffectedObject);
                 if (objectToMonitor.IsNearTouched())
                 {
-                    affectingRoutines[touchAffectedObject] = StartCoroutine(ToggleStateAfterTime(touchAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, untouchAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, touchAffectedObject, StartCoroutine(ToggleStateAfterTime(touchAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, untouchAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch)), true);
                 }
                 else
                 {
-                    affectingRoutines[touchAffectedObject] = StartCoroutine(ToggleStateAfterTime(touchAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, untouchAppearanceDelay, VRTK_InteractableObject.InteractionType.Untouch));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, touchAffectedObject, StartCoroutine(ToggleStateAfterTime(touchAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, untouchAppearanceDelay, VRTK_InteractableObject.InteractionType.Untouch)), true);
                 }
             }
         }
@@ -469,7 +458,7 @@ namespace VRTK
             {
                 GameObject grabAffectedObject = (objectToAffect == null ? GetActualController(e.interactingObject) : objectToAffect);
                 CancelRoutines(grabAffectedObject);
-                affectingRoutines[grabAffectedObject] = StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnGrab, rendererVisibleOnGrab, grabAppearanceDelay, VRTK_InteractableObject.InteractionType.Grab));
+                VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, grabAffectedObject, StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnGrab, rendererVisibleOnGrab, grabAppearanceDelay, VRTK_InteractableObject.InteractionType.Grab)), true);
             }
         }
 
@@ -481,19 +470,19 @@ namespace VRTK
                 CancelRoutines(grabAffectedObject);
                 if (objectToMonitor.IsUsing())
                 {
-                    affectingRoutines[grabAffectedObject] = StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnUse, rendererVisibleOnUse, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.Ungrab));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, grabAffectedObject, StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnUse, rendererVisibleOnUse, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.Ungrab)), true);
                 }
                 else if (objectToMonitor.IsTouched())
                 {
-                    affectingRoutines[grabAffectedObject] = StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnTouch, rendererVisibleOnTouch, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.Ungrab));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, grabAffectedObject, StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnTouch, rendererVisibleOnTouch, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.Ungrab)), true);
                 }
                 else if (objectToMonitor.IsNearTouched())
                 {
-                    affectingRoutines[grabAffectedObject] = StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, grabAffectedObject, StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch)), true);
                 }
                 else
                 {
-                    affectingRoutines[grabAffectedObject] = StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.Ungrab));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, grabAffectedObject, StartCoroutine(ToggleStateAfterTime(grabAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, ungrabAppearanceDelay, VRTK_InteractableObject.InteractionType.Ungrab)), true);
                 }
             }
         }
@@ -504,7 +493,7 @@ namespace VRTK
             {
                 GameObject useAffectedObject = (objectToAffect == null ? GetActualController(e.interactingObject) : objectToAffect);
                 CancelRoutines(useAffectedObject);
-                affectingRoutines[useAffectedObject] = StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnUse, rendererVisibleOnUse, useAppearanceDelay, VRTK_InteractableObject.InteractionType.Use));
+                VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, useAffectedObject, StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnUse, rendererVisibleOnUse, useAppearanceDelay, VRTK_InteractableObject.InteractionType.Use)), true);
             }
         }
 
@@ -516,19 +505,19 @@ namespace VRTK
                 CancelRoutines(useAffectedObject);
                 if (objectToMonitor.IsGrabbed())
                 {
-                    affectingRoutines[useAffectedObject] = StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnGrab, rendererVisibleOnGrab, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.Unuse));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, useAffectedObject, StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnGrab, rendererVisibleOnGrab, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.Unuse)), true);
                 }
                 else if (objectToMonitor.IsTouched())
                 {
-                    affectingRoutines[useAffectedObject] = StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnTouch, rendererVisibleOnTouch, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.Unuse));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, useAffectedObject, StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnTouch, rendererVisibleOnTouch, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.Unuse)), true);
                 }
                 else if (objectToMonitor.IsNearTouched())
                 {
-                    affectingRoutines[useAffectedObject] = StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, useAffectedObject, StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveOnNearTouch, rendererVisibleOnNearTouch, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.NearTouch)), true);
                 }
                 else
                 {
-                    affectingRoutines[useAffectedObject] = StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.Unuse));
+                    VRTK_SharedMethods.AddDictionaryValue(affectingRoutines, useAffectedObject, StartCoroutine(ToggleStateAfterTime(useAffectedObject, gameObjectActiveByDefault, rendererVisibleByDefault, unuseAppearanceDelay, VRTK_InteractableObject.InteractionType.Unuse)), true);
                 }
             }
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract.cs
@@ -63,13 +63,13 @@ namespace VRTK
 
         protected float regrabTimer;
         protected float reuseTimer;
-        protected List<GameObject> touchers;
+        protected HashSet<GameObject> touchers = new HashSet<GameObject>();
 
         protected virtual void OnEnable()
         {
             regrabTimer = 0f;
             reuseTimer = 0f;
-            touchers = new List<GameObject>();
+            touchers.Clear();
             EnableListeners();
         }
 
@@ -82,15 +82,15 @@ namespace VRTK
         {
             if (interactableObject != null && (continuousGrabCheck || continuousUseCheck))
             {
-                for (int i = 0; i < touchers.Count; i++)
+                foreach (GameObject toucher in touchers)
                 {
                     if (continuousGrabCheck)
                     {
-                        CheckGrab(touchers[i]);
+                        CheckGrab(toucher);
                     }
                     if (continuousUseCheck)
                     {
-                        CheckUse(touchers[i]);
+                        CheckUse(toucher);
                     }
                 }
             }
@@ -150,11 +150,11 @@ namespace VRTK
 
         protected virtual void ManageTouchers(GameObject interactingObject, bool add)
         {
-            if (add && !touchers.Contains(interactingObject))
+            if (add)
             {
                 touchers.Add(interactingObject);
             }
-            else if (!add && touchers.Contains(interactingObject))
+            else
             {
                 touchers.Remove(interactingObject);
             }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerHighlighter.cs
@@ -71,8 +71,8 @@ namespace VRTK
         public VRTK_BaseHighlighter controllerHighlighter;
 
         protected bool controllerHighlighted = false;
-        protected Dictionary<string, Transform> cachedElements;
-        protected Dictionary<string, object> highlighterOptions;
+        protected Dictionary<string, Transform> cachedElements = new Dictionary<string, Transform>();
+        protected Dictionary<string, object> highlighterOptions = new Dictionary<string, object>();
         protected VRTK_BaseHighlighter baseHighlighter;
         protected bool autoHighlighter = false;
         protected bool trackedControllerReady = false;
@@ -106,7 +106,7 @@ namespace VRTK
         /// </summary>
         public virtual void ConfigureControllerPaths()
         {
-            cachedElements = new Dictionary<string, Transform>();
+            cachedElements.Clear();
             modelElementPaths.bodyModelPath = GetElementPath(modelElementPaths.bodyModelPath, SDK_BaseController.ControllerElements.Body);
             modelElementPaths.triggerModelPath = GetElementPath(modelElementPaths.triggerModelPath, SDK_BaseController.ControllerElements.Trigger);
             modelElementPaths.leftGripModelPath = GetElementPath(modelElementPaths.leftGripModelPath, SDK_BaseController.ControllerElements.GripLeft);
@@ -125,8 +125,8 @@ namespace VRTK
         {
             if (actualController != null)
             {
-                highlighterOptions = new Dictionary<string, object>();
-                highlighterOptions.Add("resetMainTexture", true);
+                highlighterOptions.Clear();
+                VRTK_SharedMethods.AddDictionaryValue(highlighterOptions, "resetMainTexture", true, true);
 
                 autoHighlighter = false;
                 baseHighlighter = GetValidHighlighter();
@@ -475,22 +475,18 @@ namespace VRTK
 
         protected virtual Transform GetElementTransform(string path)
         {
-            if (cachedElements == null || path == null)
+            if (path == null)
             {
                 return null;
             }
 
-            if (!cachedElements.ContainsKey(path) || cachedElements[path] == null)
+            if (actualModelContainer == null && VRTK_SharedMethods.GetDictionaryValue(cachedElements, path) == null)
             {
-                if (actualModelContainer == null)
-                {
-                    VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, "Controller Model", "Controller SDK"));
-                    return null;
-                }
-
-                cachedElements[path] = actualModelContainer.transform.Find(path);
+                VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SDK_OBJECT_NOT_FOUND, "Controller Model", "Controller SDK"));
+                return null;
             }
-            return cachedElements[path];
+
+            return VRTK_SharedMethods.GetDictionaryValue(cachedElements, path, actualModelContainer.transform.Find(path), true);
         }
 
         protected virtual void ToggleHighlightAlias(bool state, string transformPath, Color? highlight, float duration = 0f)

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerTrackedCollider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerTrackedCollider.cs
@@ -79,10 +79,7 @@ namespace VRTK
             }
             else
             {
-                if (!VRTK_ObjectCache.registeredTrackedColliderToInteractTouches.ContainsKey(interactTouch))
-                {
-                    VRTK_ObjectCache.registeredTrackedColliderToInteractTouches.Add(interactTouch, this);
-                }
+                VRTK_SharedMethods.AddDictionaryValue(VRTK_ObjectCache.registeredTrackedColliderToInteractTouches, interactTouch, this);
             }
             base.OnEnable();
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractNearTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractNearTouch.cs
@@ -41,10 +41,7 @@ namespace VRTK
 
         public virtual void OnControllerNearTouchInteractableObject(ObjectInteractEventArgs e)
         {
-            if (!nearTouchedObjects.Contains(e.target))
-            {
-                nearTouchedObjects.Add(e.target);
-            }
+            VRTK_SharedMethods.AddListValue(nearTouchedObjects, e.target, true);
 
             if (ControllerNearTouchInteractableObject != null)
             {
@@ -54,10 +51,7 @@ namespace VRTK
 
         public virtual void OnControllerNearUntouchInteractableObject(ObjectInteractEventArgs e)
         {
-            if (nearTouchedObjects.Contains(e.target))
-            {
-                nearTouchedObjects.Remove(e.target);
-            }
+            nearTouchedObjects.Remove(e.target);
 
             if (ControllerNearUntouchInteractableObject != null)
             {
@@ -238,19 +232,13 @@ namespace VRTK
         protected virtual void OnTriggerEnter(Collider collider)
         {
             StartNearTouch(collider);
-            if (!nearTouchedObjects.Contains(collider.gameObject))
-            {
-                nearTouchedObjects.Add(collider.gameObject);
-            }
+            VRTK_SharedMethods.AddListValue(nearTouchedObjects, collider.gameObject, true);
         }
 
         protected virtual void OnTriggerExit(Collider collider)
         {
             EndNearTouch(collider);
-            if (nearTouchedObjects.Contains(collider.gameObject))
-            {
-                nearTouchedObjects.Remove(collider.gameObject);
-            }
+            nearTouchedObjects.Remove(collider.gameObject);
         }
 
         protected virtual void OnEnable()

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -298,10 +298,7 @@ namespace VRTK
 
         protected virtual void OnTriggerExit(Collider collider)
         {
-            if (touchedObjectActiveColliders.Contains(collider))
-            {
-                touchedObjectActiveColliders.Remove(collider);
-            }
+            touchedObjectActiveColliders.Remove(collider);
         }
 
         protected virtual void OnTriggerStay(Collider collider)
@@ -365,9 +362,9 @@ namespace VRTK
 
         protected virtual void AddActiveCollider(Collider collider)
         {
-            if (touchedObject != null && !touchedObjectActiveColliders.Contains(collider) && touchedObjectColliders.Contains(collider))
+            if (touchedObject != null && touchedObjectColliders.Contains(collider))
             {
-                touchedObjectActiveColliders.Add(collider);
+                VRTK_SharedMethods.AddListValue(touchedObjectActiveColliders, collider, true);
             }
         }
 
@@ -378,9 +375,9 @@ namespace VRTK
             Collider[] touchedObjectChildColliders = touchedObject.GetComponentsInChildren<Collider>();
             for (int i = 0; i < touchedObjectChildColliders.Length; i++)
             {
-                touchedObjectColliders.Add(touchedObjectChildColliders[i]);
+                VRTK_SharedMethods.AddListValue(touchedObjectColliders, touchedObjectChildColliders[i], true);
             }
-            touchedObjectActiveColliders.Add(collider);
+            VRTK_SharedMethods.AddListValue(touchedObjectActiveColliders, collider, true);
         }
 
         protected virtual void ToggleControllerVisibility(bool visible)

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_ControllerHaptics.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_ControllerHaptics.cs
@@ -101,10 +101,7 @@ namespace VRTK
             float hapticPulseStrength = Mathf.Clamp(strength, 0f, 1f);
             SDK_ControllerHapticModifiers hapticModifiers = VRTK_SDK_Bridge.GetHapticModifiers();
             Coroutine hapticLoop = StartCoroutine(SimpleHapticPulseRoutine(controllerReference, duration * hapticModifiers.durationModifier, hapticPulseStrength, pulseInterval * hapticModifiers.intervalModifier));
-            if (!hapticLoopCoroutines.ContainsKey(controllerReference))
-            {
-                hapticLoopCoroutines.Add(controllerReference, hapticLoop);
-            }
+            VRTK_SharedMethods.AddDictionaryValue(hapticLoopCoroutines, controllerReference, hapticLoop);
         }
 
         protected virtual void InternalTriggerHapticPulse(VRTK_ControllerReference controllerReference, AudioClip clip)
@@ -114,18 +111,16 @@ namespace VRTK
             {
                 //If the SDK Bridge doesn't support audio clips then defer to a local version
                 Coroutine hapticLoop = StartCoroutine(AudioClipHapticsRoutine(controllerReference, clip));
-                if (!hapticLoopCoroutines.ContainsKey(controllerReference))
-                {
-                    hapticLoopCoroutines.Add(controllerReference, hapticLoop);
-                }
+                VRTK_SharedMethods.AddDictionaryValue(hapticLoopCoroutines, controllerReference, hapticLoop);
             }
         }
 
         protected virtual void InternalCancelHapticPulse(VRTK_ControllerReference controllerReference)
         {
-            if (hapticLoopCoroutines.ContainsKey(controllerReference) && hapticLoopCoroutines[controllerReference] != null)
+            Coroutine currentHapticLoopRoutine = VRTK_SharedMethods.GetDictionaryValue(hapticLoopCoroutines, controllerReference);
+            if (currentHapticLoopRoutine != null)
             {
-                StopCoroutine(hapticLoopCoroutines[controllerReference]);
+                StopCoroutine(currentHapticLoopRoutine);
                 hapticLoopCoroutines.Remove(controllerReference);
             }
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_ObjectAppearance.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_ObjectAppearance.cs
@@ -157,11 +157,7 @@ namespace VRTK
                 else
                 {
                     CancelSetOpacityCoroutine(model);
-                    Coroutine setOpacityCoroutine = StartCoroutine(TransitionRendererOpacity(model, GetInitialAlpha(model), alpha, transitionDuration));
-                    if (!setOpacityCoroutines.ContainsKey(model))
-                    {
-                        setOpacityCoroutines.Add(model, setOpacityCoroutine);
-                    }
+                    VRTK_SharedMethods.AddDictionaryValue(setOpacityCoroutines, model, StartCoroutine(TransitionRendererOpacity(model, GetInitialAlpha(model), alpha, transitionDuration)));
                 }
             }
         }
@@ -316,9 +312,10 @@ namespace VRTK
 
         protected virtual void CancelSetOpacityCoroutine(GameObject model)
         {
-            if (setOpacityCoroutines.ContainsKey(model) && setOpacityCoroutines[model] != null)
+            Coroutine currentOpacityRoutine = VRTK_SharedMethods.GetDictionaryValue(setOpacityCoroutines, model);
+            if (currentOpacityRoutine != null)
             {
-                StopCoroutine(setOpacityCoroutines[model]);
+                StopCoroutine(currentOpacityRoutine);
             }
         }
     }

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_ControllerReference.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_ControllerReference.cs
@@ -12,9 +12,10 @@
         {
             if (controllerIndex < uint.MaxValue)
             {
-                if (controllerReferences.ContainsKey(controllerIndex))
+                VRTK_ControllerReference foundReference = VRTK_SharedMethods.GetDictionaryValue(controllerReferences, controllerIndex);
+                if (foundReference != null)
                 {
-                    return controllerReferences[controllerIndex];
+                    return foundReference;
                 }
                 return new VRTK_ControllerReference(controllerIndex);
             }
@@ -32,9 +33,10 @@
                 controllerIndex = VRTK_SDK_Bridge.GetControllerIndex(GetValidObjectFromHand(VRTK_SDK_Bridge.GetControllerModelHand(controllerObject)));
             }
 
-            if (controllerReferences.ContainsKey(controllerIndex))
+            VRTK_ControllerReference foundReference = VRTK_SharedMethods.GetDictionaryValue(controllerReferences, controllerIndex);
+            if (foundReference != null)
             {
-                return controllerReferences[controllerIndex];
+                return foundReference;
             }
             return new VRTK_ControllerReference(controllerIndex);
         }
@@ -43,9 +45,10 @@
         {
             GameObject scriptAlias = GetValidObjectFromHand(controllerHand);
             uint controllerIndex = VRTK_SDK_Bridge.GetControllerIndex(scriptAlias);
-            if (controllerReferences.ContainsKey(controllerIndex))
+            VRTK_ControllerReference foundReference = VRTK_SharedMethods.GetDictionaryValue(controllerReferences, controllerIndex);
+            if (foundReference != null)
             {
-                return controllerReferences[controllerIndex];
+                return foundReference;
             }
             return new VRTK_ControllerReference(scriptAlias);
         }
@@ -171,14 +174,9 @@
 
         protected virtual void AddToCache()
         {
-            if (IsValid() && controllerReferences.ContainsKey(storedControllerIndex))
+            if (IsValid())
             {
-                controllerReferences.Remove(storedControllerIndex);
-            }
-
-            if (IsValid() && !controllerReferences.ContainsKey(storedControllerIndex))
-            {
-                controllerReferences.Add(storedControllerIndex, this);
+                VRTK_SharedMethods.AddDictionaryValue(controllerReferences, storedControllerIndex, this, true);
             }
         }
 

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_Logger.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_Logger.cs
@@ -91,15 +91,16 @@
             CreateIfNotExists();
 
             string returnMessage = "";
-            if (commonMessages.ContainsKey(messageKey))
+            string outputMessage = VRTK_SharedMethods.GetDictionaryValue(commonMessages, messageKey);
+            if (outputMessage != null)
             {
-                if (parameters.Length != commonMessageParts[messageKey])
+                int outputMessageParts = VRTK_SharedMethods.GetDictionaryValue(commonMessageParts, messageKey);
+                if (parameters.Length != outputMessageParts)
                 {
-                    Array.Resize(ref parameters, commonMessageParts[messageKey]);
+                    Array.Resize(ref parameters, outputMessageParts);
                 }
-                returnMessage = string.Format(commonMessages[messageKey], parameters);
+                returnMessage = string.Format(outputMessage, parameters);
             }
-
             return returnMessage;
         }
 

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -48,7 +48,7 @@
                 {
                     nearestRaycast = castResult;
                 }
-                resultAppendList.Add(castResult);
+                VRTK_SharedMethods.AddListValue(resultAppendList, castResult);
             }
 
             if (nearestRaycast.HasValue)
@@ -140,7 +140,7 @@
                         sortingLayer = canvas.sortingLayerID,
                         sortingOrder = canvas.sortingOrder,
                     };
-                    results.Add(result);
+                    VRTK_SharedMethods.AddListValue(results, result);
                 }
             }
 

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_MoveInPlace.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_MoveInPlace.cs
@@ -129,9 +129,9 @@ namespace VRTK
         protected bool currentlyFalling;
 
         protected int averagePeriod;
-        protected List<Transform> trackedObjects;
-        protected Dictionary<Transform, List<float>> movementList;
-        protected Dictionary<Transform, float> previousYPositions;
+        protected List<Transform> trackedObjects = new List<Transform>();
+        protected Dictionary<Transform, List<float>> movementList = new Dictionary<Transform, List<float>>();
+        protected Dictionary<Transform, float> previousYPositions = new Dictionary<Transform, float>();
         protected Vector3 initialGaze;
         protected float currentSpeed;
         protected Vector3 currentDirection;
@@ -149,13 +149,13 @@ namespace VRTK
 
             if (controllerLeftHand != null && controllerRightHand != null && (controlOptions == ControlOptions.HeadsetAndControllers || controlOptions == ControlOptions.ControllersOnly))
             {
-                trackedObjects.Add(VRTK_DeviceFinder.GetActualController(controllerLeftHand).transform);
-                trackedObjects.Add(VRTK_DeviceFinder.GetActualController(controllerRightHand).transform);
+                VRTK_SharedMethods.AddListValue(trackedObjects, VRTK_DeviceFinder.GetActualController(controllerLeftHand).transform, true);
+                VRTK_SharedMethods.AddListValue(trackedObjects, VRTK_DeviceFinder.GetActualController(controllerRightHand).transform, true);
             }
 
             if (headset != null && (controlOptions == ControlOptions.HeadsetAndControllers || controlOptions == ControlOptions.HeadsetOnly))
             {
-                trackedObjects.Add(headset.transform);
+                VRTK_SharedMethods.AddListValue(trackedObjects, headset.transform, true);
             }
         }
 
@@ -184,9 +184,9 @@ namespace VRTK
 
         protected virtual void OnEnable()
         {
-            trackedObjects = new List<Transform>();
-            movementList = new Dictionary<Transform, List<float>>();
-            previousYPositions = new Dictionary<Transform, float>();
+            trackedObjects.Clear();
+            movementList.Clear();
+            previousYPositions.Clear();
             initialGaze = Vector3.zero;
             currentDirection = Vector3.zero;
             previousDirection = Vector3.zero;
@@ -212,8 +212,8 @@ namespace VRTK
             for (int i = 0; i < trackedObjects.Count; i++)
             {
                 Transform trackedObj = trackedObjects[i];
-                movementList.Add(trackedObj, new List<float>());
-                previousYPositions.Add(trackedObj, trackedObj.transform.localPosition.y);
+                VRTK_SharedMethods.AddDictionaryValue(movementList, trackedObj, new List<float>(), true);
+                VRTK_SharedMethods.AddDictionaryValue(previousYPositions, trackedObj, trackedObj.transform.localPosition.y, true);
             }
             if (playArea == null)
             {
@@ -294,19 +294,20 @@ namespace VRTK
             {
                 Transform trackedObj = trackedObjects[i];
                 // Get the amount of Y movement that's occured since the last update.
-                float deltaYPostion = Mathf.Abs(previousYPositions[trackedObj] - trackedObj.transform.localPosition.y);
+                float previousYPosition = VRTK_SharedMethods.GetDictionaryValue(previousYPositions, trackedObj);
+                float deltaYPostion = Mathf.Abs(previousYPosition - trackedObj.transform.localPosition.y);
 
                 // Convenience code.
-                List<float> trackedObjList = movementList[trackedObj];
+                List<float> trackedObjList = VRTK_SharedMethods.GetDictionaryValue(movementList, trackedObj, new List<float>(), true);
 
                 // Cap off the speed.
                 if (deltaYPostion > sensitivity)
                 {
-                    trackedObjList.Add(sensitivity);
+                    VRTK_SharedMethods.AddListValue(trackedObjList, sensitivity);
                 }
                 else
                 {
-                    trackedObjList.Add(deltaYPostion);
+                    VRTK_SharedMethods.AddListValue(trackedObjList, deltaYPostion);
                 }
 
                 // Keep our tracking list at m_averagePeriod number of elements.
@@ -395,7 +396,7 @@ namespace VRTK
             {
                 Transform trackedObj = trackedObjects[i];
                 // Get delta postions and rotations
-                previousYPositions[trackedObj] = trackedObj.transform.localPosition.y;
+                VRTK_SharedMethods.AddDictionaryValue(previousYPositions, trackedObj, trackedObj.transform.localPosition.y, true);
             }
         }
 
@@ -447,7 +448,7 @@ namespace VRTK
             for (int i = 0; i < trackedObjects.Count; i++)
             {
                 Transform trackedObj = trackedObjects[i];
-                movementList[trackedObj].Clear();
+                VRTK_SharedMethods.GetDictionaryValue(movementList, trackedObj, new List<float>()).Clear();
             }
             initialGaze = Vector3.zero;
 

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -96,7 +96,7 @@ namespace VRTK
         protected Rigidbody savedAttachPoint;
         protected bool attachedToInteractorAttachPoint = false;
         protected float savedBeamLength = 0f;
-        protected List<GameObject> makeRendererVisible;
+        protected HashSet<GameObject> makeRendererVisible = new HashSet<GameObject>();
 
         protected bool tracerVisible;
         protected bool cursorVisible;
@@ -275,7 +275,7 @@ namespace VRTK
         protected virtual void OnEnable()
         {
             defaultMaterial = Resources.Load("WorldPointer") as Material;
-            makeRendererVisible = new List<GameObject>();
+            makeRendererVisible.Clear();
             CreatePointerOriginTransformFollow();
             CreatePointerObjects();
         }
@@ -439,17 +439,14 @@ namespace VRTK
 
         protected virtual void AddVisibleRenderer(GameObject givenObject)
         {
-            if (!makeRendererVisible.Contains(givenObject))
-            {
-                makeRendererVisible.Add(givenObject);
-            }
+            makeRendererVisible.Add(givenObject);
         }
 
         protected virtual void MakeRenderersVisible()
         {
-            for (int i = 0; i < makeRendererVisible.Count; i++)
+            foreach (GameObject currentRenderer in makeRendererVisible)
             {
-                ToggleRendererVisibility(makeRendererVisible[i], true);
+                ToggleRendererVisibility(currentRenderer, true);
             }
             makeRendererVisible.Clear();
         }

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -211,7 +211,7 @@ namespace VRTK
         protected const string FOOT_COLLIDER_CONTAINER_NAME = "FootColliderContainer";
         protected bool enableBodyCollisionsStartingValue;
         protected float fallMinTime;
-        protected List<GameObject> ignoreCollisionsOnGameObjects = new List<GameObject>();
+        protected HashSet<GameObject> ignoreCollisionsOnGameObjects = new HashSet<GameObject>();
         protected Transform cachedGrabbedObjectTransform = null;
         protected VRTK_InteractableObject cachedGrabbedObject;
         protected LayerMask defaultIgnoreLayer = Physics.IgnoreRaycastLayer;
@@ -393,11 +393,11 @@ namespace VRTK
         public virtual void ResetIgnoredCollisions()
         {
             //Go through all the existing set up ignored colliders and reset their collision state
-            for (int i = 0; i < ignoreCollisionsOnGameObjects.Count; i++)
+            foreach (GameObject ignoreCollisionsOnGameObject in ignoreCollisionsOnGameObjects)
             {
-                if (ignoreCollisionsOnGameObjects[i] != null)
+                if (ignoreCollisionsOnGameObject != null)
                 {
-                    Collider[] objectColliders = ignoreCollisionsOnGameObjects[i].GetComponentsInChildren<Collider>();
+                    Collider[] objectColliders = ignoreCollisionsOnGameObject.GetComponentsInChildren<Collider>();
                     for (int j = 0; j < objectColliders.Length; j++)
                     {
                         ManagePhysicsCollider(objectColliders[j], false);
@@ -821,7 +821,7 @@ namespace VRTK
 
         protected virtual void UpdateStandingPosition(Vector2 currentHeadsetPosition)
         {
-            standingPositionHistory.Add(currentHeadsetPosition);
+            VRTK_SharedMethods.AddListValue(standingPositionHistory, currentHeadsetPosition);
             if (standingPositionHistory.Count > standingHistorySamples)
             {
                 if (!isLeaning && currentCollidingObject == null)

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
@@ -199,12 +199,7 @@ namespace VRTK
         /// <returns>The maximum length the UI Pointer will cast to.</returns>
         public static float GetPointerLength(int pointerId)
         {
-            float maxLength;
-            if (!pointerLengths.TryGetValue(pointerId, out maxLength))
-            {
-                maxLength = float.MaxValue;
-            }
-            return maxLength;
+            return VRTK_SharedMethods.GetDictionaryValue(pointerLengths, pointerId, float.MaxValue);
         }
 
         public virtual void OnUIPointerElementEnter(UIPointerEventArgs e)
@@ -489,7 +484,7 @@ namespace VRTK
             if (controllerEvents != null)
             {
                 pointerEventData.pointerId = (int)VRTK_ControllerReference.GetRealIndex(GetControllerReference());
-                pointerLengths[pointerEventData.pointerId] = maximumLength;
+                VRTK_SharedMethods.AddDictionaryValue(pointerLengths, pointerEventData.pointerId, maximumLength, true);
             }
             if (controllerRenderModel == null && VRTK_ControllerReference.IsValid(GetControllerReference()))
             {

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKInfo.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKInfo.cs
@@ -4,6 +4,7 @@ namespace VRTK
     using UnityEngine;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Holds all the info necessary to describe an SDK.
@@ -63,7 +64,7 @@ namespace VRTK
                 return new VRTK_SDKInfo[0];
             }
 
-            List<VRTK_SDKInfo> sdkInfos = new List<VRTK_SDKInfo>(descriptions.Length);
+            HashSet<VRTK_SDKInfo> sdkInfos = new HashSet<VRTK_SDKInfo>();
             foreach (SDK_DescriptionAttribute description in descriptions)
             {
                 VRTK_SDKInfo sdkInfo = new VRTK_SDKInfo();

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -155,19 +155,16 @@ namespace VRTK
         /// <returns>An array of Colliders that are found in the given GameObject array.</returns>
         public static Collider[] GetCollidersInGameObjects(GameObject[] gameObjects, bool searchChildren, bool includeInactive)
         {
-            List<Collider> foundColliders = new List<Collider>();
+            HashSet<Collider> foundColliders = new HashSet<Collider>();
             for (int i = 0; i < gameObjects.Length; i++)
             {
                 Collider[] gameObjectColliders = (searchChildren ? gameObjects[i].GetComponentsInChildren<Collider>(includeInactive) : gameObjects[i].GetComponents<Collider>());
                 for (int j = 0; j < gameObjectColliders.Length; j++)
                 {
-                    if (!foundColliders.Contains(gameObjectColliders[j]))
-                    {
-                        foundColliders.Add(gameObjectColliders[j]);
-                    }
+                    foundColliders.Add(gameObjectColliders[j]);
                 }
             }
-            return foundColliders.ToArray<Collider>();
+            return foundColliders.ToArray();
         }
 
         /// <summary>
@@ -470,6 +467,104 @@ namespace VRTK
         {
             Vector3[] worldDirections = (givenTransform != null ? new Vector3[] { givenTransform.right, givenTransform.up, givenTransform.forward } : new Vector3[] { Vector3.right, Vector3.up, Vector3.forward });
             return worldDirections[(int)Mathf.Clamp(axisIndex, 0f, worldDirections.Length)];
+        }
+
+        /// <summary>
+        /// The AddListValue method adds the given value to the given list. If `preventDuplicates` is `true` then the given value will only be added if it doesn't already exist in the given list.
+        /// </summary>
+        /// <typeparam name="TValue">The datatype for the list value.</typeparam>
+        /// <param name="list">The list to retrieve the value from.</param>
+        /// <param name="value">The value to attempt to add to the list.</param>
+        /// <param name="preventDuplicates">If this is `false` then the value provided will always be appended to the list. If this is `true` the value provided will only be added to the list if it doesn't already exist.</param>
+        /// <returns>Returns `true` if the given value was successfully added to the list. Returns `false` if the given value already existed in the list and `preventDuplicates` is `true`.</returns>
+        public static bool AddListValue<TValue>(List<TValue> list, TValue value, bool preventDuplicates = false)
+        {
+            if (list != null && (!preventDuplicates || !list.Contains(value)))
+            {
+                list.Add(value);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The GetDictionaryValue method attempts to retrieve a value from a given dictionary for the given key. It removes the need for a double dictionary lookup to ensure the key is valid and has the option of also setting the missing key value to ensure the dictionary entry is valid.
+        /// </summary>
+        /// <typeparam name="TKey">The datatype for the dictionary key.</typeparam>
+        /// <typeparam name="TValue">The datatype for the dictionary value.</typeparam>
+        /// <param name="dictionary">The dictionary to retrieve the value from.</param>
+        /// <param name="key">The key to retrieve the value for.</param>
+        /// <param name="defaultValue">The value to utilise when either setting the missing key (if `setMissingKey` is `true`) or the default value to return when no key is found (if `setMissingKey` is `false`).</param>
+        /// <param name="setMissingKey">If this is `true` and the given key is not present, then the dictionary value for the given key will be set to the `defaultValue` parameter. If this is `false` and the given key is not present then the `defaultValue` parameter will be returned as the value.</param>
+        /// <returns>The found value for the given key in the given dictionary, or the default value if no key is found.</returns>
+        public static TValue GetDictionaryValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue), bool setMissingKey = false)
+        {
+            bool keyExists;
+            return GetDictionaryValue(dictionary, key, out keyExists, defaultValue, setMissingKey);
+        }
+
+        /// <summary>
+        /// The GetDictionaryValue method attempts to retrieve a value from a given dictionary for the given key. It removes the need for a double dictionary lookup to ensure the key is valid and has the option of also setting the missing key value to ensure the dictionary entry is valid.
+        /// </summary>
+        /// <typeparam name="TKey">The datatype for the dictionary key.</typeparam>
+        /// <typeparam name="TValue">The datatype for the dictionary value.</typeparam>
+        /// <param name="dictionary">The dictionary to retrieve the value from.</param>
+        /// <param name="key">The key to retrieve the value for.</param>
+        /// <param name="keyExists">Sets the given parameter to `true` if the key exists in the given dictionary or sets to `false` if the key didn't existing in the given dictionary.</param>
+        /// <param name="defaultValue">The value to utilise when either setting the missing key (if `setMissingKey` is `true`) or the default value to return when no key is found (if `setMissingKey` is `false`).</param>
+        /// <param name="setMissingKey">If this is `true` and the given key is not present, then the dictionary value for the given key will be set to the `defaultValue` parameter. If this is `false` and the given key is not present then the `defaultValue` parameter will be returned as the value.</param>
+        /// <returns>The found value for the given key in the given dictionary, or the default value if no key is found.</returns>
+        public static TValue GetDictionaryValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, out bool keyExists, TValue defaultValue = default(TValue), bool setMissingKey = false)
+        {
+            keyExists = false;
+            if (dictionary == null)
+            {
+                return defaultValue;
+            }
+
+            TValue outputValue;
+            if (dictionary.TryGetValue(key, out outputValue))
+            {
+                keyExists = true;
+            }
+            else
+            {
+                if (setMissingKey)
+                {
+                    dictionary.Add(key, defaultValue);
+                }
+                outputValue = defaultValue;
+            }
+            return outputValue;
+        }
+
+        /// <summary>
+        /// The AddDictionaryValue method attempts to add a value for the given key in the given dictionary if the key does not already exist. If `overwriteExisting` is `true` then it always set the value even if they key exists.
+        /// </summary>
+        /// <typeparam name="TKey">The datatype for the dictionary key.</typeparam>
+        /// <typeparam name="TValue">The datatype for the dictionary value.</typeparam>
+        /// <param name="dictionary">The dictionary to set the value for.</param>
+        /// <param name="key">The key to set the value for.</param>
+        /// <param name="value">The value to set at the given key in the given dictionary.</param>
+        /// <param name="overwriteExisting">If this is `true` then the value for the given key will always be set to the provided value. If this is `false` then the value for the given key will only be set if the given key is not found in the given dictionary.</param>
+        /// <returns>Returns `true` if the given value was successfully added to the dictionary at the given key. Returns `false` if the given key already existed in the dictionary and `overwriteExisting` is `false`.</returns>
+        public static bool AddDictionaryValue<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue value, bool overwriteExisting = false)
+        {
+            if (dictionary != null)
+            {
+                if (overwriteExisting)
+                {
+                    dictionary[key] = value;
+                    return true;
+                }
+                else
+                {
+                    bool keyExists;
+                    GetDictionaryValue(dictionary, key, out keyExists, value, true);
+                    return !keyExists;
+                }
+            }
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
There are a number of places where the use of a List or Dictionary has
unnecessary repetition in checking if a value or key is present before
either adding or removing from the list or dictionary.

There are also times where a value is attempted to be retrieved from
a dictionary but it doesn't exist which would then need to be added
so multiple dictionary lookups are done, which is inefficient. The
proposed changes ensure a single look up is done via `TryGetValue`
which will reduce dictionary usage overhead.