### PR TITLE
chore(SDK): provide new location to Oculus SDK download

### DIFF
--- a/Assets/VRTK/Source/SDK/Oculus/README.md
+++ b/Assets/VRTK/Source/SDK/Oculus/README.md
@@ -1,8 +1,7 @@
 # Oculus Utilities
 
-## Instructions for using Oculus Utilities
+## Instructions for using Oculus Integration
 
- * Download the [Oculus Utilities](https://developer.oculus.com/downloads/package/oculus-utilities-for-unity-5/) from the Oculus developer website.
- * Import the `OculusUtilitiesX.XX.unitypackage`.
- * Follow the initial [Getting Started](/Assets/VRTK/Documentation/GETTING_STARTED.md) steps and then add the `OVRCameraRig` prefab from [Oculus Utilities](https://developer.oculus.com/downloads/package/oculus-utilities-for-unity-5/) as a child of the SDK Setup GameObject.
+ * Import the [Oculus Integration](https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022) from the Unity Asset Store.
+ * Follow the initial [Getting Started](/Assets/VRTK/Documentation/GETTING_STARTED.md) steps and then add the `OVRCameraRig` prefab from [Oculus Integration](https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022) as a child of the SDK Setup GameObject.
  * On the `OVRCameraRig` in the scene find the `OVRManager` and set its `Tracking Origin Type` to `Floor Level`.

--- a/Assets/VRTK/Source/SDK/SteamVR/README.md
+++ b/Assets/VRTK/Source/SDK/SteamVR/README.md
@@ -2,5 +2,5 @@
 
 ## Instructions for using SteamVR
 
- * Import the [SteamVR Plugin](https://www.assetstore.unity3d.com/en/#!/content/32647) from the Unity Asset Store.
- * Follow the initial [Getting Started](/Assets/VRTK/Documentation/GETTING_STARTED.md) steps and then add the `[CameraRig]` prefab from the [SteamVR Plugin](https://www.assetstore.unity3d.com/en/#!/content/32647) as a child of the SDK Setup GameObject.
+ * Import the [SteamVR Plugin](https://assetstore.unity.com/packages/templates/systems/steamvr-plugin-32647) from the Unity Asset Store.
+ * Follow the initial [Getting Started](/Assets/VRTK/Documentation/GETTING_STARTED.md) steps and then add the `[CameraRig]` prefab from the [SteamVR Plugin](https://assetstore.unity.com/packages/templates/systems/steamvr-plugin-32647) as a child of the SDK Setup GameObject.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 | UnityEngine.VR | _Core Unity3d library_ |
 | VR Simulator | _Included_ |
 | SteamVR | [SteamVR Plugin] |
-| Oculus | [Oculus Utilities] |
+| Oculus | [Oculus Integration] |
 | * Ximmerse | [Ximmerse Unity SDK] |
 | * Daydream | [Google VR SDK for Unity]
 | * HyperealVR | [Hypereal VR Unity Plugin]
 
-_* experimental_
+_* unsupported/experimental_
 
 ## Documentation
 
@@ -111,9 +111,9 @@ Code released under the [MIT License].
 
 Any Third Party Licenses can be viewed in [THIRD_PARTY_NOTICES.md].
 
-[SteamVR Plugin]: https://www.assetstore.unity3d.com/en/#!/content/32647
+[SteamVR Plugin]: https://assetstore.unity.com/packages/templates/systems/steamvr-plugin-32647
 [SteamVR Plugin for Unity3d Github Repo]: https://github.com/ValveSoftware/openvr/tree/master/unity_package/Assets/SteamVR
-[Oculus Utilities]: https://developer.oculus.com/downloads/package/oculus-utilities-for-unity-5/
+[Oculus Integration]: https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022
 [Ximmerse Unity SDK]: https://github.com/Ximmerse/SDK/tree/master/Unity
 [Google VR SDK for Unity]: https://developers.google.com/vr/unity/download
 [Hypereal VR Unity Plugin]: https://www.hypereal.com/#/developer/resource/download


### PR DESCRIPTION
The Oculus SDK for Unity is now available as a Unity asset on the Unity
Asset Store. This package includes the Oculus Avatar package as well so
out of the box provides controller visualisation support.

The documentation has been updated to point to this Unity asset as the
basis for getting Oculus SDK support rather than using the Oculus
Utilities download from the Oculus developer website.