### PR TITLE
fix(Pointers): update positions every frame to handle moving players

### DIFF
--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -606,7 +606,7 @@ namespace VRTK
             pointerOriginTransformFollowGameObject = new GameObject(VRTK_SharedMethods.GenerateVRTKObjectName(true, gameObject.name, "BasePointerRenderer_Origin_Smoothed"));
             pointerOriginTransformFollow = pointerOriginTransformFollowGameObject.AddComponent<VRTK_TransformFollow>();
             pointerOriginTransformFollow.enabled = false;
-            pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnLateUpdate;
+            pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnFixedUpdate;
             pointerOriginTransformFollow.followsScale = false;
         }
 

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -606,7 +606,7 @@ namespace VRTK
             pointerOriginTransformFollowGameObject = new GameObject(VRTK_SharedMethods.GenerateVRTKObjectName(true, gameObject.name, "BasePointerRenderer_Origin_Smoothed"));
             pointerOriginTransformFollow = pointerOriginTransformFollowGameObject.AddComponent<VRTK_TransformFollow>();
             pointerOriginTransformFollow.enabled = false;
-            pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnFixedUpdate;
+            pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnLateUpdate;
             pointerOriginTransformFollow.followsScale = false;
         }
 


### PR DESCRIPTION
Players can be attached or set to follow a moving objects.
(e.g. player inside a car).

When that happens, the pointer origin was not updated every frame 
and that caused a ghosting effect.

Moving from fixedUpdate to lateUpdate fixed this issue.