### PR TITLE
fix(ui canvas): check for missing camera

### DIFF
--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -25,7 +25,7 @@
 
         public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
         {
-            if (canvas == null)
+            if (canvas == null || eventCamera==null)
             {
                 return;
             }

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -25,7 +25,7 @@
 
         public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
         {
-            if (canvas == null || eventCamera==null)
+            if (canvas == null)
             {
                 return;
             }

--- a/UnityPackageManager/manifest.json
+++ b/UnityPackageManager/manifest.json
@@ -1,4 +1,0 @@
-{
-	"dependencies": {
-	}
-}

--- a/UnityPackageManager/manifest.json
+++ b/UnityPackageManager/manifest.json
@@ -1,0 +1,4 @@
+{
+	"dependencies": {
+	}
+}


### PR DESCRIPTION
When working with additive scenes there is null exception if:
-  first scene has a UICanvas, but no camera
- second scene is the one with a camera

As soon as the first scene is loaded, the raycast gives an error
because trying to do an update but there is no camera from 
where to start the raycast.

The error stops after the second scene is loaded.
- Verified that adding a camera to the first prevents the error

I checked the implementation of the unity GraphicRaycaster
and they have a check for the eventCamera been null,
in which case, they use a width/height of the display.