### PR TITLE
fix(Examples): use final scene index for constructor scene

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_AdditiveSceneLoader.cs
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_AdditiveSceneLoader.cs
@@ -5,8 +5,6 @@
 
     public class VRTKExample_AdditiveSceneLoader : MonoBehaviour
     {
-        [Tooltip("The constructor scene containing the VRTK SDK Manager setup to load into the scene.")]
-        public Object sceneConstructor;
         [Tooltip("The GameObject to inject into the VRTK SDK Manager as the Left Controller Script Alias.")]
         public GameObject leftScriptAlias;
         [Tooltip("The GameObject to inject into the VRTK SDK Manager as the Right Controller Script Alias.")]
@@ -17,12 +15,14 @@
         public bool sdkSwitcher = true;
 
         protected VRTK_SDKSetupSwitcher setupSwitcher;
+        protected int constructorSceneIndex;
 
         protected virtual void Awake()
         {
+            constructorSceneIndex = SceneManager.sceneCountInBuildSettings - 1;
             ToggleScriptAlias(false);
             SceneManager.sceneLoaded += OnSceneLoaded;
-            SceneManager.LoadScene(sceneConstructor.name, LoadSceneMode.Additive);
+            SceneManager.LoadScene(constructorSceneIndex, LoadSceneMode.Additive);
         }
 
         protected virtual void LateUpdate()
@@ -35,7 +35,7 @@
 
         protected virtual void OnSceneLoaded(Scene loadedScene, LoadSceneMode loadMode)
         {
-            if (loadedScene.name == sceneConstructor.name)
+            if (loadedScene.buildIndex == constructorSceneIndex)
             {
                 VRTK_SDKManager sdkManager = FindObjectOfType<VRTK_SDKManager>();
                 sdkManager.gameObject.SetActive(false);

--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_SceneSwitcher.cs
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_SceneSwitcher.cs
@@ -8,6 +8,9 @@
         public KeyCode backKey = KeyCode.Backspace;
         public KeyCode forwardKey = KeyCode.Space;
 
+        protected int firstSceneIndex = 0;
+        protected int lastSceneIndex;
+
         protected bool pressEnabled;
         protected VRTK_ControllerReference controllerReference;
 
@@ -18,6 +21,7 @@
 
         protected virtual void OnEnable()
         {
+            lastSceneIndex = SceneManager.sceneCountInBuildSettings - 1;
             pressEnabled = false;
             Invoke("EnablePress", 1f);
         }
@@ -33,17 +37,17 @@
             if (ForwardPressed())
             {
                 nextSceneIndex++;
-                if (nextSceneIndex >= SceneManager.sceneCountInBuildSettings)
+                if (nextSceneIndex >= lastSceneIndex)
                 {
-                    nextSceneIndex = 1;
+                    nextSceneIndex = firstSceneIndex;
                 }
             }
             else if (BackPressed())
             {
                 nextSceneIndex--;
-                if (nextSceneIndex < 1)
+                if (nextSceneIndex < firstSceneIndex)
                 {
-                    nextSceneIndex = SceneManager.sceneCountInBuildSettings - 1;
+                    nextSceneIndex = lastSceneIndex - 1;
                 }
             }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,9 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/VRTK/Examples/VRTK_SDKManager_Constructor.unity
-    guid: 3fb19ae213a4a4d45bb9ecd245a8fadb
-  - enabled: 1
     path: Assets/VRTK/Examples/[001 - Interactions] ControllerEvents.unity
     guid: 7ef04a272395bf04f8fdc6ec410f464e
   - enabled: 1
@@ -29,3 +26,6 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/VRTK/Examples/[007 - Interactions] InteractionHelpers.unity
     guid: ea2236e506afcac41a7b82e176d839d1
+  - enabled: 1
+    path: Assets/VRTK/Examples/VRTK_SDKManager_Constructor.unity
+    guid: 3fb19ae213a4a4d45bb9ecd245a8fadb


### PR DESCRIPTION
Previously, the constructor scene was injected into the
AdditiveSceneLoader component as a `Object` type and then the `name`
of this object was used to identify the constructor scene which worked
fine when running in the Unity Editor but would fail in a build.

This is most likely because the `Object` type is not being injected
in a build and only works due to quirks in the editor.

The solution is now to ensure the final scene in Build Settings is the
constructor scene and then simply to use that index in the
AdditiveSceneLoader component and remove the ability to inject a scene.