### PR TITLE
fix(Pointers): handle destroyed origin transform follow

### DIFF
--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -153,7 +153,9 @@ namespace VRTK
         /// </summary>
         public virtual void ResetPointerObjects()
         {
+            DestroyPointerOriginTransformFollow();
             DestroyPointerObjects();
+            CreatePointerOriginTransformFollow();
             CreatePointerObjects();
         }
 
@@ -295,7 +297,7 @@ namespace VRTK
                 Destroy(objectInteractor);
             }
             controllerGrabScript = null;
-            Destroy(pointerOriginTransformFollowGameObject);
+            DestroyPointerOriginTransformFollow();
         }
 
         protected virtual void OnDestroy()
@@ -316,7 +318,10 @@ namespace VRTK
                 UpdateObjectInteractor();
             }
 
-            UpdatePointerOriginTransformFollow();
+            if (pointerOriginTransformFollow != null)
+            {
+                UpdatePointerOriginTransformFollow();
+            }
         }
 
         protected virtual void ToggleObjectInteraction(bool state)
@@ -608,6 +613,16 @@ namespace VRTK
             pointerOriginTransformFollow.enabled = false;
             pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnFixedUpdate;
             pointerOriginTransformFollow.followsScale = false;
+        }
+
+        protected virtual void DestroyPointerOriginTransformFollow()
+        {
+            if (pointerOriginTransformFollowGameObject != null)
+            {
+                Destroy(pointerOriginTransformFollowGameObject);
+                pointerOriginTransformFollowGameObject = null;
+                pointerOriginTransformFollow = null;
+            }
         }
 
         protected virtual float OverrideBeamLength(float currentLength)


### PR DESCRIPTION
## Problem

Proposed fix for https://github.com/thestonefox/VRTK/issues/1723

## Details
I can't think of a great way to know this object was destroyed from inside `VRTK_BasePointerRenderer` but the null check on the component reference does work.

This also recreates the references when the `ResetPointerObjects` metrhod is called. This is the hook I use on scene unload/load to re-create the objects. 

I know deleting these objects is unlikely in a single scene setup, but it's a quick way to see the error. 

## Alternative

Another possible solution here would be to create the objects in the same scene as the controllers and assume that would never be deleted. The benefit to this would be that it wouldn't require the call to `ResetPointers`, though that change may be warranted regardless? 

It would however require that I change the scene of the auto created objects: https://github.com/thestonefox/VRTK/blob/release/3.3.0-alpha/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs#L606

and change scenes on the object if it does not reside in the same scene as the controller 