### PR TITLE
feat(Interaction): remove highlighting duty from interactable obejct

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -4227,7 +4227,6 @@ Determines if the GameObject can be interacted with.
  * `Rigidbody` - A Unity Rigidbody to allow the GameObject to be affected by the Unity Physics System (not required for Climbable Grab Attach Types).
  * `VRTK_BaseGrabAttach` - A Grab Attach mechanic for determining how the Interactable Object is grabbed by the primary interacting object.
  * `VRTK_BaseGrabAction` - A Grab Action mechanic for determining how to manipulate the Interactable Object when grabbed by the secondary interacting object.
- * `VRTK_BaseHighlighter` - The highlighter to use when highligting the Interactable Object. If one is not already injected in the `Object Highlighter` parameter then the component on the same GameObject will be used.
 
 **Script Usage:**
  * Place the `VRTK_InteractableObject` script onto the GameObject that is to be interactable.
@@ -4268,7 +4267,6 @@ Determines if the GameObject can be interacted with.
  * **Pointer Activates Use Action:** If this is checked then when a Pointer collides with the Interactable Object it will activate it's use action. If the the `Hold Button To Use` parameter is unchecked then whilst the Pointer is collising with the Interactable Object it will run the `Using` method. If `Hold Button To Use` is unchecked then the `Using` method will be run when the Pointer is deactivated. The Pointer will not emit the `Destination Set` event if it is affecting an Interactable Object with this setting checked as this prevents unwanted teleporting from happening when using an Interactable Object with a pointer.
  * **Use Override Button:** Setting to a button will ensure the override button is used to use this specific Interactable Object. Setting to `Undefined` will mean the `Use Button` on the Interact Use script will use the object.
  * **Allowed Use Controllers:** Determines which controller can initiate a use action.
- * **Object Highlighter:** An optional Highlighter to use when highlighting this Interactable Object. If this is left blank, then the first active highlighter on the same GameObject will be used, if one isn't found then a Material Color Swap Highlighter will be created at runtime.
 
 ### Class Variables
 
@@ -4454,39 +4452,6 @@ The StartUsing method is called automatically when the Interactable Object is us
    * _none_
 
 The StopUsing method is called automatically when the Interactable Object has stopped being used.
-
-#### Highlight/1
-
-  > `public virtual void Highlight(Color highlightColor)`
-
- * Parameters
-   * `Color highlightColor` - The colour to apply to the highlighter.
- * Returns
-   * _none_
-
-The Highlight method turns on the highlighter attached to the Interactable Object with the given Color.
-
-#### Unhighlight/0
-
-  > `public virtual void Unhighlight()`
-
- * Parameters
-   * _none_
- * Returns
-   * _none_
-
-The Unhighlight method turns off the highlighter attached to the Interactable Object.
-
-#### ResetHighlighter/0
-
-  > `public virtual void ResetHighlighter()`
-
- * Parameters
-   * _none_
- * Returns
-   * _none_
-
-The ResetHighlighter method is used to reset the currently attached highlighter.
 
 #### PauseCollisions/1
 
@@ -5019,7 +4984,10 @@ Adding the `VRTK_InteractObjectAppearance_UnityEvents` component to `VRTK_Intera
 Enable highlighting of an Interactable Object base on interaction type.
 
 **Required Components:**
- * `VRTK_InteractableObject` - The Interactable Object component to detect interactions on. This must be applied on the same GameObject as this script if one is not provided via the `Object To Affect` parameter.
+ * `VRTK_InteractableObject` - The Interactable Object component to detect interactions on. This must be applied on the same GameObject as this script if one is not provided via the `Object To Monitor` parameter.
+
+**Optional Components:**
+ * `VRTK_BaseHighlighter` - The highlighter to use when highligting the Object. If one is not already injected in the `Object Highlighter` parameter then the component on the same GameObject will be used.
 
 **Script Usage:**
  * Place the `VRTK_InteractObjectHighlighter` script on either:
@@ -5032,7 +5000,8 @@ Enable highlighting of an Interactable Object base on interaction type.
  * **Touch Highlight:** The colour to highlight the object on the touch interaction.
  * **Grab Highlight:** The colour to highlight the object on the grab interaction.
  * **Use Highlight:** The colour to highlight the object on the use interaction.
- * **Object To Affect:** The Interactable Object to affect the highlighter of. If this is left blank, then the Interactable Object will need to be on the current or a parent GameObject.
+ * **Object To Highlight:** The GameObject to highlight.
+ * **Object Highlighter:** An optional Highlighter to use when highlighting the specified Object. If this is left blank, then the first active highlighter on the same GameObject will be used, if one isn't found then a Material Color Swap Highlighter will be created at runtime.
 
 ### Class Events
 
@@ -5047,10 +5016,46 @@ Adding the `VRTK_InteractObjectHighlighter_UnityEvents` component to `VRTK_Inter
 
 ### Event Payload
 
- * `VRTK_InteractableObject affectedObject` - The GameObject that is being highlighted.
+ * `VRTK_InteractableObject.InteractionType interactionType` - The type of interaction occuring on the object to monitor.
+ * `Color highlightColor` - The colour being provided to highlight the affected object with.
  * `GameObject affectingObject` - The GameObject is initiating the highlight via an interaction.
+ * `VRTK_InteractableObject objectToMonitor` - The Interactable Object that is being interacted with.
+ * `GameObject affectedObject` - The GameObject that is being highlighted.
 
 ### Class Methods
+
+#### ResetHighlighter/0
+
+  > `public virtual void ResetHighlighter()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * _none_
+
+The ResetHighlighter method is used to reset the currently attached highlighter.
+
+#### Highlight/1
+
+  > `public virtual void Highlight(Color highlightColor)`
+
+ * Parameters
+   * `Color highlightColor` - The colour to apply to the highlighter.
+ * Returns
+   * _none_
+
+The Highlight method turns on the highlighter with the given Color.
+
+#### Unhighlight/0
+
+  > `public virtual void Unhighlight()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * _none_
+
+The Unhighlight method turns off the highlighter.
 
 #### GetCurrentHighlightColor/0
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -4,7 +4,6 @@ namespace VRTK
     using UnityEngine;
     using System.Collections;
     using System.Collections.Generic;
-    using Highlighters;
     using GrabAttachMechanics;
     using SecondaryControllerGrabActions;
 
@@ -35,7 +34,6 @@ namespace VRTK
     ///  * `Rigidbody` - A Unity Rigidbody to allow the GameObject to be affected by the Unity Physics System (not required for Climbable Grab Attach Types).
     ///  * `VRTK_BaseGrabAttach` - A Grab Attach mechanic for determining how the Interactable Object is grabbed by the primary interacting object.
     ///  * `VRTK_BaseGrabAction` - A Grab Action mechanic for determining how to manipulate the Interactable Object when grabbed by the secondary interacting object.
-    ///  * `VRTK_BaseHighlighter` - The highlighter to use when highligting the Interactable Object. If one is not already injected in the `Object Highlighter` parameter then the component on the same GameObject will be used.
     ///
     /// **Script Usage:**
     ///  * Place the `VRTK_InteractableObject` script onto the GameObject that is to be interactable.
@@ -202,8 +200,31 @@ namespace VRTK
 
         [Header("Custom Settings")]
 
-        [Tooltip("An optional Highlighter to use when highlighting this Interactable Object. If this is left blank, then the first active highlighter on the same GameObject will be used, if one isn't found then a Material Color Swap Highlighter will be created at runtime.")]
-        public VRTK_BaseHighlighter objectHighlighter;
+        [System.Obsolete("`VRTK_InteractableObject.objectHighlighter` has been replaced with `VRTK_InteractObjectHighlighter.objectHighlighter`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public Highlighters.VRTK_BaseHighlighter objectHighlighter;
+
+        protected Rigidbody interactableRigidbody;
+        protected HashSet<GameObject> currentIgnoredColliders = new HashSet<GameObject>();
+        protected HashSet<GameObject> hoveredSnapObjects = new HashSet<GameObject>();
+        protected HashSet<GameObject> nearTouchingObjects = new HashSet<GameObject>();
+        protected HashSet<GameObject> touchingObjects = new HashSet<GameObject>();
+        protected List<GameObject> grabbingObjects = new List<GameObject>();
+        protected VRTK_InteractUse usingObject = null;
+        protected Transform trackPoint;
+        protected bool customTrackPoint = false;
+        protected Transform primaryControllerAttachPoint;
+        protected Transform secondaryControllerAttachPoint;
+        protected Transform previousParent;
+        protected bool previousKinematicState;
+        protected bool previousIsGrabbable;
+        protected bool forcedDropped;
+        protected bool forceDisabled;
+        protected bool hoveredOverSnapDropZone = false;
+        protected bool snappedInSnapDropZone = false;
+        protected VRTK_SnapDropZone storedSnapDropZone;
+        protected Vector3 previousLocalScale = Vector3.zero;
+        protected bool startDisabled = false;
 
         /// <summary>
         /// Emitted when the Interactable Object script is enabled;
@@ -289,30 +310,6 @@ namespace VRTK
                 }
             }
         }
-
-        protected Rigidbody interactableRigidbody;
-        protected HashSet<GameObject> currentIgnoredColliders = new HashSet<GameObject>();
-        protected HashSet<GameObject> hoveredSnapObjects = new HashSet<GameObject>();
-        protected HashSet<GameObject> nearTouchingObjects = new HashSet<GameObject>();
-        protected HashSet<GameObject> touchingObjects = new HashSet<GameObject>();
-        protected List<GameObject> grabbingObjects = new List<GameObject>();
-        protected VRTK_InteractUse usingObject = null;
-        protected Transform trackPoint;
-        protected bool customTrackPoint = false;
-        protected Transform primaryControllerAttachPoint;
-        protected Transform secondaryControllerAttachPoint;
-        protected Transform previousParent;
-        protected bool previousKinematicState;
-        protected bool previousIsGrabbable;
-        protected bool forcedDropped;
-        protected bool forceDisabled;
-        protected bool autoHighlighter = false;
-        protected bool hoveredOverSnapDropZone = false;
-        protected bool snappedInSnapDropZone = false;
-        protected VRTK_SnapDropZone storedSnapDropZone;
-        protected Vector3 previousLocalScale = Vector3.zero;
-        protected bool startDisabled = false;
-        protected VRTK_BaseHighlighter baseHighlighter;
 
         public virtual void OnInteractableObjectEnabled(InteractableObjectEventArgs e)
         {
@@ -634,38 +631,39 @@ namespace VRTK
         /// The Highlight method turns on the highlighter attached to the Interactable Object with the given Color.
         /// </summary>
         /// <param name="highlightColor">The colour to apply to the highlighter.</param>
+        [System.Obsolete("`VRTK_InteractableObject.Highlight` has been replaced with `VRTK_InteractObjectHighlighter.Highlight`. This method will be removed in a future version of VRTK.")]
         public virtual void Highlight(Color highlightColor)
         {
-            InitialiseHighlighter(highlightColor);
-            if (baseHighlighter != null && highlightColor != Color.clear)
+            VRTK_InteractObjectHighlighter interactObjectHighlighter = GetComponentInChildren<VRTK_InteractObjectHighlighter>();
+            if(interactObjectHighlighter != null)
             {
-                baseHighlighter.Highlight(highlightColor);
-            }
-            else
-            {
-                Unhighlight();
+                interactObjectHighlighter.Highlight(highlightColor);
             }
         }
 
         /// <summary>
         /// The Unhighlight method turns off the highlighter attached to the Interactable Object.
         /// </summary>
+        [System.Obsolete("`VRTK_InteractableObject.Unhighlight` has been replaced with `VRTK_InteractObjectHighlighter.Unhighlight`. This method will be removed in a future version of VRTK.")]
         public virtual void Unhighlight()
         {
-            if (baseHighlighter != null)
+            VRTK_InteractObjectHighlighter interactObjectHighlighter = GetComponentInChildren<VRTK_InteractObjectHighlighter>();
+            if (interactObjectHighlighter != null)
             {
-                baseHighlighter.Unhighlight();
+                interactObjectHighlighter.Unhighlight();
             }
         }
 
         /// <summary>
         /// The ResetHighlighter method is used to reset the currently attached highlighter.
         /// </summary>
+        [System.Obsolete("`VRTK_InteractableObject.ResetHighlighter` has been replaced with `VRTK_InteractObjectHighlighter.ResetHighlighter`. This method will be removed in a future version of VRTK.")]
         public virtual void ResetHighlighter()
         {
-            if (baseHighlighter != null)
+            VRTK_InteractObjectHighlighter interactObjectHighlighter = GetComponentInChildren<VRTK_InteractObjectHighlighter>();
+            if (interactObjectHighlighter != null)
             {
-                baseHighlighter.ResetHighlighter();
+                interactObjectHighlighter.ResetHighlighter();
             }
         }
 
@@ -1043,16 +1041,13 @@ namespace VRTK
             {
                 VRTK_InteractObjectHighlighter autoGenInteractHighlighter = gameObject.AddComponent<VRTK_InteractObjectHighlighter>();
                 autoGenInteractHighlighter.touchHighlight = touchHighlightColor;
+                autoGenInteractHighlighter.objectHighlighter = (objectHighlighter == null ? Highlighters.VRTK_BaseHighlighter.GetActiveHighlighter(gameObject) : objectHighlighter);
             }
 #pragma warning restore 0618
         }
 
         protected virtual void OnEnable()
         {
-            if (GetValidHighlighter() != baseHighlighter)
-            {
-                baseHighlighter = null;
-            }
             RegisterTeleporters();
             forceDisabled = false;
             if (forcedDropped)
@@ -1067,12 +1062,6 @@ namespace VRTK
         protected virtual void OnDisable()
         {
             UnregisterTeleporters();
-
-            if (autoHighlighter)
-            {
-                Destroy(baseHighlighter);
-            }
-
             if (!startDisabled)
             {
                 forceDisabled = true;
@@ -1144,26 +1133,6 @@ namespace VRTK
             {
                 isGrabbable = previousIsGrabbable;
             }
-        }
-
-        protected virtual void InitialiseHighlighter(Color highlightColor)
-        {
-            if (baseHighlighter == null && highlightColor != Color.clear)
-            {
-                autoHighlighter = false;
-                baseHighlighter = GetValidHighlighter();
-                if (baseHighlighter == null)
-                {
-                    autoHighlighter = true;
-                    baseHighlighter = gameObject.AddComponent<VRTK_MaterialColorSwapHighlighter>();
-                }
-                baseHighlighter.Initialise(highlightColor, gameObject);
-            }
-        }
-
-        protected virtual VRTK_BaseHighlighter GetValidHighlighter()
-        {
-            return (objectHighlighter != null ? objectHighlighter : VRTK_BaseHighlighter.GetActiveHighlighter(gameObject));
         }
 
         protected virtual void IgnoreColliders(GameObject touchingObject)


### PR DESCRIPTION
The Interactable Object is no longer responsible for causing the object
to highlight. All of the highlighting code within the Interactable
Object script has now been removed or deprecated. The Interact
Object Highlight script now takes full control of highlighting an
object and it has been improved so it can listen for the events on an
interactable object and affect the highlighting of a different object.