### PR TITLE
fix(Examples): display error if script define symbols have not been set

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_AdditiveSceneLoader.cs
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_AdditiveSceneLoader.cs
@@ -2,6 +2,8 @@
 {
 #if UNITY_EDITOR
     using UnityEditor;
+    using System.Collections.Generic;
+    using System.Linq;
 #endif
     using UnityEngine;
     using UnityEngine.SceneManagement;
@@ -26,6 +28,7 @@
 
         protected virtual void Awake()
         {
+            CheckScriptingDefineSymbols();
             if (!Application.isPlaying && Application.isEditor)
             {
                 ManageBuildSettings();
@@ -44,6 +47,20 @@
                     SceneManager.LoadScene(constructorSceneIndex, LoadSceneMode.Additive);
                 }
             }
+        }
+        protected virtual void CheckScriptingDefineSymbols()
+        {
+#if UNITY_EDITOR
+            bool isMissingSDKSymbols = PlayerSettings
+                .GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup)
+                .Split(';')
+                .All(symbol => !symbol.StartsWith(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix, System.StringComparison.Ordinal));
+
+            if (isMissingSDKSymbols)
+            {
+                VRTK_Logger.Error("No VRTK scripting define symbols have been found. " + VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND), true);
+            }
+#endif
         }
 
         protected virtual void ManageBuildSettings()

--- a/Assets/VRTK/Examples/README.md
+++ b/Assets/VRTK/Examples/README.md
@@ -1,5 +1,9 @@
 # Examples
 
+**Important Note**
+
+> The example scenes no longer contain the `VRTK_SDKManager` as this is loaded in at runtime via the `VRTK_SDKManager_Constructor` scene. As the `VRTK_SDKManager` script is responsible for setting up the required Unity Scripting Define Symbols for installed SDKs it is required that the `VRTK_SDKManager_Constructor` scene is opened in the Unity Editor when first using the project or when installing a new supported SDK so it can set up the scripting define symbols. The example scenes will not work until the scripting define symbols have been set up correctly so please ensure that the `VRTK_SDKManager_Constructor` scene is loaded into the Unity Editor first.
+
 This directory contains Unity3d scenes that demonstrate the scripts and prefabs being used in the game world to create desired functionality.
 
 > *VRTK offers a VR Simulator that works without any third party SDK, but VR device support requires a supported VR SDK to be imported into the Unity project.*

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_Logger.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_Logger.cs
@@ -34,7 +34,8 @@
             SDK_NOT_FOUND,
             SDK_MANAGER_ERRORS,
             SCRIPTING_DEFINE_SYMBOLS_ADDED,
-            SCRIPTING_DEFINE_SYMBOLS_REMOVED
+            SCRIPTING_DEFINE_SYMBOLS_REMOVED,
+            SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND
         }
 
         public static VRTK_Logger instance = null;
@@ -51,7 +52,8 @@
             { CommonMessageKeys.SDK_NOT_FOUND, "The SDK '{0}' doesn't exist anymore. The fallback SDK '{1}' will be used instead." },
             { CommonMessageKeys.SDK_MANAGER_ERRORS, "The current SDK Manager setup is causing the following errors:\n\n{0}" },
             { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_ADDED, "Scripting Define Symbols added to [Project Settings->Player] for {0}: {1}" },
-            { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_REMOVED, "Scripting Define Symbols removed from [Project Settings->Player] for {0}: {1}" }
+            { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_REMOVED, "Scripting Define Symbols removed from [Project Settings->Player] for {0}: {1}" },
+            { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND, "If you are attempting to run an example scene and have not opened the `VRTK/Examples/VRTK_SDKManager_Constructor` scene in the Unity Editor then this is most likely why you are receiving this error message, try opening the `VRTK/Examples/VRTK_SDKManager_Constructor` scene and letting it configure the relevant scripting define symbols and then re-open the desired example scene and try again." }
         };
 
         public static Dictionary<CommonMessageKeys, int> commonMessageParts = new Dictionary<CommonMessageKeys, int>();
@@ -124,22 +126,22 @@
             Log(LogLevels.Warn, message);
         }
 
-        public static void Error(string message)
+        public static void Error(string message, bool forcePause = false)
         {
-            Log(LogLevels.Error, message);
+            Log(LogLevels.Error, message, forcePause);
         }
 
-        public static void Fatal(string message)
+        public static void Fatal(string message, bool forcePause = false)
         {
-            Log(LogLevels.Fatal, message);
+            Log(LogLevels.Fatal, message, forcePause);
         }
 
-        public static void Fatal(Exception exception)
+        public static void Fatal(Exception exception, bool forcePause = false)
         {
-            Log(LogLevels.Fatal, exception.Message);
+            Log(LogLevels.Fatal, exception.Message, forcePause);
         }
 
-        public static void Log(LogLevels level, string message)
+        public static void Log(LogLevels level, string message, bool forcePause = false)
         {
 #if VRTK_NO_LOGGING
             return;
@@ -163,6 +165,11 @@
                     break;
                 case LogLevels.Error:
                 case LogLevels.Fatal:
+                    if (forcePause)
+                    {
+                        UnityEngine.Debug.Break();
+                    }
+
                     if (instance.throwExceptions)
                     {
                         throw new Exception(message);

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -493,7 +493,7 @@ namespace VRTK
 
                 if (installedInfos.Select(installedInfo => installedInfo.type).Contains(selectedType))
                 {
-                    return description + " Its needed scripting define symbols are not added. You can click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and choose to automatically let the manager handle the scripting define symbols.";
+                    return description + " Its needed scripting define symbols are not added. You can click the GameObject with the `VRTK_SDKManager` script attached to it in Edit Mode and choose to automatically let the manager handle the scripting define symbols." + VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND);
                 }
 
                 return description + " The needed vendor SDK isn't installed.";

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ see if your query has already been answered.
  * Open the folder in Unity to load the project.
  * Have a look at the included example scenes.
 
+**Important Note**
+
+> The example scenes no longer contain the `VRTK_SDKManager` as this is loaded in at runtime via the `VRTK_SDKManager_Constructor` scene. As the `VRTK_SDKManager` script is responsible for setting up the required Unity Scripting Define Symbols for installed SDKs it is required that the `VRTK_SDKManager_Constructor` scene is opened in the Unity Editor when first using the project or when installing a new supported SDK so it can set up the scripting define symbols. The example scenes will not work until the scripting define symbols have been set up correctly so please ensure that the `VRTK_SDKManager_Constructor` scene is loaded into the Unity Editor first.
+
 The example scenes support all the VRTK supported VR SDKs. To make use
 of VR devices (besides the included VR Simulator) import the needed
 third party VR SDK into the project.


### PR DESCRIPTION
There is an issue where the new example scenes don't set the required
VRTK script define symbols because this is done via the SDK Manager
script and that is no longer present in the example scenes as it is
dynamically loaded in via the constructor scene.

This fix simply throws an error if the example scene cannot find the
required scripting define symbols and attempts to provide useful
information for the user to rectify the issue.