### PR TITLE
fix(Highlighter): MBP highlighter not restoring material properties

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialPropertyBlockColorSwapHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialPropertyBlockColorSwapHighlighter.cs
@@ -82,10 +82,14 @@ namespace VRTK.Highlighters
             {
                 Renderer renderer = renderers[i];
                 string objectReference = renderer.gameObject.GetInstanceID().ToString();
-                MaterialPropertyBlock blankPropertyBlock = new MaterialPropertyBlock();
-                VRTK_SharedMethods.AddDictionaryValue(originalMaterialPropertyBlocks, objectReference, blankPropertyBlock, true);
-                VRTK_SharedMethods.AddDictionaryValue(highlightMaterialPropertyBlocks, objectReference, blankPropertyBlock, true);
-                renderer.GetPropertyBlock(blankPropertyBlock);
+                // get the initial material property block to restore the original material properties later on
+                MaterialPropertyBlock originalPropertyBlock = new MaterialPropertyBlock();
+                renderer.GetPropertyBlock(originalPropertyBlock);
+                VRTK_SharedMethods.AddDictionaryValue(originalMaterialPropertyBlocks, objectReference, originalPropertyBlock, true);
+                // we need a second instance of the original material property block which will be modified for highlighting
+                MaterialPropertyBlock highlightPropertyBlock = new MaterialPropertyBlock();
+                renderer.GetPropertyBlock(highlightPropertyBlock);
+                VRTK_SharedMethods.AddDictionaryValue(highlightMaterialPropertyBlocks, objectReference, highlightPropertyBlock, true);
             }
         }
 


### PR DESCRIPTION
- a bug was introduced with c40d0d8f8e91226430615e10765e55763d12d8e3 that led to materials not being correctly restored to their initial state when unhighlighting
- the reason is that two separate material property blocks need to be stored - one for restoring the intial values and one for modifying material properties during the highlight