### PR TITLE
refactor(Structure): move obsolete parameters to bottom of inspector

### DIFF
--- a/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
@@ -94,6 +94,8 @@ namespace VRTK
         [Tooltip("If this is checked then the tooltips will be hidden when the headset is not looking at the controller.")]
         public bool hideWhenNotInView = true;
 
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`VRTK_ControllerTooltips.retryInitMaxTries` has been deprecated as tooltip initialisation now uses the `VRTK_TrackedController.ControllerModelAvailable` event.")]
         [ObsoleteInspector]
         public int retryInitMaxTries = 10;

--- a/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
+++ b/Assets/VRTK/Prefabs/SnapDropZone/VRTK_SnapDropZone.cs
@@ -82,6 +82,8 @@ namespace VRTK
         [Tooltip("The Interactable Object to snap into the dropzone when the drop zone is enabled. The Interactable Object must be valid in any given policy list to snap.")]
         public VRTK_InteractableObject defaultSnappedInteractableObject;
 
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`VRTK_SnapDropZone.defaultSnappedObject` has been replaced with the `VRTK_SnapDropZone.defaultSnappedInteractableObject`. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public GameObject defaultSnappedObject;

--- a/Assets/VRTK/Source/Editor/VRTK_SDKManagerEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKManagerEditor.cs
@@ -160,9 +160,6 @@
             serializedObject.Update();
 
             VRTK_SDKManager sdkManager = (VRTK_SDKManager)target;
-
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("persistOnLoad"));
-
             const string manageNowButtonText = "Manage Now";
 
             using (new EditorGUILayout.VerticalScope("Box"))
@@ -418,6 +415,8 @@
                     EditorGUILayout.PropertyField(excludeTargetGroups.GetArrayElementAtIndex(i));
                 }
             }
+
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("persistOnLoad"));
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/SecondaryControllerGrabActions/VRTK_AxisScaleGrabAction.cs
@@ -24,6 +24,9 @@ namespace VRTK.SecondaryControllerGrabActions
         public Vector3State lockAxis = Vector3State.False;
         [Tooltip("If checked all the axes will be scaled together (unless locked)")]
         public bool uniformScaling = false;
+
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`VRTK_AxisScaleGrabAction.lockXAxis` has been replaced with the `VRTK_AxisScaleGrabAction.lockAxis`. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public bool lockXAxis = false;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectHighlighter.cs
@@ -67,6 +67,8 @@ namespace VRTK
         [Tooltip("An optional Highlighter to use when highlighting the specified Object. If this is left blank, then the first active highlighter on the same GameObject will be used, if one isn't found then a Material Color Swap Highlighter will be created at runtime.")]
         public VRTK_BaseHighlighter objectHighlighter;
 
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`objectToAffect` has been replaced with `objectToHighlight`. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public VRTK_InteractableObject objectToAffect;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -160,10 +160,6 @@ namespace VRTK
         [Tooltip("An array of colliders on the GameObject to ignore when being touched.")]
         public Collider[] ignoredColliders;
 
-        [System.Obsolete("`VRTK_InteractableObject.touchHighlightColor` has been replaced with `VRTK_InteractObjectHighlighter.touchHighlight`. This parameter will be removed in a future version of VRTK.")]
-        [ObsoleteInspector]
-        public Color touchHighlightColor = Color.clear;
-
         [Header("Grab Settings")]
 
         [Tooltip("Determines if the Interactable Object can be grabbed.")]
@@ -198,11 +194,14 @@ namespace VRTK
         [Tooltip("Determines which controller can initiate a use action.")]
         public AllowedController allowedUseControllers = AllowedController.Both;
 
-        [Header("Custom Settings")]
+        [Header("Obsolete Settings")]
 
         [System.Obsolete("`VRTK_InteractableObject.objectHighlighter` has been replaced with `VRTK_InteractObjectHighlighter.objectHighlighter`. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public Highlighters.VRTK_BaseHighlighter objectHighlighter;
+        [System.Obsolete("`VRTK_InteractableObject.touchHighlightColor` has been replaced with `VRTK_InteractObjectHighlighter.touchHighlight`. This parameter will be removed in a future version of VRTK.")]
+        [ObsoleteInspector]
+        public Color touchHighlightColor = Color.clear;
 
         protected Rigidbody interactableRigidbody;
         protected HashSet<GameObject> currentIgnoredColliders = new HashSet<GameObject>();

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -48,6 +48,8 @@ namespace VRTK
         [Tooltip("An optional NavMeshData object that will be utilised for limiting the teleport to within any scene NavMesh.")]
         public VRTK_NavMeshData navMeshData;
 
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`VRTK_BasicTeleport.navMeshLimitDistance` is no longer used, use `VRTK_BasicTeleport.processNavMesh` instead. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public float navMeshLimitDistance = 0f;

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
@@ -65,6 +65,8 @@ namespace VRTK
         [Tooltip("A custom transform to use as the origin of the pointer. If no pointer origin transform is provided then the transform the script is attached to is used.")]
         public Transform customOrigin;
 
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`VRTK_Pointer.controller` has been replaced with `VRTK_Pointer.controllerEvents`. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public VRTK_ControllerEvents controller;

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
@@ -113,6 +113,8 @@ namespace VRTK
         [Tooltip("A custom transform to use as the origin of the pointer. If no pointer origin transform is provided then the transform the script is attached to is used.")]
         public Transform customOrigin = null;
 
+        [Header("Obsolete Settings")]
+
         [System.Obsolete("`VRTK_UIPointer.controller` has been replaced with `VRTK_UIPointer.controllerEvents`. This parameter will be removed in a future version of VRTK.")]
         [ObsoleteInspector]
         public VRTK_ControllerEvents controller;

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -157,10 +157,6 @@ namespace VRTK
         }
         private static VRTK_SDKManager _instance;
 
-        [Obsolete("`VRTK_SDKManager.persistOnLoad` has been deprecated and will be removed in a future version of VRTK. See https://github.com/thestonefox/VRTK/issues/1316 for details.")]
-        [ObsoleteInspector]
-        public bool persistOnLoad;
-
         [Tooltip("Determines whether the scripting define symbols required by the installed SDKs are automatically added to and removed from the player settings.")]
         public bool autoManageScriptDefines = true;
 
@@ -189,6 +185,12 @@ namespace VRTK
 #endif
         };
 #endif
+
+        [Header("Obsolete Settings")]
+
+        [Obsolete("`VRTK_SDKManager.persistOnLoad` has been deprecated and will be removed in a future version of VRTK. See https://github.com/thestonefox/VRTK/issues/1316 for details.")]
+        [ObsoleteInspector]
+        public bool persistOnLoad;
 
         /// <summary>
         /// The loaded SDK Setup. `null` if no setup is currently loaded.


### PR DESCRIPTION
The obsolete parameters are now all grouped at the bottom of the script
inspector window and under the header `Obsolete Settings` to make it
easier to identify deprecated variables.