### PR TITLE
feat(Structure): add ObsoleteInspector attribute

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -290,8 +290,6 @@ Adds a collection of Object Tooltips to the Controller providing information to 
  * **Controller Events:** The controller to read the controller events from. If this is blank then it will attempt to get a controller events script from the same or parent GameObject.
  * **Headset Controller Aware:** The headset controller aware script to use to see if the headset is looking at the controller. If this is blank then it will attempt to get a controller events script from the same or parent GameObject.
  * **Hide When Not In View:** If this is checked then the tooltips will be hidden when the headset is not looking at the controller.
- * **Retry Init Max Tries:** The total number of initialisation attempts to make when waiting for the button transforms to initialise.
- * **Retry Init Counter:** The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.
 
 ### Class Events
 
@@ -4254,7 +4252,6 @@ Determines if the GameObject can be interacted with.
 
  * **Disable When Idle:** If this is checked then the Interactable Object component will be disabled when the Interactable Object is not being interacted with.
  * **Allowed Near Touch Controllers:** Determines which controller can initiate a near touch action.
- * **Touch Highlight Color:** The Color to highlight the object when it is touched.
  * **Allowed Touch Controllers:** Determines which controller can initiate a touch action.
  * **Ignored Colliders:** An array of colliders on the GameObject to ignore when being touched.
  * **Is Grabbable:** Determines if the Interactable Object can be grabbed.

--- a/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
@@ -94,13 +94,11 @@ namespace VRTK
         [Tooltip("If this is checked then the tooltips will be hidden when the headset is not looking at the controller.")]
         public bool hideWhenNotInView = true;
 
-        [HideInInspector]
         [System.Obsolete("`VRTK_ControllerTooltips.retryInitMaxTries` has been deprecated as tooltip initialisation now uses the `VRTK_TrackedController.ControllerModelAvailable` event.")]
-        [Tooltip("The total number of initialisation attempts to make when waiting for the button transforms to initialise.")]
+        [ObsoleteInspector]
         public int retryInitMaxTries = 10;
-        [HideInInspector]
         [System.Obsolete("`VRTK_ControllerTooltips.retryInitCounter` has been deprecated as tooltip initialisation now uses the `VRTK_TrackedController.ControllerModelAvailable` event.")]
-        [Tooltip("The amount of seconds to wait before re-attempting to initialise the controller tooltips if the button transforms have not been initialised yet.")]
+        [ObsoleteInspector]
         public float retryInitCounter = 0.1f;
 
         /// <summary>

--- a/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
@@ -2,7 +2,6 @@
 namespace VRTK
 {
     using UnityEngine;
-    using System;
     using System.Collections;
     using System.Collections.Generic;
     using Highlighters;
@@ -80,13 +79,12 @@ namespace VRTK
         [Tooltip("If this is checked then the drop zone highlight section will be displayed in the scene editor window.")]
         public bool displayDropZoneInEditor = true;
 
-        [Tooltip("The GameObject to snap into the dropzone when the drop zone is enabled. The Interactable Object must be valid in any given policy list to snap.")]
-        [Obsolete("`VRTK_SnapDropZone.defaultSnappedObject` has been replaced with the `VRTK_SnapDropZone.defaultSnappedInteractableObject`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
-        public GameObject defaultSnappedObject;
-
         [Tooltip("The Interactable Object to snap into the dropzone when the drop zone is enabled. The Interactable Object must be valid in any given policy list to snap.")]
         public VRTK_InteractableObject defaultSnappedInteractableObject;
+
+        [System.Obsolete("`VRTK_SnapDropZone.defaultSnappedObject` has been replaced with the `VRTK_SnapDropZone.defaultSnappedInteractableObject`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public GameObject defaultSnappedObject;
 
         /// <summary>
         /// Emitted when a valid interactable object enters the snap drop zone trigger collider.

--- a/Assets/VRTK/Source/Editor/Attributes/ObsoleteInspectorDrawer.cs
+++ b/Assets/VRTK/Source/Editor/Attributes/ObsoleteInspectorDrawer.cs
@@ -1,0 +1,17 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using UnityEditor;
+    using System;
+
+    [CustomPropertyDrawer(typeof(ObsoleteInspectorAttribute))]
+    class ObsoleteInspectorDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            ObsoleteAttribute obsoleteAttribute = (ObsoleteAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(ObsoleteAttribute));
+            EditorStyles.label.richText = true;
+            EditorGUI.PropertyField(position, property, new GUIContent("<color=red><i>" + label.text + "</i></color>", "**OBSOLETE**\n\n" + obsoleteAttribute.Message), true);
+        }
+    }
+}

--- a/Assets/VRTK/Source/Editor/Attributes/ObsoleteInspectorDrawer.cs.meta
+++ b/Assets/VRTK/Source/Editor/Attributes/ObsoleteInspectorDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bb29ae21b033bdd498ff493a7055da5b
+timeCreated: 1511772833
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
@@ -22,17 +22,17 @@ namespace VRTK.SecondaryControllerGrabActions
         public float ungrabDistance = 1f;
         [Tooltip("Locks the specified checked axes so they won't be scaled")]
         public Vector3State lockAxis = Vector3State.False;
-        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockXAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
-        public bool lockXAxis = false;
-        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockYAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
-        public bool lockYAxis = false;
-        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockZAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
-        public bool lockZAxis = false;
         [Tooltip("If checked all the axes will be scaled together (unless locked)")]
         public bool uniformScaling = false;
+        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockXAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public bool lockXAxis = false;
+        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockYAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public bool lockYAxis = false;
+        [System.Obsolete("`VRTK_AxisScaleGrabAction.lockZAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public bool lockZAxis = false;
 
         protected Vector3 initialScale;
         protected float initalLength;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -155,17 +155,16 @@ namespace VRTK
         [Tooltip("Determines which controller can initiate a near touch action.")]
         public AllowedController allowedNearTouchControllers = AllowedController.Both;
 
-        [System.Obsolete("`VRTK_InteractableObject.touchHighlightColor` has been replaced with `VRTK_InteractObjectHighlighter.touchHighlight`. This parameter will be removed in a future version of VRTK.")]
-        [Tooltip("The Color to highlight the object when it is touched.")]
-        [HideInInspector]
-        public Color touchHighlightColor = Color.clear;
-
         [Header("Touch Settings")]
 
         [Tooltip("Determines which controller can initiate a touch action.")]
         public AllowedController allowedTouchControllers = AllowedController.Both;
         [Tooltip("An array of colliders on the GameObject to ignore when being touched.")]
         public Collider[] ignoredColliders;
+
+        [System.Obsolete("`VRTK_InteractableObject.touchHighlightColor` has been replaced with `VRTK_InteractObjectHighlighter.touchHighlight`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public Color touchHighlightColor = Color.clear;
 
         [Header("Grab Settings")]
 

--- a/Assets/VRTK/Source/Scripts/Internal/Attributes/ObsoleteInspectorAttribute.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/Attributes/ObsoleteInspectorAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    public class ObsoleteInspectorAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Assets/VRTK/Source/Scripts/Internal/Attributes/ObsoleteInspectorAttribute.cs.meta
+++ b/Assets/VRTK/Source/Scripts/Internal/Attributes/ObsoleteInspectorAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ceaa6c25c1637904eb29c6d688745ed8
+timeCreated: 1511772745
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -3,7 +3,6 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Collections;
-    using System;
 #if UNITY_5_5_OR_NEWER
     using UnityEngine.AI;
 #endif
@@ -49,8 +48,8 @@ namespace VRTK
         [Tooltip("An optional NavMeshData object that will be utilised for limiting the teleport to within any scene NavMesh.")]
         public VRTK_NavMeshData navMeshData;
 
-        [HideInInspector]
-        [Obsolete("`VRTK_BasicTeleport.navMeshLimitDistance` is no longer used, use `VRTK_BasicTeleport.processNavMesh` instead. This parameter will be removed in a future version of VRTK.")]
+        [System.Obsolete("`VRTK_BasicTeleport.navMeshLimitDistance` is no longer used, use `VRTK_BasicTeleport.processNavMesh` instead. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
         public float navMeshLimitDistance = 0f;
 
         /// <summary>

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_DestinationMarker.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_DestinationMarker.cs
@@ -2,7 +2,6 @@
 namespace VRTK
 {
     using UnityEngine;
-    using System;
 
     /// <summary>
     /// Event Payload
@@ -66,7 +65,7 @@ namespace VRTK
         /// </summary>
         public event DestinationMarkerEventHandler DestinationMarkerSet;
 
-        [Obsolete("`VRTK_DestinationMarker.navMeshCheckDistance` is no longer used. This parameter will be removed in a future version of VRTK.")]
+        [System.Obsolete("`VRTK_DestinationMarker.navMeshCheckDistance` is no longer used. This parameter will be removed in a future version of VRTK.")]
         protected float navMeshCheckDistance = 0f;
 
         protected VRTK_NavMeshData navmeshData;
@@ -117,7 +116,7 @@ namespace VRTK
         /// The SetNavMeshCheckDistance method sets the max distance the destination marker position can be from the edge of a nav mesh to be considered a valid destination.
         /// </summary>
         /// <param name="distance">The max distance the nav mesh can be from the sample point to be valid.</param>
-        [Obsolete("`DestinationMarker.SetNavMeshCheckDistance(distance)` has been replaced with the method `DestinationMarker.SetNavMeshCheckDistance(givenData)`. This method will be removed in a future version of VRTK.")]
+        [System.Obsolete("`DestinationMarker.SetNavMeshCheckDistance(distance)` has been replaced with the method `DestinationMarker.SetNavMeshCheckDistance(givenData)`. This method will be removed in a future version of VRTK.")]
         public virtual void SetNavMeshCheckDistance(float distance)
         {
             VRTK_NavMeshData givenData = gameObject.AddComponent<VRTK_NavMeshData>();

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
@@ -66,7 +66,7 @@ namespace VRTK
         public Transform customOrigin;
 
         [System.Obsolete("`VRTK_Pointer.controller` has been replaced with `VRTK_Pointer.controllerEvents`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
+        [ObsoleteInspector]
         public VRTK_ControllerEvents controller;
 
         /// <summary>

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
@@ -114,10 +114,10 @@ namespace VRTK
         public Transform customOrigin = null;
 
         [System.Obsolete("`VRTK_UIPointer.controller` has been replaced with `VRTK_UIPointer.controllerEvents`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
+        [ObsoleteInspector]
         public VRTK_ControllerEvents controller;
         [System.Obsolete("`VRTK_UIPointer.pointerOriginTransform` has been replaced with `VRTK_UIPointer.customOrigin`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
+        [ObsoleteInspector]
         public Transform pointerOriginTransform = null;
 
         [HideInInspector]

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -157,8 +157,8 @@ namespace VRTK
         }
         private static VRTK_SDKManager _instance;
 
-        [Tooltip("**OBSOLETE. STOP USING THIS ASAP!** If this is true then the instance of the SDK Manager won't be destroyed on every scene load.")]
         [Obsolete("`VRTK_SDKManager.persistOnLoad` has been deprecated and will be removed in a future version of VRTK. See https://github.com/thestonefox/VRTK/issues/1316 for details.")]
+        [ObsoleteInspector]
         public bool persistOnLoad;
 
         [Tooltip("Determines whether the scripting define symbols required by the installed SDKs are automatically added to and removed from the player settings.")]

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -112,11 +112,12 @@ namespace VRTK
         public Limits2D renderScaleLimits = new Limits2D(0.8f, 1.4f);
 
         [Obsolete("`VRTK_AdaptiveQuality.minimumRenderScale` has been replaced with the `VRTK_AdaptiveQuality.renderScaleLimits`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
+        [ObsoleteInspector]
         public float minimumRenderScale = 0.8f;
         [Obsolete("`VRTK_AdaptiveQuality.maximumRenderScale` has been replaced with the `VRTK_AdaptiveQuality.renderScaleLimits`. This parameter will be removed in a future version of VRTK.")]
-        [HideInInspector]
+        [ObsoleteInspector]
         public float maximumRenderScale = 1.4f;
+
         [Tooltip("The maximum allowed render target dimension.\n\n"
                  + "This puts an upper limit on the size of the render target regardless of the maximum render scale.")]
         public int maximumRenderTargetDimension = 4096;


### PR DESCRIPTION
The new `[ObsoleteInspector]` attribute is placed above public
inspector parameters in place of the previous `[HideInInspector]`
attribute as hidden deprecated parameters was causing confusion
and this new attribute will display the parameter still but render
the label in a red, italic font so it's obvious there is something
different about the field. The tooltip for the parameter is also
replaced by the obsolete message from the `[System.Obsolete]`
attribute.