### PR TITLE
Fix #1418.  Set controllerReference for later.

### DIFF
--- a/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Scripts/Pointers/VRTK_Pointer.cs
@@ -514,9 +514,9 @@ namespace VRTK
         protected virtual void DoActivationButtonPressed(object sender, ControllerInteractionEventArgs e)
         {
             OnActivationButtonPressed(controller.SetControllerEvent(ref activationButtonPressed, true));
+	    controllerReference = e.controllerReference; // needed in case the renderer is enabled later
             if (EnabledPointerRenderer())
             {
-                controllerReference = e.controllerReference;
                 Toggle(true);
             }
         }


### PR DESCRIPTION
VRTK_Pointer::DoActivationButtonPressed() should set controllerReference in case renderer is enabled later.