### PR TITLE
chore(SharedMethods): remove unnecessary variable assignment

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -634,7 +634,6 @@ namespace VRTK
                 Scene scene = SceneManager.GetSceneAt(sceneIndex);
                 if (scene.isLoaded && (searchAllScenes || scene == SceneManager.GetActiveScene()))
                 {
-                    GameObject[] rootObjects = scene.GetRootGameObjects();
                     foreach (GameObject rootObject in scene.GetRootGameObjects())
                     {
                         if (stopOnMatch)


### PR DESCRIPTION
As noticed by @virror, my bad for not catching this one.

@bddckr @thestonefox 