### PR TITLE
fix(Examples): remove script define symbol check and provide popup

### DIFF
--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_AdditiveSceneLoader.cs
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_AdditiveSceneLoader.cs
@@ -2,8 +2,6 @@
 {
 #if UNITY_EDITOR
     using UnityEditor;
-    using System.Collections.Generic;
-    using System.Linq;
 #endif
     using UnityEngine;
     using UnityEngine.SceneManagement;
@@ -28,7 +26,6 @@
 
         protected virtual void Awake()
         {
-            CheckScriptingDefineSymbols();
             if (!Application.isPlaying && Application.isEditor)
             {
                 ManageBuildSettings();
@@ -47,20 +44,6 @@
                     SceneManager.LoadScene(constructorSceneIndex, LoadSceneMode.Additive);
                 }
             }
-        }
-        protected virtual void CheckScriptingDefineSymbols()
-        {
-#if UNITY_EDITOR
-            bool isMissingSDKSymbols = PlayerSettings
-                .GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup)
-                .Split(';')
-                .All(symbol => !symbol.StartsWith(SDK_ScriptingDefineSymbolPredicateAttribute.RemovableSymbolPrefix, System.StringComparison.Ordinal));
-
-            if (isMissingSDKSymbols)
-            {
-                VRTK_Logger.Error("No VRTK scripting define symbols have been found. " + VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND), true);
-            }
-#endif
         }
 
         protected virtual void ManageBuildSettings()

--- a/Assets/VRTK/Source/Editor/VRTK_ExampleSetupInfoEditor.cs
+++ b/Assets/VRTK/Source/Editor/VRTK_ExampleSetupInfoEditor.cs
@@ -1,0 +1,93 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using UnityEditor;
+    using UnityEditor.SceneManagement;
+
+    [InitializeOnLoad]
+    public sealed class VRTK_ExampleSetupInfoEditor : EditorWindow
+    {
+        private static VRTK_ExampleSetupInfoEditor promptWindow;
+        private static Vector2 scrollPosition;
+        private const string hideInfoBoxKey = "VRTK.ExampleSetupInfo";
+        private const string toggleText = "Do not show this message again.";
+        private const string buttonText = "Close";
+
+        static VRTK_ExampleSetupInfoEditor()
+        {
+            EditorSceneManager.sceneOpened += SceneOpened;
+        }
+
+        [MenuItem("Window/VRTK/Example Setup Information")]
+        public static void ShowWindow()
+        {
+            if (promptWindow != null)
+            {
+                promptWindow.ShowUtility();
+                promptWindow.Repaint();
+                return;
+            }
+
+            promptWindow = GetWindow<VRTK_ExampleSetupInfoEditor>(true);
+            promptWindow.titleContent = new GUIContent("VRTK Example Setup Information");
+            promptWindow.minSize = new Vector2(500, 150);
+        }
+
+        private static void SceneOpened(UnityEngine.SceneManagement.Scene scene, OpenSceneMode mode)
+        {
+            AttemptShowWindow();
+        }
+
+        private static void AttemptShowWindow()
+        {
+            if (!EditorPrefs.HasKey(hideInfoBoxKey))
+            {
+                ShowWindow();
+            }
+        }
+
+        private void OnGUI()
+        {
+            using (EditorGUILayout.ScrollViewScope scrollViewScope = new EditorGUILayout.ScrollViewScope(scrollPosition))
+            {
+                scrollPosition = scrollViewScope.scrollPosition;
+                using (new EditorGUILayout.VerticalScope(EditorStyles.textArea))
+                {
+                    GUIStyle labelStyle = new GUIStyle(EditorStyles.label)
+                    {
+                        fontSize = 14,
+                        wordWrap = true,
+                        margin = new RectOffset(10, 10, 5, 0)
+                    };
+                    EditorGUILayout.LabelField(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND), labelStyle, GUILayout.ExpandHeight(true));
+                }
+            }
+
+            GUILayout.Space(10);
+
+            using (EditorGUI.ChangeCheckScope changeShowMessage = new EditorGUI.ChangeCheckScope())
+            {
+                bool hideToggle = EditorPrefs.HasKey(hideInfoBoxKey);
+
+                hideToggle = GUILayout.Toggle(hideToggle, toggleText);
+
+                if (changeShowMessage.changed)
+                {
+                    if (hideToggle)
+                    {
+                        EditorPrefs.SetBool(hideInfoBoxKey, true);
+                    }
+                    else
+                    {
+                        EditorPrefs.DeleteKey(hideInfoBoxKey);
+                    }
+                }
+            }
+
+            if (GUILayout.Button(buttonText))
+            {
+                Close();
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Source/Editor/VRTK_ExampleSetupInfoEditor.cs.meta
+++ b/Assets/VRTK/Source/Editor/VRTK_ExampleSetupInfoEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 646376142a228fa44b7083d718411ca6
+timeCreated: 1522245501
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 90d37a8f8d07cfc4cbbc2aced31167ae, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_Logger.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_Logger.cs
@@ -53,7 +53,7 @@
             { CommonMessageKeys.SDK_MANAGER_ERRORS, "The current SDK Manager setup is causing the following errors:\n\n{0}" },
             { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_ADDED, "Scripting Define Symbols added to [Project Settings->Player] for {0}: {1}" },
             { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_REMOVED, "Scripting Define Symbols removed from [Project Settings->Player] for {0}: {1}" },
-            { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND, "If you are attempting to run an example scene and have not opened the `VRTK/Examples/VRTK_SDKManager_Constructor` scene in the Unity Editor then this is most likely why you are receiving this error message, try opening the `VRTK/Examples/VRTK_SDKManager_Constructor` scene and letting it configure the relevant scripting define symbols and then re-open the desired example scene and try again." }
+            { CommonMessageKeys.SCRIPTING_DEFINE_SYMBOLS_NOT_FOUND, "Before running any of the included example scenes, you must open `Assets/VRTK/Examples/VRTK_SDKManager_Constructor` scene when adding support for 3rd party SDKs (e.g. SteamVR, Oculus) so the SDK Manager in that scene can set up the required scripting defines." }
         };
 
         public static Dictionary<CommonMessageKeys, int> commonMessageParts = new Dictionary<CommonMessageKeys, int>();


### PR DESCRIPTION
The previous way of attempting to notify the user that they need to
open the example constructor scene before opening any of the example
scenes did not work if no 3rd party SDK was installed that required
it. It would simply just continually throw the error message.

The new solution is not to try and second guess what the set up is
automatically and to just provide a popup window with information
for the user on requiring them to open the constructor example scene.