### PR TITLE
fix(SDK): update Google SDK vrDeviceName

### DIFF
--- a/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamSystem.cs
+++ b/Assets/VRTK/Source/SDK/Daydream/SDK_DaydreamSystem.cs
@@ -4,7 +4,7 @@ namespace VRTK
     /// <summary>
     /// The Daydream System SDK script provides dummy functions for system functions.
     /// </summary>
-    [SDK_Description("Google Daydream (Android:Daydream)", SDK_DaydreamDefines.ScriptingDefineSymbol, "Daydream", "Android")]
+    [SDK_Description("Google Daydream (Android:Daydream)", SDK_DaydreamDefines.ScriptingDefineSymbol, "daydream", "Android")]
     public class SDK_DaydreamSystem
 #if VRTK_DEFINE_SDK_DAYDREAM
         : SDK_BaseSystem

--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnitySystem.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnitySystem.cs
@@ -6,8 +6,8 @@ namespace VRTK
     /// </summary>
     [SDK_Description("Unity (Standalone:Oculus)", null, "Oculus", "Standalone")]
     [SDK_Description("Unity (Standalone:OpenVR)", null, "OpenVR", "Standalone", 1)]
-    [SDK_Description("Unity (Android:Cardboard)", null, "Cardboard", "Android", 2)]
-    [SDK_Description("Unity (Android:Daydream)", null, "Daydream", "Android", 3)]
+    [SDK_Description("Unity (Android:Cardboard)", null, "cardboard", "Android", 2)]
+    [SDK_Description("Unity (Android:Daydream)", null, "daydream", "Android", 3)]
     [SDK_Description("Unity (Android:Oculus)", null, "Oculus", "Android", 4)]
     [SDK_Description("Unity (Android:OpenVR)", null, "OpenVR", "Android", 5)]
     public class SDK_UnitySystem : SDK_BaseSystem

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseSystem.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseSystem.cs
@@ -5,7 +5,7 @@ namespace VRTK
     /// The Ximmerse System SDK script provides a bridge to the Ximmerse SDK.
     /// </summary>
     [SDK_Description("Ximmerse (Standalone:Oculus)", SDK_XimmerseDefines.ScriptingDefineSymbol, "Oculus", "Standalone")]
-    [SDK_Description("Ximmerse (Android:Daydream)", SDK_XimmerseDefines.ScriptingDefineSymbol, "Daydream", "Android", 1)]
+    [SDK_Description("Ximmerse (Android:Daydream)", SDK_XimmerseDefines.ScriptingDefineSymbol, "daydream", "Android", 1)]
     public class SDK_XimmerseSystem
 #if VRTK_DEFINE_SDK_XIMMERSE
         : SDK_BaseSystem


### PR DESCRIPTION
The latest version of the Google VR SDK (v1.110.0 released 2017-11-08)
uses the string constant "daydream" as the VRSettings.loadedDeviceName.
See GoogleVR/Scripts/GvrSettings.cs

This also applies to the built in Unity SDK for Daydream and for
Cardboard.

Co-authored-by: Ty <2926368+tnterdan@users.noreply.github.com>