### PR TITLE
refactor(ControllerEvents): relocate vector2 axis types from sdk

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -3163,6 +3163,10 @@ A relationship to a physical VR controller and emits events based on the inputs 
    * `MiddleFingerSense` - The middle finger sense touch is active.
    * `RingFingerSense` - The ring finger sense touch is active.
    * `PinkyFingerSense` - The pinky finger sense touch is active.
+ * `public enum Vector2AxisAlias` - Vector2 Axis Types.
+   * `Undefined` - No axis specified.
+   * `Touchpad` - Touchpad on the controller.
+   * `TouchpadTwo` - Touchpad Two on the controller.
  * `public enum AxisType` - Axis Types
    * `Digital` - A digital axis with a binary result of 0f not pressed or 1f is pressed.
    * `Axis` - An analog axis ranging from no squeeze at 0f to full squeeze at 1f.
@@ -3297,10 +3301,10 @@ The GetControllerType method is a shortcut to retrieve the current controller ty
 
 #### GetAxis/1
 
-  > `public virtual Vector2 GetAxis(SDK_BaseController.Vector2Axis vector2AxisType)`
+  > `public virtual Vector2 GetAxis(Vector2AxisAlias vector2AxisType)`
 
  * Parameters
-   * `SDK_BaseController.Vector2Axis vector2AxisType` - The Vector2AxisType to check the touch position of.
+   * `Vector2AxisAlias vector2AxisType` - The Vector2AxisType to check the touch position of.
  * Returns
    * `Vector2` - A two dimensional vector containing the `x` and `y` position of where the given axis type is being touched. `(0,0)` to `(1,1)`.
 
@@ -3330,10 +3334,10 @@ The GetTouchpadTwoAxis method returns the coordinates of where the touchpad two 
 
 #### GetAxisAngle/1
 
-  > `public virtual float GetAxisAngle(SDK_BaseController.Vector2Axis vector2AxisType)`
+  > `public virtual float GetAxisAngle(Vector2AxisAlias vector2AxisType)`
 
  * Parameters
-   * `SDK_BaseController.Vector2Axis vector2AxisType` - The Vector2AxisType to get the touch angle for.
+   * `Vector2AxisAlias vector2AxisType` - The Vector2AxisType to get the touch angle for.
  * Returns
    * `float` - A float representing the angle of where the given axis type is being touched. `0f` to `360f`.
 
@@ -3473,10 +3477,10 @@ The AnyButtonPressed method returns true if any of the controller buttons are be
 
 #### GetAxisState/2
 
-  > `public virtual bool GetAxisState(SDK_BaseController.Vector2Axis axis, SDK_BaseController.ButtonPressTypes pressType)`
+  > `public virtual bool GetAxisState(Vector2AxisAlias axis, SDK_BaseController.ButtonPressTypes pressType)`
 
  * Parameters
-   * `SDK_BaseController.Vector2Axis axis` - The axis to check on.
+   * `Vector2AxisAlias axis` - The axis to check on.
    * `SDK_BaseController.ButtonPressTypes pressType` - The button press type to check for.
  * Returns
    * `bool` - Returns `true` if the axis is being interacted with via the given press type.

--- a/Assets/VRTK/Prefabs/PointerDirectionIndicator/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/PointerDirectionIndicator/VRTK_PointerDirectionIndicator.cs
@@ -41,7 +41,7 @@ namespace VRTK
         [Tooltip("The touchpad axis needs to be above this deadzone for it to register as a valid touchpad angle.")]
         public Vector2 touchpadDeadzone = Vector2.zero;
         [Tooltip("The axis to use for the direction coordinates.")]
-        public SDK_BaseController.Vector2Axis coordinateAxis = SDK_BaseController.Vector2Axis.Touchpad;
+        public VRTK_ControllerEvents.Vector2AxisAlias coordinateAxis = VRTK_ControllerEvents.Vector2AxisAlias.Touchpad;
 
         [Header("Appearance Settings")]
 

--- a/Assets/VRTK/Source/SDK/Base/SDK_BaseController.cs
+++ b/Assets/VRTK/Source/SDK/Base/SDK_BaseController.cs
@@ -19,19 +19,6 @@ namespace VRTK
     /// </remarks>
     public abstract class SDK_BaseController : SDK_Base
     {
-        //Controller axes that provide a Vector2
-        public enum Vector2Axis
-        {
-            /// <summary>
-            /// Touchpad on the controller.
-            /// </summary>
-            Touchpad,
-            /// <summary>
-            /// Touchpad Two on the controller.
-            /// </summary>
-            TouchpadTwo
-        }
-
         /// <summary>
         /// Types of buttons on a controller
         /// </summary>

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerEvents.cs
@@ -138,6 +138,25 @@ namespace VRTK
         }
 
         /// <summary>
+        /// Vector2 Axis Types.
+        /// </summary>
+        public enum Vector2AxisAlias
+        {
+            /// <summary>
+            /// No axis specified.
+            /// </summary>
+            Undefined,
+            /// <summary>
+            /// Touchpad on the controller.
+            /// </summary>
+            Touchpad,
+            /// <summary>
+            /// Touchpad Two on the controller.
+            /// </summary>
+            TouchpadTwo
+        }
+
+        /// <summary>
         /// Axis Types
         /// </summary>
         public enum AxisType
@@ -1030,13 +1049,13 @@ namespace VRTK
         /// </summary>
         /// <param name="vector2AxisType">The Vector2AxisType to check the touch position of.</param>
         /// <returns>A two dimensional vector containing the `x` and `y` position of where the given axis type is being touched. `(0,0)` to `(1,1)`.</returns>
-        public virtual Vector2 GetAxis(SDK_BaseController.Vector2Axis vector2AxisType)
+        public virtual Vector2 GetAxis(Vector2AxisAlias vector2AxisType)
         {
             switch (vector2AxisType)
             {
-                case SDK_BaseController.Vector2Axis.Touchpad:
+                case Vector2AxisAlias.Touchpad:
                     return GetTouchpadAxis();
-                case SDK_BaseController.Vector2Axis.TouchpadTwo:
+                case Vector2AxisAlias.TouchpadTwo:
                     return GetTouchpadTwoAxis();
             }
             return Vector2.zero;
@@ -1065,13 +1084,13 @@ namespace VRTK
         /// </summary>
         /// <param name="vector2AxisType">The Vector2AxisType to get the touch angle for.</param>
         /// <returns>A float representing the angle of where the given axis type is being touched. `0f` to `360f`.</returns>
-        public virtual float GetAxisAngle(SDK_BaseController.Vector2Axis vector2AxisType)
+        public virtual float GetAxisAngle(Vector2AxisAlias vector2AxisType)
         {
             switch (vector2AxisType)
             {
-                case SDK_BaseController.Vector2Axis.Touchpad:
+                case Vector2AxisAlias.Touchpad:
                     return GetTouchpadAxisAngle();
-                case SDK_BaseController.Vector2Axis.TouchpadTwo:
+                case Vector2AxisAlias.TouchpadTwo:
                     return GetTouchpadTwoAxisAngle();
             }
             return 0f;
@@ -1197,18 +1216,18 @@ namespace VRTK
         /// <param name="axis">The axis to check on.</param>
         /// <param name="pressType">The button press type to check for.</param>
         /// <returns>Returns `true` if the axis is being interacted with via the given press type.</returns>
-        public virtual bool GetAxisState(SDK_BaseController.Vector2Axis axis, SDK_BaseController.ButtonPressTypes pressType)
+        public virtual bool GetAxisState(Vector2AxisAlias axis, SDK_BaseController.ButtonPressTypes pressType)
         {
             switch (pressType)
             {
                 case SDK_BaseController.ButtonPressTypes.Press:
                 case SDK_BaseController.ButtonPressTypes.PressDown:
                 case SDK_BaseController.ButtonPressTypes.PressUp:
-                    return (axis == SDK_BaseController.Vector2Axis.Touchpad ? touchpadPressed : false);
+                    return (axis == Vector2AxisAlias.Touchpad ? touchpadPressed : false);
                 case SDK_BaseController.ButtonPressTypes.Touch:
                 case SDK_BaseController.ButtonPressTypes.TouchDown:
                 case SDK_BaseController.ButtonPressTypes.TouchUp:
-                    return (axis == SDK_BaseController.Vector2Axis.Touchpad ? touchpadTouched : touchpadTwoTouched);
+                    return (axis == Vector2AxisAlias.Touchpad ? touchpadTouched : touchpadTwoTouched);
             }
             return false;
         }

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TouchpadControl.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TouchpadControl.cs
@@ -29,7 +29,7 @@ namespace VRTK
         [Header("Touchpad Control Settings")]
 
         [Tooltip("The axis to use for the direction coordinates.")]
-        public SDK_BaseController.Vector2Axis coordinateAxis = SDK_BaseController.Vector2Axis.Touchpad;
+        public VRTK_ControllerEvents.Vector2AxisAlias coordinateAxis = VRTK_ControllerEvents.Vector2AxisAlias.Touchpad;
         [Tooltip("An optional button that has to be engaged to allow the touchpad control to activate.")]
         public VRTK_ControllerEvents.ButtonAlias primaryActivationButton = VRTK_ControllerEvents.ButtonAlias.TouchpadTouch;
         [Tooltip("An optional button that when engaged will activate the modifier on the touchpad control action.")]
@@ -47,7 +47,7 @@ namespace VRTK
             base.OnEnable();
             touchpadFirstChange = true;
             otherTouchpadControlEnabledStateSet = false;
-            coordniateButtonAlias = (coordinateAxis == SDK_BaseController.Vector2Axis.Touchpad ? VRTK_ControllerEvents.ButtonAlias.TouchpadTouch : VRTK_ControllerEvents.ButtonAlias.TouchpadTwoTouch);
+            coordniateButtonAlias = (coordinateAxis == VRTK_ControllerEvents.Vector2AxisAlias.Touchpad ? VRTK_ControllerEvents.ButtonAlias.TouchpadTouch : VRTK_ControllerEvents.ButtonAlias.TouchpadTwoTouch);
         }
 
         protected override void ControlFixedUpdate()
@@ -82,11 +82,11 @@ namespace VRTK
                 {
                     switch (coordinateAxis)
                     {
-                        case SDK_BaseController.Vector2Axis.Touchpad:
+                        case VRTK_ControllerEvents.Vector2AxisAlias.Touchpad:
                             controllerEvents.TouchpadAxisChanged += TouchpadAxisChanged;
                             controllerEvents.TouchpadTouchEnd += TouchpadTouchEnd;
                             break;
-                        case SDK_BaseController.Vector2Axis.TouchpadTwo:
+                        case VRTK_ControllerEvents.Vector2AxisAlias.TouchpadTwo:
                             controllerEvents.TouchpadTwoAxisChanged += TouchpadAxisChanged;
                             controllerEvents.TouchpadTwoTouchEnd += TouchpadTouchEnd;
                             break;
@@ -96,11 +96,11 @@ namespace VRTK
                 {
                     switch (coordinateAxis)
                     {
-                        case SDK_BaseController.Vector2Axis.Touchpad:
+                        case VRTK_ControllerEvents.Vector2AxisAlias.Touchpad:
                             controllerEvents.TouchpadAxisChanged -= TouchpadAxisChanged;
                             controllerEvents.TouchpadTouchEnd -= TouchpadTouchEnd;
                             break;
-                        case SDK_BaseController.Vector2Axis.TouchpadTwo:
+                        case VRTK_ControllerEvents.Vector2AxisAlias.TouchpadTwo:
                             controllerEvents.TouchpadTwoAxisChanged -= TouchpadAxisChanged;
                             controllerEvents.TouchpadTwoTouchEnd -= TouchpadTouchEnd;
                             break;
@@ -121,22 +121,22 @@ namespace VRTK
 
         protected virtual bool ValidPrimaryButton()
         {
-            return (controllerEvents && (primaryActivationButton == VRTK_ControllerEvents.ButtonAlias.Undefined || controllerEvents.IsButtonPressed(primaryActivationButton)));
+            return (controllerEvents != null && (primaryActivationButton == VRTK_ControllerEvents.ButtonAlias.Undefined || controllerEvents.IsButtonPressed(primaryActivationButton)));
         }
 
         protected virtual void ModifierButtonActive()
         {
-            modifierActive = (controllerEvents && actionModifierButton != VRTK_ControllerEvents.ButtonAlias.Undefined && controllerEvents.IsButtonPressed(actionModifierButton));
+            modifierActive = (controllerEvents != null && actionModifierButton != VRTK_ControllerEvents.ButtonAlias.Undefined && controllerEvents.IsButtonPressed(actionModifierButton));
         }
 
         protected virtual bool TouchpadTouched()
         {
-            return (controllerEvents && controllerEvents.IsButtonPressed(coordniateButtonAlias));
+            return (controllerEvents != null && controllerEvents.IsButtonPressed(coordniateButtonAlias));
         }
 
         protected virtual void TouchpadAxisChanged(object sender, ControllerInteractionEventArgs e)
         {
-            Vector2 actualAxis = (coordinateAxis == SDK_BaseController.Vector2Axis.Touchpad ? e.touchpadAxis : e.touchpadTwoAxis);
+            Vector2 actualAxis = (coordinateAxis == VRTK_ControllerEvents.Vector2AxisAlias.Touchpad ? e.touchpadAxis : e.touchpadTwoAxis);
             if (touchpadFirstChange && otherObjectControl != null && disableOtherControlsOnActive && actualAxis != Vector2.zero)
             {
                 otherTouchpadControlEnabledState = otherObjectControl.enabled;


### PR DESCRIPTION
The Vector2Axis from the BaseController script has now been moved to
the Controller Events script as it's only really used by the
controller events and it also requires an `Undefined` state which
wouldn't make sense in the BaseController enum.