### PR TITLE
fix(Highlighter): copy shadow casting mode from object renderer - fixes #1278

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_OutlineObjectCopyHighlighter.cs
@@ -231,10 +231,7 @@ namespace VRTK.Highlighters
             {
                 Renderer copyModelRenderer = objectToAffect.GetComponentInChildren<Renderer>();
                 copyModel = (copyModelRenderer != null ? copyModelRenderer.gameObject : null);
-            }
 
-            if (copyModel == null)
-            {
                 VRTK_Logger.Error(VRTK_Logger.GetCommonMessage(VRTK_Logger.CommonMessageKeys.REQUIRED_COMPONENT_MISSING_FROM_GAMEOBJECT, "VRTK_OutlineObjectCopyHighlighter", "Renderer", "the same or child", " to add the highlighter to"));
                 return null;
             }
@@ -281,6 +278,7 @@ namespace VRTK.Highlighters
                     highlightMesh.mesh = copyMesh.mesh;
                 }
                 returnHighlightModel.material = stencilOutline;
+                returnHighlightModel.shadowCastingMode = copyModel.transform.GetComponent<Renderer>().shadowCastingMode;
             }
             highlightModel.SetActive(false);
 


### PR DESCRIPTION
The shadow casting mode is now copied over from the object's renderer.
Also removed an unnecessary duplicate if statement.

fixes: #1278 