### PR TITLE
feat(Teleport): added teleport transform override

### DIFF
--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -47,6 +47,8 @@ namespace VRTK
         public VRTK_PolicyList targetListPolicy;
         [Tooltip("An optional NavMeshData object that will be utilised for limiting the teleport to within any scene NavMesh.")]
         public VRTK_NavMeshData navMeshData;
+        [Tooltip("This is the transform that will be moved when a Teleport occurs. Be default this is the vr play area.")]
+        public Transform TransformToTeleport;
 
         [System.Obsolete("`VRTK_BasicTeleport.navMeshLimitDistance` is no longer used, use `VRTK_BasicTeleport.processNavMesh` instead. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
@@ -62,7 +64,6 @@ namespace VRTK
         public event TeleportEventHandler Teleported;
 
         protected Transform headset;
-        protected Transform playArea;
         protected bool adjustYForTerrain = false;
         protected bool enableTeleport = true;
 
@@ -184,7 +185,7 @@ namespace VRTK
             Blink(blinkTransitionSpeed);
             if (ValidRigObjects())
             {
-                playArea.position = finalDestination;
+                TransformToTeleport.position = finalDestination;
             }
             ProcessOrientation(this, teleportArgs, finalDestination, updatedRotation);
             EndTeleport(this, teleportArgs);
@@ -219,7 +220,7 @@ namespace VRTK
         {
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
             headset = VRTK_SharedMethods.AddCameraFade();
-            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+            TransformToTeleport = VRTK_DeviceFinder.PlayAreaTransform();
 
             adjustYForTerrain = false;
             enableTeleport = true;
@@ -255,7 +256,7 @@ namespace VRTK
         protected virtual DestinationMarkerEventArgs BuildTeleportArgs(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null, bool forceDestinationPosition = false)
         {
             DestinationMarkerEventArgs teleportArgs = new DestinationMarkerEventArgs();
-            teleportArgs.distance = (ValidRigObjects() ? Vector3.Distance(new Vector3(headset.position.x, playArea.position.y, headset.position.z), destinationPosition) : 0f);
+            teleportArgs.distance = (ValidRigObjects() ? Vector3.Distance(new Vector3(headset.position.x, TransformToTeleport.position.y, headset.position.z), destinationPosition) : 0f);
             teleportArgs.target = target;
             teleportArgs.raycastHit = new RaycastHit();
             teleportArgs.destinationPosition = destinationPosition;
@@ -272,7 +273,7 @@ namespace VRTK
                 VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "VRTK_BasicTeleport", "rig headset", ". Are you trying to access the headset before the SDK Manager has initialised it?"));
                 return false;
             }
-            if (playArea == null)
+            if (TransformToTeleport == null)
             {
                 VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "VRTK_BasicTeleport", "rig boundaries", ". Are you trying to access the boundaries before the SDK Manager has initialised it?"));
                 return false;
@@ -319,8 +320,8 @@ namespace VRTK
         {
             if (ValidRigObjects())
             {
-                playArea.position = CheckTerrainCollision(position, target, forceDestinationPosition);
-                return playArea.position;
+                TransformToTeleport.position = CheckTerrainCollision(position, target, forceDestinationPosition);
+                return TransformToTeleport.position;
             }
             return Vector3.zero;
         }
@@ -331,9 +332,9 @@ namespace VRTK
             {
                 if (rotation != null)
                 {
-                    playArea.rotation = (Quaternion)rotation;
+                    TransformToTeleport.rotation = (Quaternion)rotation;
                 }
-                return playArea.rotation;
+                return TransformToTeleport.rotation;
             }
             return Quaternion.identity;
         }
@@ -345,7 +346,7 @@ namespace VRTK
                 return tipPosition;
             }
 
-            return GetCompensatedPosition(tipPosition, playArea.position);
+            return GetCompensatedPosition(tipPosition, TransformToTeleport.position);
         }
 
         protected virtual Vector3 GetCompensatedPosition(Vector3 givenPosition, Vector3 defaultPosition)
@@ -356,9 +357,9 @@ namespace VRTK
 
             if (ValidRigObjects())
             {
-                newX = (headsetPositionCompensation ? (givenPosition.x - (headset.position.x - playArea.position.x)) : givenPosition.x);
+                newX = (headsetPositionCompensation ? (givenPosition.x - (headset.position.x - TransformToTeleport.position.x)) : givenPosition.x);
                 newY = defaultPosition.y;
-                newZ = (headsetPositionCompensation ? (givenPosition.z - (headset.position.z - playArea.position.z)) : givenPosition.z);
+                newZ = (headsetPositionCompensation ? (givenPosition.z - (headset.position.z - TransformToTeleport.position.z)) : givenPosition.z);
             }
 
             return new Vector3(newX, newY, newZ);
@@ -398,7 +399,7 @@ namespace VRTK
             if (distanceBlinkDelay > 0f)
             {
                 float minBlink = 0.5f;
-                float distance = (ValidRigObjects() ? Vector3.Distance(playArea.position, newPosition) : 0f);
+                float distance = (ValidRigObjects() ? Vector3.Distance(TransformToTeleport.position, newPosition) : 0f);
                 blinkPause = Mathf.Clamp((distance * blinkTransitionSpeed) / (maxBlinkDistance - distanceBlinkDelay), minBlink, maxBlinkTransitionSpeed);
                 blinkPause = (blinkSpeed <= 0.25 ? minBlink : blinkPause);
             }

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -48,7 +48,7 @@ namespace VRTK
         [Tooltip("An optional NavMeshData object that will be utilised for limiting the teleport to within any scene NavMesh.")]
         public VRTK_NavMeshData navMeshData;
         [Tooltip("This is the transform that will be moved when a Teleport occurs. Be default this is the vr play area.")]
-        public Transform TransformToTeleport;
+        public Transform transformToTeleport;
 
         [System.Obsolete("`VRTK_BasicTeleport.navMeshLimitDistance` is no longer used, use `VRTK_BasicTeleport.processNavMesh` instead. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
@@ -185,7 +185,7 @@ namespace VRTK
             Blink(blinkTransitionSpeed);
             if (ValidRigObjects())
             {
-                TransformToTeleport.position = finalDestination;
+                transformToTeleport.position = finalDestination;
             }
             ProcessOrientation(this, teleportArgs, finalDestination, updatedRotation);
             EndTeleport(this, teleportArgs);
@@ -220,7 +220,11 @@ namespace VRTK
         {
             VRTK_PlayerObject.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
             headset = VRTK_SharedMethods.AddCameraFade();
-            TransformToTeleport = VRTK_DeviceFinder.PlayAreaTransform();
+
+            if (transformToTeleport == null)
+            {
+                transformToTeleport = VRTK_DeviceFinder.PlayAreaTransform();
+            }
 
             adjustYForTerrain = false;
             enableTeleport = true;
@@ -256,7 +260,7 @@ namespace VRTK
         protected virtual DestinationMarkerEventArgs BuildTeleportArgs(Transform target, Vector3 destinationPosition, Quaternion? destinationRotation = null, bool forceDestinationPosition = false)
         {
             DestinationMarkerEventArgs teleportArgs = new DestinationMarkerEventArgs();
-            teleportArgs.distance = (ValidRigObjects() ? Vector3.Distance(new Vector3(headset.position.x, TransformToTeleport.position.y, headset.position.z), destinationPosition) : 0f);
+            teleportArgs.distance = (ValidRigObjects() ? Vector3.Distance(new Vector3(headset.position.x, transformToTeleport.position.y, headset.position.z), destinationPosition) : 0f);
             teleportArgs.target = target;
             teleportArgs.raycastHit = new RaycastHit();
             teleportArgs.destinationPosition = destinationPosition;
@@ -273,7 +277,7 @@ namespace VRTK
                 VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "VRTK_BasicTeleport", "rig headset", ". Are you trying to access the headset before the SDK Manager has initialised it?"));
                 return false;
             }
-            if (TransformToTeleport == null)
+            if (transformToTeleport == null)
             {
                 VRTK_Logger.Warn(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "VRTK_BasicTeleport", "rig boundaries", ". Are you trying to access the boundaries before the SDK Manager has initialised it?"));
                 return false;
@@ -320,8 +324,8 @@ namespace VRTK
         {
             if (ValidRigObjects())
             {
-                TransformToTeleport.position = CheckTerrainCollision(position, target, forceDestinationPosition);
-                return TransformToTeleport.position;
+                transformToTeleport.position = CheckTerrainCollision(position, target, forceDestinationPosition);
+                return transformToTeleport.position;
             }
             return Vector3.zero;
         }
@@ -332,9 +336,9 @@ namespace VRTK
             {
                 if (rotation != null)
                 {
-                    TransformToTeleport.rotation = (Quaternion)rotation;
+                    transformToTeleport.rotation = (Quaternion)rotation;
                 }
-                return TransformToTeleport.rotation;
+                return transformToTeleport.rotation;
             }
             return Quaternion.identity;
         }
@@ -346,7 +350,7 @@ namespace VRTK
                 return tipPosition;
             }
 
-            return GetCompensatedPosition(tipPosition, TransformToTeleport.position);
+            return GetCompensatedPosition(tipPosition, transformToTeleport.position);
         }
 
         protected virtual Vector3 GetCompensatedPosition(Vector3 givenPosition, Vector3 defaultPosition)
@@ -357,9 +361,9 @@ namespace VRTK
 
             if (ValidRigObjects())
             {
-                newX = (headsetPositionCompensation ? (givenPosition.x - (headset.position.x - TransformToTeleport.position.x)) : givenPosition.x);
+                newX = (headsetPositionCompensation ? (givenPosition.x - (headset.position.x - transformToTeleport.position.x)) : givenPosition.x);
                 newY = defaultPosition.y;
-                newZ = (headsetPositionCompensation ? (givenPosition.z - (headset.position.z - TransformToTeleport.position.z)) : givenPosition.z);
+                newZ = (headsetPositionCompensation ? (givenPosition.z - (headset.position.z - transformToTeleport.position.z)) : givenPosition.z);
             }
 
             return new Vector3(newX, newY, newZ);
@@ -399,7 +403,7 @@ namespace VRTK
             if (distanceBlinkDelay > 0f)
             {
                 float minBlink = 0.5f;
-                float distance = (ValidRigObjects() ? Vector3.Distance(TransformToTeleport.position, newPosition) : 0f);
+                float distance = (ValidRigObjects() ? Vector3.Distance(transformToTeleport.position, newPosition) : 0f);
                 blinkPause = Mathf.Clamp((distance * blinkTransitionSpeed) / (maxBlinkDistance - distanceBlinkDelay), minBlink, maxBlinkTransitionSpeed);
                 blinkPause = (blinkSpeed <= 0.25 ? minBlink : blinkPause);
             }

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DashTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DashTeleport.cs
@@ -103,7 +103,7 @@ namespace VRTK
         {
             if (ValidRigObjects())
             {
-                return (rotation != null ? (Quaternion)rotation : TransformToTeleport.rotation);
+                return (rotation != null ? (Quaternion)rotation : transformToTeleport.rotation);
             }
             return Quaternion.identity;
         }
@@ -118,7 +118,7 @@ namespace VRTK
             if (ValidRigObjects())
             {
                 Vector3 finalPosition = CalculateOffsetPosition(targetPosition, targetRotation);
-                attemptLerpRoutine = StartCoroutine(lerpToPosition(sender, e, TransformToTeleport.position, finalPosition, TransformToTeleport.rotation, targetRotation));
+                attemptLerpRoutine = StartCoroutine(lerpToPosition(sender, e, transformToTeleport.position, finalPosition, transformToTeleport.rotation, targetRotation));
             }
         }
 
@@ -129,8 +129,8 @@ namespace VRTK
                 return targetPosition;
             }
 
-            Vector3 playerOffset = new Vector3(headset.position.x - TransformToTeleport.position.x, 0, headset.position.z - TransformToTeleport.position.z);
-            Quaternion relativeRotation = Quaternion.Inverse(TransformToTeleport.rotation) * targetRotation;
+            Vector3 playerOffset = new Vector3(headset.position.x - transformToTeleport.position.x, 0, headset.position.z - transformToTeleport.position.z);
+            Quaternion relativeRotation = Quaternion.Inverse(transformToTeleport.rotation) * targetRotation;
             Vector3 adjustedOffset = relativeRotation * playerOffset;
             return targetPosition - (adjustedOffset - playerOffset);
         }
@@ -146,13 +146,13 @@ namespace VRTK
 
             // Find the objects we will be dashing through and broadcast them via events
             Vector3 eyeCameraPosition = headset.transform.position;
-            Vector3 eyeCameraPositionOnGround = new Vector3(eyeCameraPosition.x, TransformToTeleport.position.y, eyeCameraPosition.z);
-            Vector3 eyeCameraRelativeToRig = eyeCameraPosition - TransformToTeleport.position;
+            Vector3 eyeCameraPositionOnGround = new Vector3(eyeCameraPosition.x, transformToTeleport.position.y, eyeCameraPosition.z);
+            Vector3 eyeCameraRelativeToRig = eyeCameraPosition - transformToTeleport.position;
             Vector3 targetEyeCameraPosition = targetPosition + eyeCameraRelativeToRig;
             Vector3 direction = (targetEyeCameraPosition - eyeCameraPosition).normalized;
             Vector3 bottomPoint = eyeCameraPositionOnGround + (Vector3.up * capsuleBottomOffset) + direction;
             Vector3 topPoint = eyeCameraPosition + (Vector3.up * capsuleTopOffset) + direction;
-            float maxDistance = Vector3.Distance(TransformToTeleport.position, targetPosition - direction * 0.5f);
+            float maxDistance = Vector3.Distance(transformToTeleport.position, targetPosition - direction * 0.5f);
             RaycastHit[] allHits = Physics.CapsuleCastAll(bottomPoint, topPoint, capsuleRadius, direction, maxDistance);
 
             for (int i = 0; i < allHits.Length; i++)
@@ -173,15 +173,15 @@ namespace VRTK
 
             while (currentLerpedTime < 1f)
             {
-                TransformToTeleport.position = Vector3.Lerp(startPosition, targetPosition, currentLerpedTime);
-                TransformToTeleport.rotation = Quaternion.Lerp(startRotation, targetRotation, currentLerpedTime);
+                transformToTeleport.position = Vector3.Lerp(startPosition, targetPosition, currentLerpedTime);
+                transformToTeleport.rotation = Quaternion.Lerp(startRotation, targetRotation, currentLerpedTime);
                 elapsedTime += Time.deltaTime;
                 currentLerpedTime = elapsedTime / lerpTime;
                 yield return delayInstruction;
             }
 
-            TransformToTeleport.position = targetPosition;
-            TransformToTeleport.rotation = targetRotation;
+            transformToTeleport.position = targetPosition;
+            transformToTeleport.rotation = targetRotation;
 
             if (gameObjectInTheWay)
             {

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DashTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DashTeleport.cs
@@ -103,7 +103,7 @@ namespace VRTK
         {
             if (ValidRigObjects())
             {
-                return (rotation != null ? (Quaternion)rotation : playArea.rotation);
+                return (rotation != null ? (Quaternion)rotation : TransformToTeleport.rotation);
             }
             return Quaternion.identity;
         }
@@ -118,7 +118,7 @@ namespace VRTK
             if (ValidRigObjects())
             {
                 Vector3 finalPosition = CalculateOffsetPosition(targetPosition, targetRotation);
-                attemptLerpRoutine = StartCoroutine(lerpToPosition(sender, e, playArea.position, finalPosition, playArea.rotation, targetRotation));
+                attemptLerpRoutine = StartCoroutine(lerpToPosition(sender, e, TransformToTeleport.position, finalPosition, TransformToTeleport.rotation, targetRotation));
             }
         }
 
@@ -129,8 +129,8 @@ namespace VRTK
                 return targetPosition;
             }
 
-            Vector3 playerOffset = new Vector3(headset.position.x - playArea.position.x, 0, headset.position.z - playArea.position.z);
-            Quaternion relativeRotation = Quaternion.Inverse(playArea.rotation) * targetRotation;
+            Vector3 playerOffset = new Vector3(headset.position.x - TransformToTeleport.position.x, 0, headset.position.z - TransformToTeleport.position.z);
+            Quaternion relativeRotation = Quaternion.Inverse(TransformToTeleport.rotation) * targetRotation;
             Vector3 adjustedOffset = relativeRotation * playerOffset;
             return targetPosition - (adjustedOffset - playerOffset);
         }
@@ -146,13 +146,13 @@ namespace VRTK
 
             // Find the objects we will be dashing through and broadcast them via events
             Vector3 eyeCameraPosition = headset.transform.position;
-            Vector3 eyeCameraPositionOnGround = new Vector3(eyeCameraPosition.x, playArea.position.y, eyeCameraPosition.z);
-            Vector3 eyeCameraRelativeToRig = eyeCameraPosition - playArea.position;
+            Vector3 eyeCameraPositionOnGround = new Vector3(eyeCameraPosition.x, TransformToTeleport.position.y, eyeCameraPosition.z);
+            Vector3 eyeCameraRelativeToRig = eyeCameraPosition - TransformToTeleport.position;
             Vector3 targetEyeCameraPosition = targetPosition + eyeCameraRelativeToRig;
             Vector3 direction = (targetEyeCameraPosition - eyeCameraPosition).normalized;
             Vector3 bottomPoint = eyeCameraPositionOnGround + (Vector3.up * capsuleBottomOffset) + direction;
             Vector3 topPoint = eyeCameraPosition + (Vector3.up * capsuleTopOffset) + direction;
-            float maxDistance = Vector3.Distance(playArea.position, targetPosition - direction * 0.5f);
+            float maxDistance = Vector3.Distance(TransformToTeleport.position, targetPosition - direction * 0.5f);
             RaycastHit[] allHits = Physics.CapsuleCastAll(bottomPoint, topPoint, capsuleRadius, direction, maxDistance);
 
             for (int i = 0; i < allHits.Length; i++)
@@ -173,15 +173,15 @@ namespace VRTK
 
             while (currentLerpedTime < 1f)
             {
-                playArea.position = Vector3.Lerp(startPosition, targetPosition, currentLerpedTime);
-                playArea.rotation = Quaternion.Lerp(startRotation, targetRotation, currentLerpedTime);
+                TransformToTeleport.position = Vector3.Lerp(startPosition, targetPosition, currentLerpedTime);
+                TransformToTeleport.rotation = Quaternion.Lerp(startRotation, targetRotation, currentLerpedTime);
                 elapsedTime += Time.deltaTime;
                 currentLerpedTime = elapsedTime / lerpTime;
                 yield return delayInstruction;
             }
 
-            playArea.position = targetPosition;
-            playArea.rotation = targetRotation;
+            TransformToTeleport.position = targetPosition;
+            TransformToTeleport.rotation = targetRotation;
 
             if (gameObjectInTheWay)
             {

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -58,20 +58,20 @@ namespace VRTK
 
         protected virtual void AdjustForParentOffset()
         {
-            if (snapToNearestFloor && applyPlayareaParentOffset && playArea != null && playArea.parent != null)
+            if (snapToNearestFloor && applyPlayareaParentOffset && TransformToTeleport != null && TransformToTeleport.parent != null)
             {
-                Ray ray = new Ray(playArea.parent.position, -playArea.up);
+                Ray ray = new Ray(TransformToTeleport.parent.position, -TransformToTeleport.up);
                 RaycastHit rayCollidedWith;
                 if (VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, Physics.IgnoreRaycastLayer, Mathf.Infinity, QueryTriggerInteraction.Ignore))
                 {
-                    playArea.position = new Vector3(playArea.position.x, playArea.position.y + rayCollidedWith.point.y, playArea.position.z);
+                    TransformToTeleport.position = new Vector3(TransformToTeleport.position.x, TransformToTeleport.position.y + rayCollidedWith.point.y, TransformToTeleport.position.z);
                 }
             }
         }
 
         protected virtual float GetParentOffset()
         {
-            return (applyPlayareaParentOffset && playArea.parent != null ? playArea.parent.transform.localPosition.y : 0f);
+            return (applyPlayareaParentOffset && TransformToTeleport.parent != null ? TransformToTeleport.parent.transform.localPosition.y : 0f);
         }
 
         protected virtual float GetTeleportY(Transform target, Vector3 tipPosition)
@@ -82,11 +82,11 @@ namespace VRTK
                 return tipPosition.y + parentOffset;
             }
 
-            float newY = playArea.position.y;
+            float newY = TransformToTeleport.position.y;
             float heightOffset = 0.1f;
             //Check to see if the tip is on top of an object
             Vector3 rayStartPositionOffset = Vector3.up * heightOffset;
-            Ray ray = new Ray(tipPosition + rayStartPositionOffset, -playArea.up);
+            Ray ray = new Ray(tipPosition + rayStartPositionOffset, -TransformToTeleport.up);
             RaycastHit rayCollidedWith;
             if (target != null && VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, Physics.IgnoreRaycastLayer, Mathf.Infinity, QueryTriggerInteraction.Ignore))
             {

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_HeightAdjustTeleport.cs
@@ -58,20 +58,20 @@ namespace VRTK
 
         protected virtual void AdjustForParentOffset()
         {
-            if (snapToNearestFloor && applyPlayareaParentOffset && TransformToTeleport != null && TransformToTeleport.parent != null)
+            if (snapToNearestFloor && applyPlayareaParentOffset && transformToTeleport != null && transformToTeleport.parent != null)
             {
-                Ray ray = new Ray(TransformToTeleport.parent.position, -TransformToTeleport.up);
+                Ray ray = new Ray(transformToTeleport.parent.position, -transformToTeleport.up);
                 RaycastHit rayCollidedWith;
                 if (VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, Physics.IgnoreRaycastLayer, Mathf.Infinity, QueryTriggerInteraction.Ignore))
                 {
-                    TransformToTeleport.position = new Vector3(TransformToTeleport.position.x, TransformToTeleport.position.y + rayCollidedWith.point.y, TransformToTeleport.position.z);
+                    transformToTeleport.position = new Vector3(transformToTeleport.position.x, transformToTeleport.position.y + rayCollidedWith.point.y, transformToTeleport.position.z);
                 }
             }
         }
 
         protected virtual float GetParentOffset()
         {
-            return (applyPlayareaParentOffset && TransformToTeleport.parent != null ? TransformToTeleport.parent.transform.localPosition.y : 0f);
+            return (applyPlayareaParentOffset && transformToTeleport.parent != null ? transformToTeleport.parent.transform.localPosition.y : 0f);
         }
 
         protected virtual float GetTeleportY(Transform target, Vector3 tipPosition)
@@ -82,11 +82,11 @@ namespace VRTK
                 return tipPosition.y + parentOffset;
             }
 
-            float newY = TransformToTeleport.position.y;
+            float newY = transformToTeleport.position.y;
             float heightOffset = 0.1f;
             //Check to see if the tip is on top of an object
             Vector3 rayStartPositionOffset = Vector3.up * heightOffset;
-            Ray ray = new Ray(tipPosition + rayStartPositionOffset, -TransformToTeleport.up);
+            Ray ray = new Ray(tipPosition + rayStartPositionOffset, -transformToTeleport.up);
             RaycastHit rayCollidedWith;
             if (target != null && VRTK_CustomRaycast.Raycast(customRaycast, ray, out rayCollidedWith, Physics.IgnoreRaycastLayer, Mathf.Infinity, QueryTriggerInteraction.Ignore))
             {


### PR DESCRIPTION
Added the ability to specify which transform is moved when teleporting. This allows teleporting to work in situations where the top level parent gameobject must be moved not just the vr play area. Defaults to the vr play area.

Note: I needed to make this change for my game to work correctly since the position of the parent object that contained VTRK is what is tracked over the network.