### PR TITLE
refactor(Editor): replace deprecated `EnumMaskField()`

### DIFF
--- a/Assets/VRTK/Source/Editor/VRTK_PolicyListEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_PolicyListEditor.cs
@@ -20,7 +20,11 @@
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("operation"));
+ #if UNITY_2017_3_OR_NEWER
+            staticFlagMask.intValue = (int)((VRTK_PolicyList.CheckTypes)EditorGUILayout.EnumFlagsField("Check Types", (VRTK_PolicyList.CheckTypes)staticFlagMask.intValue));
+ #else
             staticFlagMask.intValue = (int)((VRTK_PolicyList.CheckTypes)EditorGUILayout.EnumMaskField("Check Types", (VRTK_PolicyList.CheckTypes)staticFlagMask.intValue));
+ #endif
             ArrayGUI(identifiers);
 
             serializedObject.ApplyModifiedProperties();


### PR DESCRIPTION
[`EnumMaskField()`](https://docs.unity3d.com/ScriptReference/EditorGUILayout.EnumMaskField.html) is deprecated in Unity 2017.3 and its exact functionality was replaced by [`EnumFlagsField()`](https://docs.unity3d.com/ScriptReference/EditorGUILayout.EnumFlagsField.html).