### PR TITLE
fix(SDKManager & SDKSetup): Obsolete hierarchyWindowChanged in Unity 2018.1

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -820,7 +820,11 @@ namespace VRTK
 
 #if UNITY_EDITOR
             //call AutoManageScriptingDefineSymbolsAndManageVRSettings when the currently active scene changes
+#if UNITY_2018_1_OR_NEWER
+            EditorApplication.hierarchyChanged += AutoManageScriptingDefineSymbolsAndManageVRSettings;
+#else
             EditorApplication.hierarchyWindowChanged += AutoManageScriptingDefineSymbolsAndManageVRSettings;
+#endif
 #endif
         }
 

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -423,7 +423,11 @@ namespace VRTK
         static VRTK_SDKSetup()
         {
             //call AutoPopulateObjectReferences when the currently active scene changes
+#if UNITY_2018_1_OR_NEWER
+            EditorApplication.hierarchyChanged += AutoPopulateObjectReferences;
+#else
             EditorApplication.hierarchyWindowChanged += AutoPopulateObjectReferences;
+#endif
         }
 
         [DidReloadScripts(2)]


### PR DESCRIPTION
I know that pull requests aren't accepted for fixes specific to beta versions of Unity, but submitting for when 2018.1 final is released.


Fixes console warnings in 2018.1.0b4 or newer:

> `warning CS0618: 'UnityEditor.EditorApplication.hierarchyWindowChanged' is obsolete: 'Use EditorApplication.hierarchyChanged'`


From Unity 2018.1.0b4 [Change Log](https://unity3d.com/unity/beta/unity2018.1.0b4):

> Editor: EditorApplication.hierarchyWindowChanged is now obsolete, superceded by EditorApplication.hierarchyChanged.