### PR TITLE
fix(UI): check for error with null event camera

### DIFF
--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -25,7 +25,7 @@
 
         public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
         {
-            if (canvas == null)
+            if (canvas == null || eventCamera == null)
             {
                 return;
             }


### PR DESCRIPTION
When working with additive scenes there is null exception if:

- first scene has a UICanvas, but no camera
- second scene is the one with a camera

As soon as the first scene is loaded, the raycast gives an error
because trying to do an update but there is no camera.
The error stops after the second scene is loaded.

Thanks to @interillusion for the fix.