### PR TITLE
fix(GraphicRaycaster): transfer BlockingMask across

### DIFF
--- a/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Source/Scripts/Internal/VRTK_UIGraphicRaycaster.cs
@@ -70,7 +70,7 @@
                 if (blockingObjects == BlockingObjects.ThreeD || blockingObjects == BlockingObjects.All)
                 {
                     RaycastHit hit;
-                    Physics.Raycast(ray, out hit, maxDistance);
+                    Physics.Raycast(ray, out hit, maxDistance, m_BlockingMask);
                     if (hit.collider != null && !VRTK_PlayerObject.IsPlayerObject(hit.collider.gameObject))
                     {
                         hitDistance = hit.distance;

--- a/Assets/VRTK/Source/Scripts/UI/VRTK_UICanvas.cs
+++ b/Assets/VRTK/Source/Scripts/UI/VRTK_UICanvas.cs
@@ -5,6 +5,8 @@ namespace VRTK
     using UnityEngine.UI;
     using UnityEngine.EventSystems;
     using System.Collections;
+    using System.Reflection;
+    using System;
 
     /// <summary>
     /// Denotes a Unity World UI Canvas can be interacted with a UIPointer script.
@@ -93,6 +95,10 @@ namespace VRTK
             {
                 customRaycaster.ignoreReversedGraphics = defaultRaycaster.ignoreReversedGraphics;
                 customRaycaster.blockingObjects = defaultRaycaster.blockingObjects;
+                
+                //Use Reflection to transfer the BlockingMask
+                customRaycaster.GetType().GetField("m_BlockingMask", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(customRaycaster,defaultRaycaster.GetType().GetField("m_BlockingMask", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(defaultRaycaster));
+
                 defaultRaycaster.enabled = false;
             }
 


### PR DESCRIPTION
BlockingMask is now transfered across using reflection
GraphicRaycaster -> VRTK_GraphicRaycaster

fixes: #1418 