### PR TITLE
fix(SharedMethods): Unused in FindEvenInactiveComponentsInScenes

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -634,7 +634,6 @@ namespace VRTK
                 Scene scene = SceneManager.GetSceneAt(sceneIndex);
                 if (scene.isLoaded && (searchAllScenes || scene == SceneManager.GetActiveScene()))
                 {
-                    GameObject[] rootObjects = scene.GetRootGameObjects();
                     foreach (GameObject rootObject in scene.GetRootGameObjects())
                     {
                         if (stopOnMatch)


### PR DESCRIPTION
## Fixes Warning of Unused Variable in FindEvenInactiveComponentsInLoadedScenes

Looks like the intent was to loop over `rootObjects` array which is
a copy of `scene.GetRootGameObjects()` but was calling
scene.GetRootGameObjects() again anyway in the foreach loop. It is
unecessary to make a copy though according to [a post on
stackexchange](https://stackoverflow.com/questions/30348356/in-c-sharp-does-foreach-call-method-in-each-loop).

## Console warning:
`Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs(637,34):
warning CS0219: The variable 'rootObjects' is assigned but its value
is never used`
