### PR TITLE
fix(Presence): provide custom boxcast to ensure correct settings used

### DIFF
--- a/Assets/VRTK/Documentation/API.md
+++ b/Assets/VRTK/Documentation/API.md
@@ -9719,13 +9719,32 @@ The Linecast method is used to generate a linecast either from the given CustomR
    * `float radius` - The radius of the capsule.
    * `Vector3 direction` - The direction into which to sweep the capsule.
    * `float maxDistance` - The max length of the sweep.
-   * `out RaycastHit hitData` - The linecast hit data.
-   * `LayerMask ignoreLayers` - A layermask of layers to ignore from the linecast.
+   * `out RaycastHit hitData` - The capsulecast hit data.
+   * `LayerMask ignoreLayers` - A layermask of layers to ignore from the capsulecast.
    * `QueryTriggerInteraction affectTriggers` - Determines the trigger interaction level of the cast.
  * Returns
-   * `bool` - Returns true if the linecast successfully collides with a valid object.
+   * `bool` - Returns true if the capsulecast successfully collides with a valid object.
 
-The CapsuleCast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
+The CapsuleCast method is used to generate a capsulecast either from the given CustomRaycast object or a default Physics.CapsuleCast.
+
+#### BoxCast/9
+
+  > `public static bool BoxCast(VRTK_CustomRaycast customCast, Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)`
+
+ * Parameters
+   * `VRTK_CustomRaycast customCast` - The optional object with customised cast parameters.
+   * `Vector3 center` - The center of the box.
+   * `Vector3 halfExtents` - Half the size of the box in each dimension.
+   * `Vector3 direction` - The direction in which to cast the box.
+   * `Quaternion orientation` - The rotation of the box.
+   * `float maxDistance` - The max length of the cast.
+   * `out RaycastHit hitData` - The boxcast hit data.
+   * `LayerMask ignoreLayers` - A layermask of layers to ignore from the boxcast.
+   * `QueryTriggerInteraction affectTriggers` - Determines the trigger interaction level of the cast.
+ * Returns
+   * `bool` - Returns true if the boxcast successfully collides with a valid object.
+
+The BoxCast method is used to generate a boxcast either from the given CustomRaycast object or a default Physics.BoxCast.
 
 #### CustomRaycast/3
 
@@ -9768,6 +9787,22 @@ The CustomLinecast method is used to generate a linecast based on the options de
    * `bool` - Returns true if the capsule successfully collides with a valid object.
 
 The CustomCapsuleCast method is used to generate a capsulecast based on the options defined in the CustomRaycast object.
+
+#### CustomBoxCast/6
+
+  > `public virtual bool CustomBoxCast(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance, out RaycastHit hitData)`
+
+ * Parameters
+   * `Vector3 center` - The center of the box.
+   * `Vector3 halfExtents` - Half the size of the box in each dimension.
+   * `Vector3 direction` - The direction in which to cast the box.
+   * `Quaternion orientation` - The rotation of the box.
+   * `float maxDistance` - The max length of the cast.
+   * `out RaycastHit hitData` - The boxcast hit data.
+ * Returns
+   * `bool` - Returns true if the box successfully collides with a valid object.
+
+The CustomBoxCast method is used to generate a boxcast based on the options defined in the CustomRaycast object.
 
 ---
 

--- a/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
+++ b/Assets/VRTK/Source/Scripts/Presence/VRTK_BodyPhysics.cs
@@ -963,9 +963,10 @@ namespace VRTK
                 Vector3 colliderWorldCenter = playArea.TransformPoint(footCollider.center);
                 Vector3 castStart = new Vector3(colliderWorldCenter.x, colliderWorldCenter.y + (CalculateStepUpYOffset() * stepYIncrement), colliderWorldCenter.z);
                 Vector3 castExtents = new Vector3(bodyCollider.radius, boxCastHeight, bodyCollider.radius);
-                RaycastHit floorCheckHit;
                 float castDistance = castStart.y - playArea.position.y;
-                if (Physics.BoxCast(castStart, castExtents, Vector3.down, out floorCheckHit, Quaternion.identity, castDistance) && (floorCheckHit.point.y - playArea.position.y) > stepDropThreshold)
+                RaycastHit floorCheckHit;
+                bool floorHit = VRTK_CustomRaycast.BoxCast(customRaycast, castStart, castExtents, Vector3.down, Quaternion.identity, castDistance, out floorCheckHit, defaultIgnoreLayer, QueryTriggerInteraction.Ignore);
+                if (floorHit && (floorCheckHit.point.y - playArea.position.y) > stepDropThreshold)
                 {
                     //If there is a teleporter attached then use that to move
                     if (teleporter != null && enableTeleport)

--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_CustomRaycast.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_CustomRaycast.cs
@@ -64,7 +64,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The CapsuleCast method is used to generate a linecast either from the given CustomRaycast object or a default Physics.Linecast.
+        /// The CapsuleCast method is used to generate a capsulecast either from the given CustomRaycast object or a default Physics.CapsuleCast.
         /// </summary>
         /// <param name="customCast">The optional object with customised cast parameters.</param>
         /// <param name="point1">The center of the sphere at the start of the capsule.</param>
@@ -72,10 +72,10 @@ namespace VRTK
         /// <param name="radius">The radius of the capsule.</param>
         /// <param name="direction">The direction into which to sweep the capsule.</param>
         /// <param name="maxDistance">The max length of the sweep.</param>
-        /// <param name="hitData">The linecast hit data.</param>
-        /// <param name="ignoreLayers">A layermask of layers to ignore from the linecast.</param>
+        /// <param name="hitData">The capsulecast hit data.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the capsulecast.</param>
         /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
-        /// <returns>Returns true if the linecast successfully collides with a valid object.</returns>
+        /// <returns>Returns true if the capsulecast successfully collides with a valid object.</returns>
         public static bool CapsuleCast(VRTK_CustomRaycast customCast, Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
@@ -85,6 +85,31 @@ namespace VRTK
             else
             {
                 return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
+        /// The BoxCast method is used to generate a boxcast either from the given CustomRaycast object or a default Physics.BoxCast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="center">The center of the box.</param>
+        /// <param name="halfExtents">Half the size of the box in each dimension.</param>
+        /// <param name="direction">The direction in which to cast the box.</param>
+        /// <param name="orientation">The rotation of the box.</param>
+        /// <param name="maxDistance">The max length of the cast.</param>
+        /// <param name="hitData">The boxcast hit data.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the boxcast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns true if the boxcast successfully collides with a valid object.</returns>
+        public static bool BoxCast(VRTK_CustomRaycast customCast, Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomBoxCast(center, halfExtents, direction, orientation, maxDistance, out hitData);
+            }
+            else
+            {
+                return Physics.BoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance, ~ignoreLayers, affectTriggers);
             }
         }
 
@@ -125,6 +150,21 @@ namespace VRTK
         public virtual bool CustomCapsuleCast(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, out RaycastHit hitData)
         {
             return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomBoxCast method is used to generate a boxcast based on the options defined in the CustomRaycast object.
+        /// </summary>
+        /// <param name="center">The center of the box.</param>
+        /// <param name="halfExtents">Half the size of the box in each dimension.</param>
+        /// <param name="direction">The direction in which to cast the box.</param>
+        /// <param name="orientation">The rotation of the box.</param>
+        /// <param name="maxDistance">The max length of the cast.</param>
+        /// <param name="hitData">The boxcast hit data.</param>
+        /// <returns>Returns true if the box successfully collides with a valid object.</returns>
+        public virtual bool CustomBoxCast(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance, out RaycastHit hitData)
+        {
+            return Physics.BoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance, ~layersToIgnore, triggerInteraction);
         }
     }
 }


### PR DESCRIPTION
The Body Physics script was doing a BoxCast but always just using the
default `Physics.BoxCast` which meant it never took into consideration
the custom raycast settings being applied.

The CustomRaycast script now contains a CustomBoxCast method that the
Body Physics script is now using which brings it in line with other
raycast types.