### PR TITLE
feat(Presence): add policy list to headset collision fade

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -7488,6 +7488,7 @@ Initiates a fade of the headset view when a headset collision event is detected.
  * **Time Till Fade:** The amount of time to wait until a fade occurs.
  * **Blink Transition Speed:** The fade blink speed on collision.
  * **Fade Color:** The colour to fade the headset to on collision.
+ * **Target List Policy:** A specified VRTK_PolicyList to use to determine whether any objects will be acted upon by the Headset Collision Fade.
  * **Headset Collision:** The VRTK Headset Collision script to use when determining headset collisions. If this is left blank then the script will need to be applied to the same GameObject.
  * **Headset Fade:** The VRTK Headset Fade script to use when fading the headset. If this is left blank then the script will need to be applied to the same GameObject.
 

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetCollisionFade.cs
@@ -28,6 +28,8 @@ namespace VRTK
         public float blinkTransitionSpeed = 0.1f;
         [Tooltip("The colour to fade the headset to on collision.")]
         public Color fadeColor = Color.black;
+        [Tooltip("A specified VRTK_PolicyList to use to determine whether any objects will be acted upon by the Headset Collision Fade.")]
+        public VRTK_PolicyList targetListPolicy;
 
         [Header("Custom Settings")]
 
@@ -68,18 +70,29 @@ namespace VRTK
 
         protected virtual void OnHeadsetCollisionDetect(object sender, HeadsetCollisionEventArgs e)
         {
-            Invoke("StartFade", timeTillFade);
+            if (ValidTarget(e.collider))
+            {
+                Invoke("StartFade", timeTillFade);
+            }
         }
 
         protected virtual void OnHeadsetCollisionEnded(object sender, HeadsetCollisionEventArgs e)
         {
-            CancelInvoke("StartFade");
-            headsetFade.Unfade(blinkTransitionSpeed);
+            if (ValidTarget(e.collider))
+            {
+                CancelInvoke("StartFade");
+                headsetFade.Unfade(blinkTransitionSpeed);
+            }
         }
 
         protected virtual void StartFade()
         {
             headsetFade.Fade(fadeColor, blinkTransitionSpeed);
+        }
+
+        protected virtual bool ValidTarget(Collider target)
+        {
+            return (target != null && !(VRTK_PolicyList.Check(target.gameObject, targetListPolicy)));
         }
     }
 }


### PR DESCRIPTION
The Headset Collision Fade script can now accept a policy list to
determine which targets cause the headset fade on collision.