### PR TITLE
chore(Input): provide correct docs on input overrides

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -9799,7 +9799,8 @@ The SetStateByControllerReference method sets the object state based on the cont
 Provides the ability to switch button mappings based on the current SDK or controller type
 
 **Script Usage:**
- * Place the `VRTK_PlayerClimb` script on any active scene GameObject.
+ * Place the `VRTK_SDKInputOverride` script on any active scene GameObject.
+ * Customise the input button for each script type for each SDK controller type.
 
 ### Inspector Parameters
 

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKInputOverride.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKInputOverride.cs
@@ -40,7 +40,8 @@ namespace VRTK
     /// </summary>
     /// <remarks>
     /// **Script Usage:**
-    ///  * Place the `VRTK_PlayerClimb` script on any active scene GameObject.
+    ///  * Place the `VRTK_SDKInputOverride` script on any active scene GameObject.
+    ///  * Customise the input button for each script type for each SDK controller type.
     /// </remarks>
     public class VRTK_SDKInputOverride : VRTK_SDKControllerReady
     {


### PR DESCRIPTION
The Input Overrides docs were incorrect, this ensures they make
sense.