### PR TITLE
fix(Structure): clone HashSet when iterating to prevent change errors

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectAppearance.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractObjectAppearance.cs
@@ -268,12 +268,12 @@ namespace VRTK
         {
             if (objectToMonitor != null && objectToMonitor.IsTouched())
             {
-                foreach (GameObject touchingObject in touchingObjects)
+                foreach (GameObject touchingObject in new HashSet<GameObject>(touchingObjects))
                 {
                     ToggleState(touchingObject, gameObjectActiveByDefault, rendererVisibleByDefault, VRTK_InteractableObject.InteractionType.None);
                 }
 
-                foreach (GameObject nearTouchingObject in nearTouchingObjects)
+                foreach (GameObject nearTouchingObject in new HashSet<GameObject>(nearTouchingObjects))
                 {
                     ToggleState(nearTouchingObject, gameObjectActiveByDefault, rendererVisibleByDefault, VRTK_InteractableObject.InteractionType.None);
                 }

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_InteractableObject.cs
@@ -962,7 +962,7 @@ namespace VRTK
         public virtual void ResetIgnoredColliders()
         {
             //Go through all the existing set up ignored colliders and reset their collision state
-            foreach (GameObject currentIgnoredCollider in currentIgnoredColliders)
+            foreach (GameObject currentIgnoredCollider in new HashSet<GameObject>(currentIgnoredColliders))
             {
                 if (currentIgnoredCollider != null)
                 {
@@ -1374,7 +1374,7 @@ namespace VRTK
 
         protected virtual void StopTouchingInteractions()
         {
-            foreach (GameObject touchingObject in touchingObjects)
+            foreach (GameObject touchingObject in new HashSet<GameObject>(touchingObjects))
             {
                 if (touchingObject.activeInHierarchy || forceDisabled)
                 {

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/VRTK_ObjectTouchAutoInteract.cs
@@ -63,7 +63,7 @@ namespace VRTK
 
         protected float regrabTimer;
         protected float reuseTimer;
-        protected HashSet<GameObject> touchers = new HashSet<GameObject>();
+        protected List<GameObject> touchers = new List<GameObject>();
 
         protected virtual void OnEnable()
         {
@@ -82,15 +82,15 @@ namespace VRTK
         {
             if (interactableObject != null && (continuousGrabCheck || continuousUseCheck))
             {
-                foreach (GameObject toucher in touchers)
+                for (int i = 0; i < touchers.Count; i++)
                 {
                     if (continuousGrabCheck)
                     {
-                        CheckGrab(toucher);
+                        CheckGrab(touchers[i]);
                     }
                     if (continuousUseCheck)
                     {
-                        CheckUse(toucher);
+                        CheckUse(touchers[i]);
                     }
                 }
             }
@@ -152,7 +152,7 @@ namespace VRTK
         {
             if (add)
             {
-                touchers.Add(interactingObject);
+                VRTK_SharedMethods.AddListValue(touchers, interactingObject, true);
             }
             else
             {

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -456,7 +456,7 @@ namespace VRTK
 
         protected virtual void MakeRenderersVisible()
         {
-            foreach (GameObject currentRenderer in makeRendererVisible)
+            foreach (GameObject currentRenderer in new HashSet<GameObject>(makeRendererVisible))
             {
                 ToggleRendererVisibility(currentRenderer, true);
             }

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -393,7 +393,7 @@ namespace VRTK
         public virtual void ResetIgnoredCollisions()
         {
             //Go through all the existing set up ignored colliders and reset their collision state
-            foreach (GameObject ignoreCollisionsOnGameObject in ignoreCollisionsOnGameObjects)
+            foreach (GameObject ignoreCollisionsOnGameObject in new HashSet<GameObject>(ignoreCollisionsOnGameObjects))
             {
                 if (ignoreCollisionsOnGameObject != null)
                 {

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -209,7 +209,7 @@ namespace VRTK
         {
             if (ValidInstance())
             {
-                foreach (Behaviour currentBehaviour in delayedToggleBehaviours)
+                foreach (Behaviour currentBehaviour in new HashSet<Behaviour>(delayedToggleBehaviours))
                 {
                     instance.AddBehaviourToToggleOnLoadedSetupChange(currentBehaviour);
                 }


### PR DESCRIPTION
There was an issue when using a HashSet and a foreach loop that if the
HashSet contents had changed during the iteration then an error would
be thrown.

The solution is to clone the HashSet before iterating over the clone
so any changes to the original HashSet don't affect the iteration.