### PR TITLE
fix(Pointers): stop direction indicator working when script disabled

### DIFF
--- a/Assets/VRTK/Prefabs/PointerDirectionIndicator/VRTK_PointerDirectionIndicator.cs
+++ b/Assets/VRTK/Prefabs/PointerDirectionIndicator/VRTK_PointerDirectionIndicator.cs
@@ -116,8 +116,15 @@ namespace VRTK
         /// <param name="validity">Determines if the colour being set is based from a valid location or invalid location.</param>
         public virtual void SetMaterialColor(Color color, bool validity)
         {
-            validLocation.SetActive(validity);
-            invalidLocation.SetActive((displayOnInvalidLocation ? !validity : validity));
+            if (validLocation != null)
+            {
+                validLocation.SetActive(validity);
+            }
+
+            if (invalidLocation != null)
+            {
+                invalidLocation.SetActive((displayOnInvalidLocation ? !validity : validity));
+            }
 
             if (usePointerColor)
             {

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -198,7 +198,7 @@ namespace VRTK
                         headsetOutOfBounds = false;
                     }
                 }
-                playAreaCursor.transform.rotation = (directionIndicator != null ? directionIndicator.transform.rotation : playArea.rotation);
+                playAreaCursor.transform.rotation = (directionIndicator != null && directionIndicator.gameObject.activeInHierarchy ? directionIndicator.transform.rotation : playArea.rotation);
                 playAreaCursor.transform.position = location + offset;
             }
         }

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
@@ -300,7 +300,10 @@ namespace VRTK
 #pragma warning restore 0618
             base.OnEnable();
             attachedTo = (attachedTo == null ? gameObject : attachedTo);
-            VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Pointer);
+            if (!VRTK_PlayerObject.IsPlayerObject(gameObject))
+            {
+                VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Pointer);
+            }
             SetDefaultValues();
 
             if (NoPointerRenderer())
@@ -389,7 +392,7 @@ namespace VRTK
 
         protected virtual Quaternion? GetCursorRotation()
         {
-            if (EnabledPointerRenderer() && pointerRenderer.directionIndicator != null)
+            if (EnabledPointerRenderer() && pointerRenderer.directionIndicator != null && pointerRenderer.directionIndicator.gameObject.activeInHierarchy)
             {
                 return pointerRenderer.directionIndicator.GetRotation();
             }


### PR DESCRIPTION
The Pointer Direction Indicator will now only work when the script
is active in the current GameObject hierarchy which is useful for
turning the direction indicator on and off by simply disabling a
container parent GameObject.