### PR TITLE
fix(Highlighters): use whiteTexture in place of new Texture

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
@@ -160,7 +160,7 @@ namespace VRTK.Highlighters
 
                     if (resetMainTexture && material.HasProperty("_MainTex"))
                     {
-                        renderer.material.SetTexture("_MainTex", new Texture());
+                        renderer.material.SetTexture("_MainTex", Texture2D.whiteTexture);
                     }
 
                     if (material.HasProperty("_Color"))


### PR DESCRIPTION
Fixes #1758 

Base class `Texture` constructor is inaccessible due to protection level.

Update to use `Texture2D.whiteTexture` which has been confirmed not to create new textures at runtime.