### PR TITLE
fix(SDK): exclude WindowsMR from unsupported versions of Unity

### DIFF
--- a/Assets/VRTK/Source/SDK/WindowsMR/Resources/WindowsMR_Camera.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/Resources/WindowsMR_Camera.cs
@@ -1,7 +1,13 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+#if UNITY_2017_2_OR_NEWER
     using UnityEngine.XR;
+#else
+    using UnityEngine.VR;
+    using XRSettings = UnityEngine.VR.VRSettings;
+    using XRDevice = UnityEngine.VR.VRDevice;
+#endif
 
     /// <summary>
     /// Camera script for the main camera for Immersive Mixed Reality. 

--- a/Assets/VRTK/Source/SDK/WindowsMR/Resources/WindowsMR_TrackedObject.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/Resources/WindowsMR_TrackedObject.cs
@@ -1,8 +1,8 @@
 ﻿namespace VRTK
 {
-    using System.Collections;
     using UnityEngine;
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
+    using System.Collections;
     using UnityEngine.XR.WSA.Input;
     using VRTK.WindowsMixedReality.Utilities;
 #endif
@@ -12,7 +12,7 @@
 
     public class WindowsMR_TrackedObject : MonoBehaviour
     {
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         private struct ButtonState
         {
             //

--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRBoundaries.cs
@@ -3,10 +3,15 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Collections.Generic;
-    using UnityEngine.Experimental.XR;
+#if UNITY_2017_2_OR_NEWER
     using UnityEngine.XR;
+    using UnityEngine.Experimental.XR;
 #if VRTK_DEFINE_SDK_WINDOWSMR
     using UnityEngine.XR.WSA;
+#endif
+#else
+    using UnityEngine.VR;
+    using XRDevice = UnityEngine.VR.VRDevice;
 #endif
 
     /// <summary>
@@ -14,13 +19,13 @@ namespace VRTK
     /// </summary>
     [SDK_Description(typeof(SDK_WindowsMR))]
     public class SDK_WindowsMRBoundaries
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         : SDK_BaseBoundaries
 #else
         : SDK_FallbackBoundaries
 #endif
     {
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         /// <summary>
         /// The GetDrawAtRuntime method returns whether the given play area drawn border is being displayed.
         /// </summary>
@@ -71,7 +76,7 @@ namespace VRTK
         public override Vector3[] GetPlayAreaVertices()
         {
             List<Vector3> boundaryGeometry = new List<Vector3>(0);
-
+#if UNITY_2017_2_OR_NEWER
             if (Boundary.TryGetGeometry(boundaryGeometry))
             {
                 if (boundaryGeometry.Count > 0)
@@ -86,7 +91,7 @@ namespace VRTK
                     Debug.LogWarning("Boundary has no points");
                 }
             }
-
+#endif
             return null;
         }
 
@@ -95,7 +100,11 @@ namespace VRTK
         /// </summary>
         public override void InitBoundaries()
         {
-            if (HolographicSettings.IsDisplayOpaque)
+            bool isDisplayOpaque = false;
+#if UNITY_2017_2_OR_NEWER
+            isDisplayOpaque = HolographicSettings.IsDisplayOpaque;
+#endif
+            if (isDisplayOpaque)
             {
                 // Defaulting coordinate system to RoomScale in immersive headsets.
                 // This puts the origin 0,0,0 on the floor if a floor has been established during RunSetup via MixedRealityPortal

--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRController.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRController.cs
@@ -3,7 +3,7 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Collections.Generic;
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
     using UnityEngine.XR.WSA.Input;
 #endif
 #if VRTK_DEFINE_WINDOWSMR_CONTROLLER_VISUALIZATION
@@ -15,13 +15,13 @@ namespace VRTK
     /// </summary>
     [SDK_Description(typeof(SDK_WindowsMR))]
     public class SDK_WindowsMRController
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         : SDK_BaseController
 #else
         : SDK_FallbackController
 #endif
     {
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         protected WindowsMR_TrackedObject cachedLeftTrackedObject;
         protected WindowsMR_TrackedObject cachedRightTrackedObject;
         protected VRTK_VelocityEstimator cachedLeftVelocityEstimator;

--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRHeadset.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRHeadset.cs
@@ -9,13 +9,13 @@ namespace VRTK
     /// </summary>
     [SDK_Description(typeof(SDK_WindowsMR))]
     public class SDK_WindowsMRHeadset
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         : SDK_BaseHeadset
 #else
         : SDK_FallbackHeadset
 #endif
     {
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         protected Vector3 currentHeadsetPosition;
         protected Vector3 previousHeadsetPosition;
         protected Vector3 currentHeadsetVelocity;

--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRSystem.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRSystem.cs
@@ -6,13 +6,13 @@ namespace VRTK
     /// </summary>
     [SDK_Description("WindowsMR", SDK_WindowsMRDefines.ScriptingDefineSymbol, "WindowsMR", "WSA")]
     public class SDK_WindowsMR
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         : SDK_BaseSystem
 #else
         : SDK_FallbackSystem
 #endif
     {
-#if VRTK_DEFINE_SDK_WINDOWSMR
+#if VRTK_DEFINE_SDK_WINDOWSMR && UNITY_2017_2_OR_NEWER
         /// <summary>
         /// The ForceInterleavedReprojectionOn method determines whether Interleaved Reprojection should be forced on or off.
         /// </summary>


### PR DESCRIPTION
Many of the required WindowsMR libraries didn't appear until
Unity 2017.2 and beyond, so this fix ensures that any libraries
that didn't appear until 2017.2 are commented out so they don't
create errors. As Windows MR features shouldn't be used on anything
prior to Unity 2017.3 then this is a fair solution.