### PR TITLE
refactor(Pointers): move activation button logic to separate method

### DIFF
--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
@@ -552,26 +552,36 @@ namespace VRTK
             }
         }
 
-        protected virtual void DoActivationButtonPressed(object sender, ControllerInteractionEventArgs e)
+        protected virtual void PointerActivated()
         {
-            OnActivationButtonPressed(controllerEvents.SetControllerEvent(ref activationButtonPressed, true));
             if (EnabledPointerRenderer())
             {
-                controllerReference = e.controllerReference;
                 Toggle(true);
             }
         }
 
-        protected virtual void DoActivationButtonReleased(object sender, ControllerInteractionEventArgs e)
+        protected virtual void PointerDeactivated()
         {
             if (EnabledPointerRenderer())
             {
-                controllerReference = e.controllerReference;
                 if (IsPointerActive())
                 {
                     Toggle(false);
                 }
             }
+        }
+
+        protected virtual void DoActivationButtonPressed(object sender, ControllerInteractionEventArgs e)
+        {
+            controllerReference = e.controllerReference;
+            OnActivationButtonPressed(controllerEvents.SetControllerEvent(ref activationButtonPressed, true));
+            PointerActivated();
+        }
+
+        protected virtual void DoActivationButtonReleased(object sender, ControllerInteractionEventArgs e)
+        {
+            controllerReference = e.controllerReference;
+            PointerDeactivated();
             OnActivationButtonReleased(controllerEvents.SetControllerEvent(ref activationButtonPressed, false));
         }
 


### PR DESCRIPTION
The activation logic has been moved from the button callback method
to it's own separate method as this helps decouple the logic.