### PR TITLE
fix(SDK): handle multiple Oculus devices - fixes #1762

### DIFF
--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
@@ -88,22 +88,32 @@ namespace VRTK
         /// <returns>The ControllerType based on the SDK and headset being used.</returns>
         public override ControllerType GetCurrentControllerType(VRTK_ControllerReference controllerReference = null)
         {
-            switch (OVRInput.GetConnectedControllers())
+            OVRInput.Controller connectedControllers = OVRInput.GetConnectedControllers();
+            if ((connectedControllers & (OVRInput.Controller.LTouch | OVRInput.Controller.RTouch | OVRInput.Controller.Touch)) != 0)
             {
-                case OVRInput.Controller.LTouch:
-                case OVRInput.Controller.RTouch:
-                case OVRInput.Controller.Touch:
-                    return ControllerType.Oculus_OculusTouch;
-                case OVRInput.Controller.Remote:
-                    return ControllerType.Oculus_OculusRemote;
-                case OVRInput.Controller.Gamepad:
-                    return ControllerType.Oculus_OculusGamepad;
-                case OVRInput.Controller.Touchpad:
-                    return ControllerType.Oculus_GearVRHMD;
-                case OVRInput.Controller.LTrackedRemote:
-                case OVRInput.Controller.RTrackedRemote:
-                    return ControllerType.Oculus_GearVRController;
+                return ControllerType.Oculus_OculusTouch;
             }
+
+            if ((connectedControllers & OVRInput.Controller.Remote) == OVRInput.Controller.Remote)
+            {
+                return ControllerType.Oculus_OculusRemote;
+            }
+
+            if ((connectedControllers & OVRInput.Controller.Gamepad) == OVRInput.Controller.Gamepad)
+            {
+                return ControllerType.Oculus_OculusGamepad;
+            }
+
+            if ((connectedControllers & OVRInput.Controller.Touchpad) == OVRInput.Controller.Touchpad)
+            {
+                return ControllerType.Oculus_GearVRHMD;
+            }
+
+            if ((connectedControllers & (OVRInput.Controller.LTrackedRemote | OVRInput.Controller.RTrackedRemote)) != 0)
+            {
+                return ControllerType.Oculus_GearVRController;
+            }
+
             return ControllerType.Undefined;
         }
 


### PR DESCRIPTION
The Oculus Controller SDK assumed the vendor SDK reports a single
tracked device via its `Controller` enum. This enum is actually a
flag so to handle multiple devices being connected at the same time
this fix ensures to check via the proper binary operations instead
of doing an equality check.
Since VRTK currently only supports returning a single device enum
this change leaves the device importance order untouched.