### PR TITLE
feat(SDKManager): allow delayed assignment of behaviour toggles

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -8291,6 +8291,7 @@ A helper class that simply holds references to both the SDK_ScriptingDefineSymbo
  * `public static ReadOnlyCollection<VRTK_SDKInfo> InstalledHeadsetSDKInfos { get private set }` - All installed headset SDK infos. This is a subset of `AvailableHeadsetSDKInfos`. It contains only those available SDK infos for which an SDK_ScriptingDefineSymbolPredicateAttribute exists that uses the same symbol and whose associated method returns true.
  * `public static ReadOnlyCollection<VRTK_SDKInfo> InstalledControllerSDKInfos { get private set }` - All installed controller SDK infos. This is a subset of `AvailableControllerSDKInfos`. It contains only those available SDK infos for which an SDK_ScriptingDefineSymbolPredicateAttribute exists that uses the same symbol and whose associated method returns true.
  * `public static VRTK_SDKManager instance` - The singleton instance to access the SDK Manager variables from.
+ * `public static HashSet<Behaviour> delayedToggleBehaviours` - A collection of behaviours to toggle on loaded setup change. Default: `new HashSet<Behaviour>()`
  * `public List<SDK_ScriptingDefineSymbolPredicateAttribute> activeScriptingDefineSymbolsWithoutSDKClasses` - The active (i.e. to be added to the PlayerSettings) scripting define symbol predicate attributes that have no associated SDK classes. Default: `new List<SDK_ScriptingDefineSymbolPredicateAttribute>()`
  * `public VRTK_SDKSetup loadedSetup` - The loaded SDK Setup. `null` if no setup is currently loaded.
  * `public ReadOnlyCollection<Behaviour> behavioursToToggleOnLoadedSetupChange { get private set }` - All behaviours that need toggling whenever `loadedSetup` changes.
@@ -8325,6 +8326,129 @@ Adding the `VRTK_SDKManager_UnityEvents` component to `VRTK_SDKManager` object a
 
 Event Payload. Constructs a new instance with the specified predicate attribute and associated method info.
 
+#### ValidInstance/0
+
+  > `public static bool ValidInstance()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance is valid or returns `false` if it is null.
+
+The ValidInstance method returns whether the SDK Manager isntance is valid (i.e. it's not null).
+
+#### AttemptAddBehaviourToToggleOnLoadedSetupChange/1
+
+  > `public static bool AttemptAddBehaviourToToggleOnLoadedSetupChange(Behaviour givenBehaviour)`
+
+ * Parameters
+   * `Behaviour givenBehaviour` - The behaviour to add.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The AttemptAddBehaviourToToggleOnLoadedSetupChange method will attempt to add the given behaviour to the loaded setup change toggle if the SDK Manager instance exists. If it doesn't exist then it adds it to the `delayedToggleBehaviours` HashSet to be manually added later with the `ProcessDelayedToggleBehaviours` method.
+
+#### AttemptRemoveBehaviourToToggleOnLoadedSetupChange/1
+
+  > `public static bool AttemptRemoveBehaviourToToggleOnLoadedSetupChange(Behaviour givenBehaviour)`
+
+ * Parameters
+   * `Behaviour givenBehaviour` - The behaviour to remove.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The AttemptRemoveBehaviourToToggleOnLoadedSetupChange method will attempt to remove the given behaviour from the loaded setup change toggle if the SDK Manager instance exists.
+
+#### ProcessDelayedToggleBehaviours/0
+
+  > `public static void ProcessDelayedToggleBehaviours()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * _none_
+
+The ProcessDelayedToggleBehaviours method will attempt to addd the behaviours in the `delayedToggleBehaviours` HashSet to the loaded setup change toggle.
+
+#### SubscribeLoadedSetupChanged/1
+
+  > `public static bool SubscribeLoadedSetupChanged(LoadedSetupChangeEventHandler callback)`
+
+ * Parameters
+   * `LoadedSetupChangeEventHandler callback` - The callback to register.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The SubscribeLoadedSetupChanged method attempts to register the given callback with the `LoadedSetupChanged` event.
+
+#### UnsubscribeLoadedSetupChanged/1
+
+  > `public static bool UnsubscribeLoadedSetupChanged(LoadedSetupChangeEventHandler callback)`
+
+ * Parameters
+   * `LoadedSetupChangeEventHandler callback` - The callback to unregister.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The UnsubscribeLoadedSetupChanged method attempts to unregister the given callback from the `LoadedSetupChanged` event.
+
+#### GetLoadedSDKSetup/0
+
+  > `public static VRTK_SDKSetup GetLoadedSDKSetup()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `VRTK_SDKSetup` - Returns `true` if the SDK Manager instance was valid.
+
+The GetLoadedSDKSetup method returns the current loaded SDK Setup for the SDK Manager instance.
+
+#### GetAllSDKSetups/0
+
+  > `public static VRTK_SDKSetup[] GetAllSDKSetups()`
+
+ * Parameters
+   * _none_
+ * Returns
+   * `VRTK_SDKSetup[]` - An SDKSetup array of all valid SDK Setups for the current SDK Manager instance. If no SDK Manager instance is found then an empty array is returned.
+
+The GetAllSDKSetups method returns all valid SDK Setups attached to the SDK Manager instance.
+
+#### AttemptTryLoadSDKSetup/3
+
+  > `public static bool AttemptTryLoadSDKSetup(int startIndex, bool tryToReinitialize, params VRTK_SDKSetup[] sdkSetups)`
+
+ * Parameters
+   * `int startIndex` - The index of the VRTK_SDKSetup to start the loading with.
+   * `bool tryToReinitialize` - Whether or not to retry initializing and using the currently set but unusable VR Device.
+   * `params VRTK_SDKSetup[] sdkSetups` - The list to try to load a VRTK_SDKSetup from.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The AttemptTryLoadSDKSetup method attempts to load a valid VRTK_SDKSetup from a list if the SDK Manager instance is valid.
+
+#### AttemptTryLoadSDKSetupFromList/1
+
+  > `public static bool AttemptTryLoadSDKSetupFromList(bool tryUseLastLoadedSetup = true)`
+
+ * Parameters
+   * `bool tryUseLastLoadedSetup` - Attempt to use the last loaded setup if it's available.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The AttemptUnloadSDKSetup method tries to load a valid VRTK_SDKSetup from setups if the SDK Manager instance is valid.
+
+#### AttemptUnloadSDKSetup/1
+
+  > `public static bool AttemptUnloadSDKSetup(bool disableVR = false)`
+
+ * Parameters
+   * `bool disableVR` - Whether to disable VR altogether after unloading the SDK Setup.
+ * Returns
+   * `bool` - Returns `true` if the SDK Manager instance was valid.
+
+The AttemptUnloadSDKSetup method attempts to unload the currently loaded VRTK_SDKSetup, if there is one and if the SDK Manager instance is valid.
+
 #### ManageScriptingDefineSymbols/2
 
   > `public bool ManageScriptingDefineSymbols(bool ignoreAutoManageScriptDefines, bool ignoreIsActiveAndEnabled)`
@@ -8335,7 +8459,7 @@ Event Payload. Constructs a new instance with the specified predicate attribute 
  * Returns
    * `bool` - Whether the PlayerSettings' scripting define symbols were changed.
 
-Manages (i.e. adds and removes) the scripting define symbols of the PlayerSettings for the currently set SDK infos. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
+The ManageScriptingDefineSymbols method manages (i.e. adds and removes) the scripting define symbols of the PlayerSettings for the currently set SDK infos. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
 
 #### ManageVRSettings/1
 
@@ -8346,7 +8470,7 @@ Manages (i.e. adds and removes) the scripting define symbols of the PlayerSettin
  * Returns
    * _none_
 
-Manages (i.e. adds and removes) the VR SDKs of the PlayerSettings for the currently set SDK infos. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
+The ManageVRSettings method manages (i.e. adds and removes) the VR SDKs of the PlayerSettings for the currently set SDK infos. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
 
 #### AddBehaviourToToggleOnLoadedSetupChange/1
 
@@ -8357,7 +8481,7 @@ Manages (i.e. adds and removes) the VR SDKs of the PlayerSettings for the curren
  * Returns
    * _none_
 
-Adds a behaviour to the list of behaviours to toggle when `loadedSetup` changes.
+The AddBehaviourToToggleOnLoadedSetupChange method adds a behaviour to the list of behaviours to toggle when `loadedSetup` changes.
 
 #### RemoveBehaviourToToggleOnLoadedSetupChange/1
 
@@ -8368,18 +8492,18 @@ Adds a behaviour to the list of behaviours to toggle when `loadedSetup` changes.
  * Returns
    * _none_
 
-Removes a behaviour of the list of behaviours to toggle when `loadedSetup` changes.
+The RemoveBehaviourToToggleOnLoadedSetupChange method removes a behaviour of the list of behaviours to toggle when `loadedSetup` changes.
 
 #### TryLoadSDKSetupFromList/1
 
   > `public void TryLoadSDKSetupFromList(bool tryUseLastLoadedSetup = true)`
 
  * Parameters
-   * _none_
+   * `bool tryUseLastLoadedSetup` - Attempt to use the last loaded setup if it's available.
  * Returns
    * _none_
 
-Tries to load a valid VRTK_SDKSetup from setups.
+The TryLoadSDKSetupFromList method tries to load a valid VRTK_SDKSetup from setups.
 
 #### TryLoadSDKSetup/3
 
@@ -8392,7 +8516,7 @@ Tries to load a valid VRTK_SDKSetup from setups.
  * Returns
    * _none_
 
-Tries to load a valid VRTK_SDKSetup from a list. The first loadable VRTK_SDKSetup in the list will be loaded. Will fall back to disable VR if none of the provided Setups is useable.
+The TryLoadSDKSetup method tries to load a valid VRTK_SDKSetup from a list. The first loadable VRTK_SDKSetup in the list will be loaded. Will fall back to disable VR if none of the provided Setups is useable.
 
 #### SetLoadedSDKSetupToPopulateObjectReferences/1
 
@@ -8403,7 +8527,7 @@ Tries to load a valid VRTK_SDKSetup from a list. The first loadable VRTK_SDKSetu
  * Returns
    * _none_
 
-Sets a given VRTK_SDKSetup as the loaded SDK Setup to be able to use it when populating object references in the SDK Setup. This method should only be called when not playing as it's only for populating the object references. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
+The SetLoadedSDKSetupToPopulateObjectReferences method sets a given VRTK_SDKSetup as the loaded SDK Setup to be able to use it when populating object references in the SDK Setup. This method should only be called when not playing as it's only for populating the object references. This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used in a type that is also compiled for a standalone build.
 
 #### UnloadSDKSetup/1
 
@@ -8414,7 +8538,7 @@ Sets a given VRTK_SDKSetup as the loaded SDK Setup to be able to use it when pop
  * Returns
    * _none_
 
-Unloads the currently loaded VRTK_SDKSetup, if there is one.
+The UnloadSDKSetup method unloads the currently loaded VRTK_SDKSetup, if there is one.
 
 ---
 
@@ -8464,7 +8588,7 @@ Adding the `VRTK_SDKSetup_UnityEvents` component to `VRTK_SDKSetup` object allow
  * Returns
    * _none_
 
-Populates the object references by using the currently set SDKs.
+The PopulateObjectReferences method populates the object references by using the currently set SDKs.
 
 #### GetSimplifiedErrorDescriptions/0
 
@@ -8475,7 +8599,29 @@ Populates the object references by using the currently set SDKs.
  * Returns
    * `string[]` - An array of all the error descriptions. Returns an empty array if no errors are found.
 
-Checks the setup for errors and creates an array of error descriptions. The returned error descriptions handle the following cases for the current SDK infos:  * Its type doesn't exist anymore.  * It's a fallback SDK.  * It doesn't have its scripting define symbols added.  * It's missing its vendor SDK.Additionally the current SDK infos are checked whether they use multiple VR Devices.
+The GetSimplifiedErrorDescriptions method checks the setup for errors and creates an array of error descriptions. The returned error descriptions handle the following cases for the current SDK infos:  * Its type doesn't exist anymore.  * It's a fallback SDK.  * It doesn't have its scripting define symbols added.  * It's missing its vendor SDK.Additionally the current SDK infos are checked whether they use multiple VR Devices.
+
+#### OnLoaded/1
+
+  > `public void OnLoaded(VRTK_SDKManager sender)`
+
+ * Parameters
+   * `VRTK_SDKManager sender` - The SDK Manager that has loaded the SDK Setup.
+ * Returns
+   * _none_
+
+The OnLoaded method determines when an SDK Setup has been loaded.
+
+#### OnUnloaded/1
+
+  > `public void OnUnloaded(VRTK_SDKManager sender)`
+
+ * Parameters
+   * `VRTK_SDKManager sender` - The SDK Manager that has unloaded the SDK Setup.
+ * Returns
+   * _none_
+
+The OnUnloaded method determines when an SDK Setup has been unloaded.
 
 ---
 

--- a/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
@@ -203,7 +203,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
             InitButtonsArray();
         }
 
@@ -238,7 +238,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void EmitEvent(bool state, TooltipButtons element)

--- a/Assets/VRTK/Prefabs/DesktopCamera/VRTK_DesktopCamera.cs
+++ b/Assets/VRTK/Prefabs/DesktopCamera/VRTK_DesktopCamera.cs
@@ -32,7 +32,6 @@ namespace VRTK
 
         protected Camera headsetCameraCopy;
         protected VRTK_TransformFollow headsetCameraTransformFollow;
-        protected VRTK_SDKManager sdkManager;
 
         protected virtual void OnEnable()
         {
@@ -54,24 +53,15 @@ namespace VRTK
             headsetCameraTransformFollow = gameObject.AddComponent<VRTK_TransformFollow>();
             headsetCameraTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnLateUpdate;
 
-            sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
+            if (VRTK_SDKManager.SubscribeLoadedSetupChanged(LoadedSetupChanged) && VRTK_SDKManager.GetLoadedSDKSetup() != null)
             {
-                sdkManager.LoadedSetupChanged += LoadedSetupChanged;
-                if (sdkManager.loadedSetup != null)
-                {
-                    ConfigureForCurrentSDKSetup();
-                }
+                ConfigureForCurrentSDKSetup();
             }
         }
 
         protected virtual void OnDisable()
         {
-            if (sdkManager != null)
-            {
-                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
-            }
-
+            VRTK_SDKManager.UnsubscribeLoadedSetupChanged(LoadedSetupChanged);
             Destroy(headsetCameraTransformFollow);
             if (headsetCameraCopy != null)
             {
@@ -94,7 +84,7 @@ namespace VRTK
             headsetCameraTransformFollow.enabled = false;
             followScript.enabled = false;
 
-            if (sdkManager.loadedSetup == null)
+            if (VRTK_SDKManager.GetLoadedSDKSetup() == null)
             {
                 return;
             }

--- a/Assets/VRTK/Prefabs/DestinationPoint/VRTK_DestinationPoint.cs
+++ b/Assets/VRTK/Prefabs/DestinationPoint/VRTK_DestinationPoint.cs
@@ -152,7 +152,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected override void OnEnable()
@@ -190,7 +190,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Prefabs/FramesPerSecondCanvas/VRTK_FramesPerSecondViewer.cs
+++ b/Assets/VRTK/Prefabs/FramesPerSecondCanvas/VRTK_FramesPerSecondViewer.cs
@@ -38,23 +38,18 @@ namespace VRTK
         protected float framesTime;
         protected Canvas canvas;
         protected Text text;
-        protected VRTK_SDKManager sdkManager;
 
         protected virtual void OnEnable()
         {
-            sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
-            {
-                sdkManager.LoadedSetupChanged += LoadedSetupChanged;
-            }
+            VRTK_SDKManager.SubscribeLoadedSetupChanged(LoadedSetupChanged);
             InitCanvas();
         }
 
         protected virtual void OnDisable()
         {
-            if (sdkManager != null && !gameObject.activeSelf)
+            if (!gameObject.activeSelf)
             {
-                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
+                VRTK_SDKManager.UnsubscribeLoadedSetupChanged(LoadedSetupChanged);
             }
         }
 
@@ -87,7 +82,7 @@ namespace VRTK
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
-            if (this != null && sdkManager != null && gameObject.activeInHierarchy)
+            if (this != null && VRTK_SDKManager.ValidInstance() && gameObject.activeInHierarchy)
             {
                 SetCanvasCamera();
             }

--- a/Assets/VRTK/Prefabs/ObjectTooltip/VRTK_ObjectTooltip.cs
+++ b/Assets/VRTK/Prefabs/ObjectTooltip/VRTK_ObjectTooltip.cs
@@ -111,7 +111,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -122,7 +122,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Prefabs/PanelMenu/VRTK_PanelMenuController.cs
+++ b/Assets/VRTK/Prefabs/PanelMenu/VRTK_PanelMenuController.cs
@@ -122,7 +122,7 @@ namespace VRTK
         protected virtual void Awake()
         {
             Initialize();
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Start()
@@ -146,7 +146,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Prefabs/RadialMenu/VRTK_IndependentRadialMenuController.cs
+++ b/Assets/VRTK/Prefabs/RadialMenu/VRTK_IndependentRadialMenuController.cs
@@ -138,7 +138,7 @@ namespace VRTK
         protected override void Awake()
         {
             menu = GetComponent<VRTK_RadialMenu>();
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Start()
@@ -178,7 +178,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_InputSimulator.cs
@@ -165,7 +165,7 @@
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -216,7 +216,7 @@
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
             destroyed = true;
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerEvents.cs
@@ -1337,7 +1337,7 @@ namespace VRTK
         #region MonoBehaviour methods
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -1363,7 +1363,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerHighlighter.cs
@@ -233,7 +233,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -273,7 +273,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerTrackedCollider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_ControllerTrackedCollider.cs
@@ -94,7 +94,7 @@ namespace VRTK
 
         protected override void ControllerReady(VRTK_ControllerReference passedControllerReference)
         {
-            if (sdkManager != null && sdkManager.loadedSetup != null && gameObject.activeInHierarchy && VRTK_ControllerReference.IsValid(passedControllerReference))
+            if (VRTK_SDKManager.GetLoadedSDKSetup() != null && gameObject.activeInHierarchy && VRTK_ControllerReference.IsValid(passedControllerReference))
             {
                 Cleanup(true);
                 controllerReference = passedControllerReference;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractGrab.cs
@@ -186,7 +186,7 @@ namespace VRTK
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_NOT_INJECTED, "VRTK_InteractGrab", "VRTK_InteractTouch", "interactTouch", "the same or parent"));
             }
 
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -217,7 +217,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -254,7 +254,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -282,7 +282,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnTriggerEnter(Collider collider)

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_ControllerHaptics.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_ControllerHaptics.cs
@@ -82,7 +82,7 @@ namespace VRTK
 
         protected static void SetupInstance()
         {
-            if (instance == null && VRTK_SDKManager.instance != null)
+            if (instance == null && VRTK_SDKManager.ValidInstance())
             {
                 instance = VRTK_SDKManager.instance.gameObject.AddComponent<VRTK_ControllerHaptics>();
             }

--- a/Assets/VRTK/Source/Scripts/Interactions/VRTK_ObjectAppearance.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/VRTK_ObjectAppearance.cs
@@ -140,7 +140,7 @@ namespace VRTK
 
         protected static void SetupInstance()
         {
-            if (instance == null && VRTK_SDKManager.instance != null)
+            if (instance == null && VRTK_SDKManager.ValidInstance())
             {
                 instance = VRTK_SDKManager.instance.gameObject.AddComponent<VRTK_ObjectAppearance>();
             }

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_RoomExtender_PlayAreaGizmo.cs
@@ -15,7 +15,7 @@
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -31,7 +31,7 @@
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnDrawGizmos()

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_SDKControllerReady.cs
@@ -4,24 +4,18 @@
 
     public abstract class VRTK_SDKControllerReady : MonoBehaviour
     {
-        protected VRTK_SDKManager sdkManager;
         protected SDK_BaseController previousControllerSDK;
 
         protected virtual void OnEnable()
         {
-            sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
-            {
-                sdkManager.LoadedSetupChanged += LoadedSetupChanged;
-            }
+            VRTK_SDKManager.SubscribeLoadedSetupChanged(LoadedSetupChanged);
             CheckControllersReady();
         }
 
         protected virtual void OnDisable()
         {
-            if (sdkManager != null)
+            if (VRTK_SDKManager.UnsubscribeLoadedSetupChanged(LoadedSetupChanged))
             {
-                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
                 UnregisterPreviousLeftController();
                 UnregisterPreviousRightController();
             }

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_TrackedController.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_TrackedController.cs
@@ -81,7 +81,7 @@
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -108,7 +108,7 @@
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void FixedUpdate()

--- a/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
@@ -44,7 +44,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -83,7 +83,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void AxisChanged(object sender, ObjectControlEventArgs e)

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_BasicTeleport.cs
@@ -214,7 +214,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -241,7 +241,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Blink(float transitionSpeed)

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DragWorld.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_DragWorld.cs
@@ -149,7 +149,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -173,7 +173,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
 

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_MoveInPlace.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_MoveInPlace.cs
@@ -179,7 +179,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -234,7 +234,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_ObjectControl.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_ObjectControl.cs
@@ -127,7 +127,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -155,7 +155,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_PlayerClimb.cs
@@ -104,7 +104,7 @@ namespace VRTK
             headsetCollision = (headsetCollision != null ? headsetCollision : FindObjectOfType<VRTK_HeadsetCollision>());
             positionRewind = (positionRewind != null ? positionRewind : FindObjectOfType<VRTK_PositionRewind>());
 
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -121,7 +121,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_RoomExtender.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_RoomExtender.cs
@@ -61,7 +61,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -83,7 +83,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_SlingshotJump.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_SlingshotJump.cs
@@ -124,7 +124,7 @@ namespace VRTK
         {
             bodyPhysics = (bodyPhysics != null ? bodyPhysics : FindObjectOfType<VRTK_BodyPhysics>());
             playerClimb = (playerClimb != null ? playerClimb : FindObjectOfType<VRTK_PlayerClimb>());
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -142,7 +142,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void LeftButtonPressed(object sender, ControllerInteractionEventArgs e)

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_StepMultiplier.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_StepMultiplier.cs
@@ -67,7 +67,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -86,7 +86,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TunnelOverlay.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/VRTK_TunnelOverlay.cs
@@ -70,7 +70,7 @@ namespace VRTK
             shaderPropertyAV = Shader.PropertyToID("_AngularVelocity");
             shaderPropertyFeather = Shader.PropertyToID("_FeatherSize");
             shaderPropertySkyboxTexture = Shader.PropertyToID("_SecondarySkyBox");
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -115,7 +115,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void FixedUpdate()

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -274,7 +274,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -300,7 +300,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnValidate()

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_PlayAreaCursor.cs
@@ -256,7 +256,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -279,7 +279,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/VRTK_Pointer.cs
@@ -292,7 +292,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected override void OnEnable()
@@ -332,7 +332,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -424,7 +424,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected override void OnEnable()
@@ -450,7 +450,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void FixedUpdate()

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetCollision.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetCollision.cs
@@ -103,7 +103,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -128,7 +128,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetControllerAware.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetControllerAware.cs
@@ -149,7 +149,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -167,7 +167,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetFade.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_HeadsetFade.cs
@@ -136,7 +136,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -154,7 +154,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual HeadsetFadeEventArgs SetHeadsetFadeEvent(Transform currentTransform, float duration)

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_HipTracking.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_HipTracking.cs
@@ -26,7 +26,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -36,7 +36,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void LateUpdate()

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_PositionRewind.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_PositionRewind.cs
@@ -141,7 +141,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -166,7 +166,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UIPointer.cs
@@ -434,7 +434,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -478,7 +478,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void LateUpdate()

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -155,6 +155,171 @@ namespace VRTK
                 return _instance;
             }
         }
+
+        /// <summary>
+        /// A collection of behaviours to toggle on loaded setup change.
+        /// </summary>
+        public static HashSet<Behaviour> delayedToggleBehaviours = new HashSet<Behaviour>();
+
+        /// <summary>
+        /// The ValidInstance method returns whether the SDK Manager isntance is valid (i.e. it's not null).
+        /// </summary>
+        /// <returns>Returns `true` if the SDK Manager instance is valid or returns `false` if it is null.</returns>
+        public static bool ValidInstance()
+        {
+            return (instance != null);
+        }
+
+        /// <summary>
+        /// The AttemptAddBehaviourToToggleOnLoadedSetupChange method will attempt to add the given behaviour to the loaded setup change toggle if the SDK Manager instance exists. If it doesn't exist then it adds it to the `delayedToggleBehaviours` HashSet to be manually added later with the `ProcessDelayedToggleBehaviours` method.
+        /// </summary>
+        /// <param name="givenBehaviour">The behaviour to add.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool AttemptAddBehaviourToToggleOnLoadedSetupChange(Behaviour givenBehaviour)
+        {
+            if (ValidInstance())
+            {
+                instance.AddBehaviourToToggleOnLoadedSetupChange(givenBehaviour);
+                return true;
+            }
+            delayedToggleBehaviours.Add(givenBehaviour);
+            return false;
+        }
+
+        /// <summary>
+        /// The AttemptRemoveBehaviourToToggleOnLoadedSetupChange method will attempt to remove the given behaviour from the loaded setup change toggle if the SDK Manager instance exists.
+        /// </summary>
+        /// <param name="givenBehaviour">The behaviour to remove.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool AttemptRemoveBehaviourToToggleOnLoadedSetupChange(Behaviour givenBehaviour)
+        {
+            if (ValidInstance())
+            {
+                instance.RemoveBehaviourToToggleOnLoadedSetupChange(givenBehaviour);
+                delayedToggleBehaviours.Remove(givenBehaviour);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The ProcessDelayedToggleBehaviours method will attempt to addd the behaviours in the `delayedToggleBehaviours` HashSet to the loaded setup change toggle.
+        /// </summary>
+        public static void ProcessDelayedToggleBehaviours()
+        {
+            if (ValidInstance())
+            {
+                foreach (Behaviour currentBehaviour in delayedToggleBehaviours)
+                {
+                    instance.AddBehaviourToToggleOnLoadedSetupChange(currentBehaviour);
+                }
+                delayedToggleBehaviours.Clear();
+            }
+        }
+
+        /// <summary>
+        /// The SubscribeLoadedSetupChanged method attempts to register the given callback with the `LoadedSetupChanged` event.
+        /// </summary>
+        /// <param name="callback">The callback to register.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool SubscribeLoadedSetupChanged(LoadedSetupChangeEventHandler callback)
+        {
+            if (ValidInstance())
+            {
+                instance.LoadedSetupChanged += callback;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The UnsubscribeLoadedSetupChanged method attempts to unregister the given callback from the `LoadedSetupChanged` event. 
+        /// </summary>
+        /// <param name="callback">The callback to unregister.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool UnsubscribeLoadedSetupChanged(LoadedSetupChangeEventHandler callback)
+        {
+            if (ValidInstance())
+            {
+                instance.LoadedSetupChanged -= callback;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The GetLoadedSDKSetup method returns the current loaded SDK Setup for the SDK Manager instance.
+        /// </summary>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static VRTK_SDKSetup GetLoadedSDKSetup()
+        {
+            if (ValidInstance())
+            {
+                return instance.loadedSetup;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The GetAllSDKSetups method returns all valid SDK Setups attached to the SDK Manager instance.
+        /// </summary>
+        /// <returns>An SDKSetup array of all valid SDK Setups for the current SDK Manager instance. If no SDK Manager instance is found then an empty array is returned.</returns>
+        public static VRTK_SDKSetup[] GetAllSDKSetups()
+        {
+            if (ValidInstance())
+            {
+                return instance.setups;
+            }
+            return new VRTK_SDKSetup[0];
+        }
+
+        /// <summary>
+        /// The AttemptTryLoadSDKSetup method attempts to load a valid VRTK_SDKSetup from a list if the SDK Manager instance is valid.
+        /// </summary>
+        /// <param name="startIndex">The index of the VRTK_SDKSetup to start the loading with.</param>
+        /// <param name="tryToReinitialize">Whether or not to retry initializing and using the currently set but unusable VR Device.</param>
+        /// <param name="sdkSetups">The list to try to load a VRTK_SDKSetup from.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool AttemptTryLoadSDKSetup(int startIndex, bool tryToReinitialize, params VRTK_SDKSetup[] sdkSetups)
+        {
+            if (ValidInstance())
+            {
+                instance.TryLoadSDKSetup(startIndex, tryToReinitialize, sdkSetups);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The AttemptUnloadSDKSetup method tries to load a valid VRTK_SDKSetup from setups if the SDK Manager instance is valid.
+        /// </summary>
+        /// <param name="tryUseLastLoadedSetup">Attempt to use the last loaded setup if it's available.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool AttemptTryLoadSDKSetupFromList(bool tryUseLastLoadedSetup = true)
+        {
+            if (ValidInstance())
+            {
+                instance.TryLoadSDKSetupFromList(tryUseLastLoadedSetup);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The AttemptUnloadSDKSetup method attempts to unload the currently loaded VRTK_SDKSetup, if there is one and if the SDK Manager instance is valid.
+        /// </summary>
+        /// <param name="disableVR">Whether to disable VR altogether after unloading the SDK Setup.</param>
+        /// <returns>Returns `true` if the SDK Manager instance was valid.</returns>
+        public static bool AttemptUnloadSDKSetup(bool disableVR = false)
+        {
+            if (ValidInstance())
+            {
+                instance.UnloadSDKSetup(disableVR);
+                return true;
+            }
+            return false;
+        }
+
         private static VRTK_SDKManager _instance;
 
         [Tooltip("Determines whether the scripting define symbols required by the installed SDKs are automatically added to and removed from the player settings.")]
@@ -208,6 +373,7 @@ namespace VRTK
             }
             private set { _loadedSetup = value; }
         }
+
         private VRTK_SDKSetup _loadedSetup;
         private static HashSet<VRTK_SDKInfo> _previouslyUsedSetupInfos = new HashSet<VRTK_SDKInfo>();
 
@@ -231,7 +397,7 @@ namespace VRTK
 
 #if UNITY_EDITOR
         /// <summary>
-        /// Manages (i.e. adds and removes) the scripting define symbols of the PlayerSettings for the currently set SDK infos.
+        /// The ManageScriptingDefineSymbols method manages (i.e. adds and removes) the scripting define symbols of the PlayerSettings for the currently set SDK infos.
         /// This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used
         /// in a type that is also compiled for a standalone build.
         /// </summary>
@@ -346,7 +512,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// Manages (i.e. adds and removes) the VR SDKs of the PlayerSettings for the currently set SDK infos.
+        /// The ManageVRSettings method manages (i.e. adds and removes) the VR SDKs of the PlayerSettings for the currently set SDK infos.
         /// This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used
         /// in a type that is also compiled for a standalone build.
         /// </summary>
@@ -418,7 +584,7 @@ namespace VRTK
 #endif
 
         /// <summary>
-        /// Adds a behaviour to the list of behaviours to toggle when `loadedSetup` changes.
+        /// The AddBehaviourToToggleOnLoadedSetupChange method adds a behaviour to the list of behaviours to toggle when `loadedSetup` changes.
         /// </summary>
         /// <param name="behaviour">The behaviour to add.</param>
         public void AddBehaviourToToggleOnLoadedSetupChange(Behaviour behaviour)
@@ -436,7 +602,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// Removes a behaviour of the list of behaviours to toggle when `loadedSetup` changes.
+        /// The RemoveBehaviourToToggleOnLoadedSetupChange method removes a behaviour of the list of behaviours to toggle when `loadedSetup` changes.
         /// </summary>
         /// <param name="behaviour">The behaviour to remove.</param>
         public void RemoveBehaviourToToggleOnLoadedSetupChange(Behaviour behaviour)
@@ -445,8 +611,9 @@ namespace VRTK
         }
 
         /// <summary>
-        /// Tries to load a valid VRTK_SDKSetup from setups.
+        /// The TryLoadSDKSetupFromList method tries to load a valid VRTK_SDKSetup from setups.
         /// </summary>
+        /// <param name="tryUseLastLoadedSetup">Attempt to use the last loaded setup if it's available.</param>
         public void TryLoadSDKSetupFromList(bool tryUseLastLoadedSetup = true)
         {
             int index = 0;
@@ -496,7 +663,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// Tries to load a valid VRTK_SDKSetup from a list.
+        /// The TryLoadSDKSetup method tries to load a valid VRTK_SDKSetup from a list.
         /// </summary>
         /// <remarks>
         /// The first loadable VRTK_SDKSetup in the list will be loaded. Will fall back to disable VR if none of the provided Setups is useable.
@@ -581,11 +748,13 @@ namespace VRTK
 
 #if UNITY_EDITOR
         /// <summary>
-        /// Sets a given VRTK_SDKSetup as the loaded SDK Setup to be able to use it when populating object references in the SDK Setup.
+        /// The SetLoadedSDKSetupToPopulateObjectReferences method sets a given VRTK_SDKSetup as the loaded SDK Setup to be able to use it when populating object references in the SDK Setup.
+        /// </summary>
+        /// <remarks>
         /// This method should only be called when not playing as it's only for populating the object references.
         /// This method is only available in the editor, so usage of the method needs to be surrounded by `#if UNITY_EDITOR` and `#endif` when used
         /// in a type that is also compiled for a standalone build.
-        /// </summary>
+        /// </remarks>
         /// <param name="setup">The SDK Setup to set as the loaded SDK.</param>
         public void SetLoadedSDKSetupToPopulateObjectReferences(VRTK_SDKSetup setup)
         {
@@ -600,7 +769,7 @@ namespace VRTK
 #endif
 
         /// <summary>
-        /// Unloads the currently loaded VRTK_SDKSetup, if there is one.
+        /// The UnloadSDKSetup method unloads the currently loaded VRTK_SDKSetup, if there is one.
         /// </summary>
         /// <param name="disableVR">Whether to disable VR altogether after unloading the SDK Setup.</param>
         public void UnloadSDKSetup(bool disableVR = false)

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -66,6 +66,7 @@ namespace VRTK
                 PopulateObjectReferences(false);
             }
         }
+
         /// <summary>
         /// The info of the SDK to use to utilize room scale boundaries. By setting this to `null` the fallback SDK will be used.
         /// </summary>
@@ -94,6 +95,7 @@ namespace VRTK
                 PopulateObjectReferences(false);
             }
         }
+
         /// <summary>
         /// The info of the SDK to use to utilize the VR headset. By setting this to `null` the fallback SDK will be used.
         /// </summary>
@@ -122,6 +124,7 @@ namespace VRTK
                 PopulateObjectReferences(false);
             }
         }
+
         /// <summary>
         /// The info of the SDK to use to utilize the input devices. By setting this to `null` the fallback SDK will be used.
         /// </summary>
@@ -168,6 +171,7 @@ namespace VRTK
                 return cachedSystemSDK;
             }
         }
+
         /// <summary>
         /// The selected boundaries SDK.
         /// </summary>
@@ -185,6 +189,7 @@ namespace VRTK
                 return cachedBoundariesSDK;
             }
         }
+
         /// <summary>
         /// The selected headset SDK.
         /// </summary>
@@ -202,6 +207,7 @@ namespace VRTK
                 return cachedHeadsetSDK;
             }
         }
+
         /// <summary>
         /// The selected controller SDK.
         /// </summary>
@@ -260,7 +266,7 @@ namespace VRTK
         private SDK_BaseController cachedControllerSDK;
 
         /// <summary>
-        /// Populates the object references by using the currently set SDKs.
+        /// The PopulateObjectReferences method populates the object references by using the currently set SDKs.
         /// </summary>
         /// <param name="force">Whether to ignore `autoPopulateObjectReferences` while deciding to populate.</param>
         public void PopulateObjectReferences(bool force)
@@ -271,7 +277,7 @@ namespace VRTK
             }
 
 #if UNITY_EDITOR
-            if (!EditorApplication.isPlaying)
+            if (!EditorApplication.isPlaying && VRTK_SDKManager.ValidInstance())
             {
                 VRTK_SDKManager.instance.SetLoadedSDKSetupToPopulateObjectReferences(this);
             }
@@ -301,7 +307,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// Checks the setup for errors and creates an array of error descriptions.
+        /// The GetSimplifiedErrorDescriptions method checks the setup for errors and creates an array of error descriptions.
         /// </summary>
         /// <remarks>
         /// The returned error descriptions handle the following cases for the current SDK infos:
@@ -359,6 +365,10 @@ namespace VRTK
             return sdkErrorDescriptions.Distinct().ToArray();
         }
 
+        /// <summary>
+        /// The OnLoaded method determines when an SDK Setup has been loaded.
+        /// </summary>
+        /// <param name="sender">The SDK Manager that has loaded the SDK Setup.</param>
         public void OnLoaded(VRTK_SDKManager sender)
         {
             List<SDK_Base> sdkBases = new SDK_Base[] { systemSDK, boundariesSDK, headsetSDK, controllerSDK }.ToList();
@@ -379,6 +389,10 @@ namespace VRTK
             }
         }
 
+        /// <summary>
+        /// The OnUnloaded method determines when an SDK Setup has been unloaded.
+        /// </summary>
+        /// <param name="sender">The SDK Manager that has unloaded the SDK Setup.</param>
         public void OnUnloaded(VRTK_SDKManager sender)
         {
             List<SDK_Base> sdkBases = new SDK_Base[] { systemSDK, boundariesSDK, headsetSDK, controllerSDK }.ToList();
@@ -398,7 +412,7 @@ namespace VRTK
         private void OnEnable()
         {
 #pragma warning disable 618
-            if (!VRTK_SDKManager.instance.persistOnLoad)
+            if (VRTK_SDKManager.ValidInstance() && !VRTK_SDKManager.instance.persistOnLoad)
 #pragma warning restore 618
             {
                 PopulateObjectReferences(false);
@@ -519,7 +533,7 @@ namespace VRTK
                 scriptAliasTransform.localRotation = Quaternion.identity;
             };
 
-            if (actualLeftController != null)
+            if (actualLeftController != null && VRTK_SDKManager.ValidInstance())
             {
                 setParent(VRTK_SDKManager.instance.scriptAliasLeftController, actualLeftController);
 
@@ -529,7 +543,7 @@ namespace VRTK
                 }
             }
 
-            if (actualRightController != null)
+            if (actualRightController != null && VRTK_SDKManager.ValidInstance())
             {
                 setParent(VRTK_SDKManager.instance.scriptAliasRightController, actualRightController);
 

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_AdaptiveQuality.cs
@@ -303,7 +303,7 @@ namespace VRTK
 
         private void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         private void OnEnable()
@@ -331,7 +331,7 @@ namespace VRTK
 
         private void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         private void OnValidate()

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKInputOverride.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKInputOverride.cs
@@ -147,16 +147,15 @@ namespace VRTK
 
         protected override void OnDisable()
         {
-            base.OnDisable();
-            if (sdkManager != null && !gameObject.activeSelf)
+            if (!gameObject.activeSelf)
             {
-                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
+                base.OnDisable();
             }
         }
 
         protected override void ControllerReady(VRTK_ControllerReference controllerReference)
         {
-            if (sdkManager != null && sdkManager.loadedSetup != null && gameObject.activeInHierarchy)
+            if (VRTK_SDKManager.GetLoadedSDKSetup() != null && gameObject.activeInHierarchy)
             {
                 ManageInputs();
             }
@@ -166,9 +165,9 @@ namespace VRTK
         {
             VRTK_SDKButtonInputOverrideType selectedModifier = null;
             //attempt to find by the overall SDK set up to start with
-            if (sdkManager.loadedSetup != null)
+            if (VRTK_SDKManager.GetLoadedSDKSetup() != null)
             {
-                selectedModifier = overrideTypes.FirstOrDefault(item => item.loadedSDKSetup == sdkManager.loadedSetup);
+                selectedModifier = overrideTypes.FirstOrDefault(item => item.loadedSDKSetup == VRTK_SDKManager.GetLoadedSDKSetup());
             }
 
             //If no sdk set up is found or it is null then try and find by the SDK controller
@@ -183,7 +182,7 @@ namespace VRTK
         protected virtual VRTK_SDKVector2AxisInputOverrideType GetSelectedModifier(List<VRTK_SDKVector2AxisInputOverrideType> overrideTypes, VRTK_ControllerReference controllerReference)
         {
             //attempt to find by the overall SDK set up to start with
-            VRTK_SDKVector2AxisInputOverrideType selectedModifier = overrideTypes.FirstOrDefault(item => item.loadedSDKSetup == sdkManager.loadedSetup);
+            VRTK_SDKVector2AxisInputOverrideType selectedModifier = overrideTypes.FirstOrDefault(item => item.loadedSDKSetup == VRTK_SDKManager.GetLoadedSDKSetup());
 
             //If no sdk set up is found or it is null then try and find by the SDK controller
             if (selectedModifier == null)

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectAlias.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectAlias.cs
@@ -27,29 +27,23 @@ namespace VRTK
         [Tooltip("The specific SDK Object to child this GameObject to.")]
         public SDKObject sdkObject = SDKObject.Boundary;
 
-        protected VRTK_SDKManager sdkManager;
-
         protected virtual void OnEnable()
         {
-            sdkManager = VRTK_SDKManager.instance;
-            if (sdkManager != null)
-            {
-                sdkManager.LoadedSetupChanged += LoadedSetupChanged;
-            }
+            VRTK_SDKManager.SubscribeLoadedSetupChanged(LoadedSetupChanged);
             ChildToSDKObject();
         }
 
         protected virtual void OnDisable()
         {
-            if (sdkManager != null && !gameObject.activeSelf)
+            if (!gameObject.activeSelf)
             {
-                sdkManager.LoadedSetupChanged -= LoadedSetupChanged;
+                VRTK_SDKManager.UnsubscribeLoadedSetupChanged(LoadedSetupChanged);
             }
         }
 
         protected virtual void LoadedSetupChanged(VRTK_SDKManager sender, VRTK_SDKManager.LoadedSetupChangeEventArgs e)
         {
-            if (sdkManager != null && gameObject.activeInHierarchy)
+            if (VRTK_SDKManager.ValidInstance() && gameObject.activeInHierarchy)
             {
                 ChildToSDKObject();
             }

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKObjectState.cs
@@ -83,7 +83,7 @@ namespace VRTK
 
         protected virtual void ToggleOnSDK()
         {
-            if (loadedSDKSetup != null && loadedSDKSetup == sdkManager.loadedSetup)
+            if (loadedSDKSetup != null && loadedSDKSetup == VRTK_SDKManager.GetLoadedSDKSetup())
             {
                 ToggleObject();
             }

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKTransformModify.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SDKTransformModify.cs
@@ -98,7 +98,7 @@ namespace VRTK
 
         protected override void ControllerReady(VRTK_ControllerReference controllerReference)
         {
-            if (sdkManager != null && sdkManager.loadedSetup != null && gameObject.activeInHierarchy)
+            if (VRTK_SDKManager.GetLoadedSDKSetup() != null && gameObject.activeInHierarchy)
             {
                 UpdateTransform(controllerReference);
             }
@@ -107,7 +107,7 @@ namespace VRTK
         protected virtual VRTK_SDKTransformModifiers GetSelectedModifier(VRTK_ControllerReference controllerReference)
         {
             //attempt to find by the overall SDK set up to start with
-            VRTK_SDKTransformModifiers selectedModifier = sdkOverrides.FirstOrDefault(item => item.loadedSDKSetup == sdkManager.loadedSetup);
+            VRTK_SDKTransformModifiers selectedModifier = sdkOverrides.FirstOrDefault(item => item.loadedSDKSetup == VRTK_SDKManager.GetLoadedSDKSetup());
 
             //If no sdk set up is found or it is null then try and find by the SDK controller
             if (selectedModifier == null)

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_Simulator.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_Simulator.cs
@@ -45,7 +45,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            VRTK_SDKManager.instance.AddBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptAddBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void OnEnable()
@@ -78,7 +78,7 @@ namespace VRTK
 
         protected virtual void OnDestroy()
         {
-            VRTK_SDKManager.instance.RemoveBehaviourToToggleOnLoadedSetupChange(this);
+            VRTK_SDKManager.AttemptRemoveBehaviourToToggleOnLoadedSetupChange(this);
         }
 
         protected virtual void Update()


### PR DESCRIPTION
The `AddBehaviourToToggleOnLoadedSetupChange` method can now be called
via a static method called
`AttemptAddBehaviourToToggleOnLoadedSetupChange` which will attempt to
add the behaviour if the SDK Manager instance is valid, if it's not
valid then it's added to a HashSet and can be manually processed at
a later time with `ProcessDelayedToggleBehaviours`.

This is useful if the SDK Manager is in an additively loaded scene
but other scripts in the original scene are attempting to register
their behaviour in the `Awake` method.

This will make it easier to additively load in a constructor scene
and the SDK Manager will still work correctly.

A bunch of other SDK Manager public methods have also had static
counterparts added for them, making it easier to call methods without
always having to check if the SDK Manager instance is valid.