### PR TITLE
fix(SharedMethods): change FindEvenInactive to search all loaded scenes

### DIFF
--- a/Assets/VRTK/Source/Editor/VRTK_SDKManagerEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_SDKManagerEditor.cs
@@ -380,7 +380,7 @@
                     SerializedProperty serializedProperty = setupsList.serializedProperty;
                     serializedProperty.ClearArray();
                     VRTK_SDKSetup[] setups = sdkManager.GetComponentsInChildren<VRTK_SDKSetup>(true)
-                                                       .Concat(VRTK_SharedMethods.FindEvenInactiveComponents<VRTK_SDKSetup>())
+                                                       .Concat(VRTK_SharedMethods.FindEvenInactiveComponents<VRTK_SDKSetup>(true))
                                                        .Distinct()
                                                        .ToArray();
 

--- a/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamController.cs
+++ b/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamController.cs
@@ -163,7 +163,7 @@ namespace VRTK
             controller = GetSDKManagerControllerRightHand(actual);
             if ((controller == null) && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<GvrControllerVisualManager>("Controller");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<GvrControllerVisualManager>("Controller", true);
             }
             if (controller != null)
             {

--- a/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRBoundaries.cs
@@ -37,7 +37,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                GameObject myHeadGO = VRTK_SharedMethods.FindEvenInactiveGameObject<HyHead>();
+                GameObject myHeadGO = VRTK_SharedMethods.FindEvenInactiveGameObject<HyHead>(null, true);
                 cachedPlayArea = (myHeadGO != null ? myHeadGO.transform.parent : null);
             }
             return cachedPlayArea;

--- a/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRController.cs
+++ b/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRController.cs
@@ -148,7 +148,7 @@ namespace VRTK
         {
             if (actual)
             {
-                HyTrackObjRig trackedObjRig = VRTK_SharedMethods.FindEvenInactiveComponent<HyTrackObjRig>();
+                HyTrackObjRig trackedObjRig = VRTK_SharedMethods.FindEvenInactiveComponent<HyTrackObjRig>(true);
                 if (trackedObjRig)
                 {
                     return trackedObjRig.leftController;
@@ -174,7 +174,7 @@ namespace VRTK
         {
             if (actual)
             {
-                HyTrackObjRig trackedObjRig = VRTK_SharedMethods.FindEvenInactiveComponent<HyTrackObjRig>();
+                HyTrackObjRig trackedObjRig = VRTK_SharedMethods.FindEvenInactiveComponent<HyTrackObjRig>(true);
                 if (trackedObjRig)
                 {
                     return trackedObjRig.rightController;

--- a/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRHeadset.cs
+++ b/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRHeadset.cs
@@ -44,7 +44,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                GameObject myHeadGO = VRTK_SharedMethods.FindEvenInactiveGameObject<HyHead>();
+                GameObject myHeadGO = VRTK_SharedMethods.FindEvenInactiveGameObject<HyHead>(null, true);
                 cachedHeadset = (myHeadGO != null ? myHeadGO.transform : null);
             }
             return cachedHeadset;
@@ -56,7 +56,7 @@ namespace VRTK
         /// <returns>A transform of the object holding the headset camera in the scene.</returns>
         public override Transform GetHeadsetCamera()
         {
-            GameObject myHeadsetCameraGO = VRTK_SharedMethods.FindEvenInactiveGameObject<HyCamera>();
+            GameObject myHeadsetCameraGO = VRTK_SharedMethods.FindEvenInactiveGameObject<HyCamera>(null, true);
             cachedHeadsetCamera = (myHeadsetCameraGO != null ? myHeadsetCameraGO.transform : null);
             return cachedHeadsetCamera;
         }

--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusBoundaries.cs
@@ -37,7 +37,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                OVRManager ovrManager = VRTK_SharedMethods.FindEvenInactiveComponent<OVRManager>();
+                OVRManager ovrManager = VRTK_SharedMethods.FindEvenInactiveComponent<OVRManager>(true);
                 if (ovrManager != null)
                 {
                     cachedPlayArea = ovrManager.transform;
@@ -122,7 +122,7 @@ namespace VRTK
         {
             if (avatarContainer == null)
             {
-                avatarContainer = VRTK_SharedMethods.FindEvenInactiveComponent<OvrAvatar>();
+                avatarContainer = VRTK_SharedMethods.FindEvenInactiveComponent<OvrAvatar>(true);
                 if (avatarContainer != null && avatarContainer.GetComponent<VRTK_TransformFollow>() == null)
                 {
                     VRTK_TransformFollow objectFollow = avatarContainer.gameObject.AddComponent<VRTK_TransformFollow>();

--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
@@ -234,7 +234,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerLeftHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/LeftHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/LeftHandAnchor", true);
             }
             return controller;
         }
@@ -249,7 +249,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerRightHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/RightHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/RightHandAnchor", true);
             }
             return controller;
         }

--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusHeadset.cs
@@ -46,7 +46,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                cachedHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/CenterEyeAnchor").transform;
+                cachedHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<OVRCameraRig>("TrackingSpace/CenterEyeAnchor", true).transform;
             }
             return cachedHeadset;
         }

--- a/Assets/VRTK/Source/SDK/Simulator/SDK_InputSimulator.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_InputSimulator.cs
@@ -154,7 +154,7 @@
         {
             if (cachedCameraRig == null && !destroyed)
             {
-                cachedCameraRig = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_InputSimulator>();
+                cachedCameraRig = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_InputSimulator>(null, true);
                 if (!cachedCameraRig)
                 {
                     VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_SCENE, "[VRSimulator_CameraRig]", "SDK_InputSimulator", ". check that the `VRTK/Prefabs/CameraRigs/[VRSimulator_CameraRig]` prefab been added to the scene."));

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRBoundaries.cs
@@ -47,7 +47,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                SteamVR_PlayArea steamVRPlayArea = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_PlayArea>();
+                SteamVR_PlayArea steamVRPlayArea = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_PlayArea>(true);
                 if (steamVRPlayArea != null)
                 {
                     cachedSteamVRPlayArea = steamVRPlayArea;

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
@@ -263,7 +263,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerLeftHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("Controller (left)");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("Controller (left)", true);
             }
             return controller;
         }
@@ -278,7 +278,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerRightHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("Controller (right)");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SteamVR_ControllerManager>("Controller (right)", true);
             }
             return controller;
         }

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRHeadset.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRHeadset.cs
@@ -45,9 +45,9 @@ namespace VRTK
             if (cachedHeadset == null)
             {
 #if (UNITY_5_4_OR_NEWER)
-                SteamVR_Camera foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
+                SteamVR_Camera foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>(true);
 #else
-                SteamVR_GameView foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_GameView>();
+                SteamVR_GameView foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_GameView>(true);
 #endif
                 if (foundCamera != null)
                 {
@@ -66,7 +66,7 @@ namespace VRTK
             cachedHeadsetCamera = GetSDKManagerHeadset();
             if (cachedHeadsetCamera == null)
             {
-                SteamVR_Camera foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>();
+                SteamVR_Camera foundCamera = VRTK_SharedMethods.FindEvenInactiveComponent<SteamVR_Camera>(true);
                 if (foundCamera != null)
                 {
                     cachedHeadsetCamera = foundCamera.transform;

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityBoundaries.cs
@@ -30,7 +30,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                GameObject foundCameraRig = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityCameraRig>();
+                GameObject foundCameraRig = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityCameraRig>(null, true);
                 if (foundCameraRig != null)
                 {
                     cachedPlayArea = foundCameraRig.transform;

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -247,7 +247,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerLeftHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityCameraRig>("LeftHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityCameraRig>("LeftHandAnchor", true);
             }
             return controller;
         }
@@ -262,7 +262,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerRightHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityCameraRig>("RightHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityCameraRig>("RightHandAnchor", true);
             }
             return controller;
         }

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityHeadset.cs
@@ -42,7 +42,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                GameObject foundHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityHeadsetTracker>();
+                GameObject foundHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<SDK_UnityHeadsetTracker>(null, true);
                 if (foundHeadset != null)
                 {
                     cachedHeadset = foundHeadset.transform;

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseBoundaries.cs
@@ -35,7 +35,7 @@ namespace VRTK
             cachedPlayArea = GetSDKManagerPlayArea();
             if (cachedPlayArea == null)
             {
-                VRContext vrContext = VRTK_SharedMethods.FindEvenInactiveComponent<VRContext>();
+                VRContext vrContext = VRTK_SharedMethods.FindEvenInactiveComponent<VRContext>(true);
                 if (Application.isPlaying)
                 {
                     vrContext.InitVRContext();

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -213,7 +213,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerLeftHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/LeftHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/LeftHandAnchor", true);
             }
             return controller;
         }
@@ -228,7 +228,7 @@ namespace VRTK
             GameObject controller = GetSDKManagerControllerRightHand(actual);
             if (controller == null && actual)
             {
-                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/RightHandAnchor");
+                controller = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/RightHandAnchor", true);
             }
             return controller;
         }

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseHeadset.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseHeadset.cs
@@ -88,7 +88,7 @@ namespace VRTK
             cachedHeadset = GetSDKManagerHeadset();
             if (cachedHeadset == null)
             {
-                var foundHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/CenterEyeAnchor");
+                var foundHeadset = VRTK_SharedMethods.FindEvenInactiveGameObject<VRContext>("TrackingSpace/CenterEyeAnchor", true);
                 if (foundHeadset)
                 {
                     cachedHeadset = foundHeadset.transform;

--- a/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_BaseObjectControlAction.cs
@@ -62,7 +62,7 @@ namespace VRTK
                         break;
                 }
             }
-            internalBodyPhysics = (internalBodyPhysics == null ? VRTK_SharedMethods.FindEvenInactiveComponent<VRTK_BodyPhysics>() : internalBodyPhysics);
+            internalBodyPhysics = (internalBodyPhysics == null ? VRTK_SharedMethods.FindEvenInactiveComponent<VRTK_BodyPhysics>(true) : internalBodyPhysics);
         }
 
         protected virtual void OnDisable()

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -145,7 +145,7 @@ namespace VRTK
             {
                 if (_instance == null)
                 {
-                    VRTK_SDKManager sdkManager = VRTK_SharedMethods.FindEvenInactiveComponent<VRTK_SDKManager>();
+                    VRTK_SDKManager sdkManager = VRTK_SharedMethods.FindEvenInactiveComponent<VRTK_SDKManager>(true);
                     if (sdkManager != null)
                     {
                         sdkManager.CreateInstance();

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -434,7 +434,7 @@ namespace VRTK
                 return;
             }
 
-            foreach (VRTK_SDKSetup setup in VRTK_SharedMethods.FindEvenInactiveComponents<VRTK_SDKSetup>())
+            foreach (VRTK_SDKSetup setup in VRTK_SharedMethods.FindEvenInactiveComponents<VRTK_SDKSetup>(true))
             {
                 setup.PopulateObjectReferences(false);
             }


### PR DESCRIPTION
This is an updated proposed fix for https://github.com/thestonefox/VRTK/issues/1580.

It builds on the work done by @peaj in this PR https://github.com/thestonefox/VRTK/pull/1645 with a few minor changes.  

# Problem

The problem is the same, I'm loading scenes additively and VRTK is only searching the active scene. 

# Solution

This PR fixes the problem (as originally proposed by @peaj) by iterating through all active scenes and searching for the component rather than only the active scene. 

# The change

The main difference in this version vs the one done by @peaj in https://github.com/thestonefox/VRTK/pull/1645 is just that I use a common private method with an option to avoid duplicating the code and leaving room for bugs in that sense.

This PR also remains backwards compatible with the `VRTK_SharedMethods` API, only searching the active scene by default while giving an option to search all scenes if needed.
