### PR TITLE
fix(Locomotion): eradicated vector math calculation issue

### DIFF
--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DragWorld.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DragWorld.cs
@@ -374,7 +374,7 @@ namespace VRTK
             Vector3 newPosition = controllingTransform.localPosition - Vector3.Scale((movementOffset * movementMultiplier), controllingTransform.localScale);
             controllingTransform.localPosition = new Vector3((movementPositionLock.xState ? controllingTransform.localPosition.x : newPosition.x), (movementPositionLock.yState ? controllingTransform.localPosition.y : newPosition.y), (movementPositionLock.zState ? controllingTransform.localPosition.z : newPosition.z));
             SetControllerPositions();
-        }
+Signed        }
 
         protected virtual void Rotate()
         {
@@ -386,7 +386,7 @@ namespace VRTK
             if (rotationTrackingController == TrackingController.BothControllers && VRTK_ControllerReference.IsValid(leftControllerReference) && VRTK_ControllerReference.IsValid(rightControllerReference))
             {
                 Vector2 currentRotationAngle = GetControllerRotation();
-                float newAngle = Vector2.Angle(currentRotationAngle, previousRotationAngle) * Mathf.Sign(currentRotationAngle.x * currentRotationAngle.y - previousRotationAngle.x * previousRotationAngle.y);
+                float newAngle = Vector2.SignedAngle(currentRotationAngle, previousRotationAngle);
                 RotateByAngle(newAngle);
                 previousRotationAngle = currentRotationAngle;
             }

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DragWorld.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DragWorld.cs
@@ -386,7 +386,7 @@ Signed        }
             if (rotationTrackingController == TrackingController.BothControllers && VRTK_ControllerReference.IsValid(leftControllerReference) && VRTK_ControllerReference.IsValid(rightControllerReference))
             {
                 Vector2 currentRotationAngle = GetControllerRotation();
-                float newAngle = Vector2.SignedAngle(currentRotationAngle, previousRotationAngle);
+                float newAngle = Vector2.Angle(currentRotationAngle, previousRotationAngle)*Mathf.Sign(Vector3.Cross(currentRotationAngle, previousRotationAngle).z);
                 RotateByAngle(newAngle);
                 previousRotationAngle = currentRotationAngle;
             }


### PR DESCRIPTION
The mathematical operation used to determine the change in angle between the two controllers would periodically fail when the vector would cross into a new quadrant - and CameraRig would begin rotating opposite of user intention mid-turn. 

float newAngle = Vector2.Angle(currentRotationAngle, previousRotationAngle) * Mathf.Sign(currentRotationAngle.x * currentRotationAngle.y - previousRotationAngle.x * previousRotationAngle.y);

proposed change (tested):

float newAngle = Vector2.SignedAngle(currentRotationAngle, previousRotationAngle);