### PR TITLE
fix(SDKManager): Unity 2018 Requires "None" Device to Be Last

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -563,7 +563,7 @@ namespace VRTK
                 if (vrEnabled)
                 {
                     devices = setupCount > 1
-                                  ? new[] { "None" }.Concat(deviceNames).ToArray()
+                                  ? deviceNames.Concat(new[] { "None" }).ToArray()
                                   : deviceNames;
                 }
                 else


### PR DESCRIPTION
As it is right now "None" will be put at the top of the list in
Player Settings > XR Devices > VR Enabled Devices. In 2017 this
seemed be bypassed by default, but in 2018 the assumed intent is to
not start in VR mode.

This fix puts "None" last when the settings are auto managed.
