### PR TITLE
fix(Locomotion): fix player position offset after rotation

### DIFF
--- a/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_RotateObjectControlAction.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_RotateObjectControlAction.cs
@@ -32,11 +32,15 @@ namespace VRTK
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
+            CheckForPlayerBeforeRotation(controlledGameObject);
+
             float angle = Rotate(axis, modifierActive);
             if (angle != 0f)
             {
                 RotateAroundPlayer(controlledGameObject, angle);
             }
+
+            CheckForPlayerAfterRotation(controlledGameObject);
         }
 
         protected virtual float Rotate(float axis, bool modifierActive)

--- a/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_SnapRotateObjectControlAction.cs
+++ b/Assets/VRTK/Source/Scripts/Locomotion/ObjectControlActions/VRTK_SnapRotateObjectControlAction.cs
@@ -41,6 +41,8 @@ namespace VRTK
 
         protected override void Process(GameObject controlledGameObject, Transform directionDevice, Vector3 axisDirection, float axis, float deadzone, bool currentlyFalling, bool modifierActive)
         {
+            CheckForPlayerBeforeRotation(controlledGameObject);
+
             if (snapDelayTimer < Time.time && ValidThreshold(axis))
             {
                 float angle = Rotate(axis, modifierActive);
@@ -50,6 +52,8 @@ namespace VRTK
                     RotateAroundPlayer(controlledGameObject, angle);
                 }
             }
+
+            CheckForPlayerAfterRotation(controlledGameObject);
         }
 
         protected virtual bool ValidThreshold(float axis)


### PR DESCRIPTION
Player used to have an offset after rotation
through the scripts
VRTK_RotateObjectControlAction and
VRTK_SnapRotateObjectControlAction
(see #1693).
Gameobject [CameraRig] is moved after
rotation to compensate the offset.