### PR TITLE
fix(Interaction): ensure the collision detector is set on custom models

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -635,7 +635,7 @@ namespace VRTK
         public virtual void Highlight(Color highlightColor)
         {
             VRTK_InteractObjectHighlighter interactObjectHighlighter = GetComponentInChildren<VRTK_InteractObjectHighlighter>();
-            if(interactObjectHighlighter != null)
+            if (interactObjectHighlighter != null)
             {
                 interactObjectHighlighter.Highlight(highlightColor);
             }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -260,6 +260,7 @@ namespace VRTK
         protected virtual void OnEnable()
         {
             destroyColliderOnDisable = false;
+            controllerCollisionDetector = (customColliderContainer != null ? customColliderContainer : controllerCollisionDetector);
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
             CreateTouchRigidBody();
             trackedController = GetComponentInParent<VRTK_TrackedController>();


### PR DESCRIPTION
The Interact Touch script was not having the custom collision detector
set if the controller model was custom. This fix ensures it is set
correctly.