### PR TITLE
fix(Pointers): clear cached attach point on sdk change

### DIFF
--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -272,8 +272,15 @@ namespace VRTK
         protected abstract void DestroyPointerObjects();
         protected abstract void ToggleRenderer(bool pointerState, bool actualState);
 
+        protected virtual void Awake()
+        {
+            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+        }
+
         protected virtual void OnEnable()
         {
+            cachedPointerAttachPoint = null;
+            cachedAttachedHand = SDK_BaseController.ControllerHand.None;
             defaultMaterial = Resources.Load("WorldPointer") as Material;
             makeRendererVisible.Clear();
             CreatePointerOriginTransformFollow();
@@ -289,6 +296,11 @@ namespace VRTK
             }
             controllerGrabScript = null;
             Destroy(pointerOriginTransformFollowGameObject);
+        }
+
+        protected virtual void OnDestroy()
+        {
+            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnValidate()


### PR DESCRIPTION
The cached attach point on the Base Pointer Renderer was not being
cleared when the SDK was switched so the transform follow script was
not updating to track the new hand type.

This has been fixed by clearing the cache in the `OnEnable` method
and registering the script with the SDKManager toggle method.