### PR TITLE
Improve Oculus SDK controller detection

### DIFF
--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
@@ -88,7 +88,7 @@ namespace VRTK
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
         public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
-            switch (OVRInput.GetActiveController())
+            switch (OVRInput.GetConnectedControllers())
             {
                 case OVRInput.Controller.LTouch:
                 case OVRInput.Controller.RTouch:


### PR DESCRIPTION
Replace `OVRInput.GetActiveController` with `GetConnectedControllers` 
for earlier and more reliable controller type detection. 

GetActiveController only reports the type of the single controller 
whose inputs are being processed right now, whereas 
GetConnectedControllers reports the overall controller scheme type 
as soon as the SDK has connected to them.

Fixes #1712 (more discussion and justification in that thread)