### PR TITLE
fix(Presence): add null checks on colliders before ignoring collisions

### DIFF
--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -940,8 +940,14 @@ namespace VRTK
 
         protected virtual void ManagePhysicsCollider(Collider collider, bool state)
         {
-            Physics.IgnoreCollision(bodyCollider, collider, state);
-            Physics.IgnoreCollision(footCollider, collider, state);
+            if (bodyCollider != null)
+            {
+                Physics.IgnoreCollision(bodyCollider, collider, state);
+            }
+            if (footCollider != null)
+            {
+                Physics.IgnoreCollision(footCollider, collider, state);
+            }
         }
 
         protected virtual void CheckStepUpCollision(Collision collision)


### PR DESCRIPTION
The Body Physics script would crash if no foot collider was created
because it would attempt to ignore collisions on a null object.