### PR TITLE
fix(DestinationPoint): Change GetRotation to use eulerAngles - fixes #1775

### DIFF
--- a/Assets/VRTK/Prefabs/DestinationPoint/VRTK_DestinationPoint.cs
+++ b/Assets/VRTK/Prefabs/DestinationPoint/VRTK_DestinationPoint.cs
@@ -453,7 +453,7 @@ namespace VRTK
             }
 
             float offset = (snapToRotation == RotationTypes.RotateWithHeadsetOffset && playArea != null && headset != null ? playArea.eulerAngles.y - headset.eulerAngles.y : 0f);
-            return Quaternion.Euler(0f, destinationLocation.localEulerAngles.y + offset, 0f);
+            return Quaternion.Euler(0f, destinationLocation.eulerAngles.y + offset, 0f);
         }
     }
 }


### PR DESCRIPTION
Changed the SetLocation function in VRTK_DestinationPoint.cs.

It now uses eulerAngles instead of localEulerAngles.