### PR TITLE
fix(UnityXR): add more joystick names

### DIFF
--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -38,12 +38,14 @@ namespace VRTK
         protected List<string> validRightHands = new List<string>()
         {
             "OpenVR Controller - Right",
+            "OpenVR Controller(Vive. Controller MV) - Right",
             "Oculus Touch - Right",
             "Oculus Remote"
         };
         protected List<string> validLeftHands = new List<string>()
         {
             "OpenVR Controller - Left",
+            "OpenVR Controller(Vive. Controller MV) - Left",
             "Oculus Touch - Left"
         };
 


### PR DESCRIPTION
Add HTC Vive controller joystick names as reported by Unity 2017.4.2f2.

Fixes #1798 