### PR TITLE
fix(controllables): no longer resets value on re-enable

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialPusher.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialPusher.cs
@@ -68,6 +68,14 @@ namespace VRTK.Controllables.ArtificialBased
         }
 
         /// <summary>
+        /// The SetValue method is not implemented as the pusher resets automatically.
+        /// </summary>
+        /// <param name="value">Not used.</param>
+        public override void SetValue(float value)
+        {
+        }
+
+        /// <summary>
         /// The IsResting method returns whether the pusher is currently at it's resting position.
         /// </summary>
         /// <returns>Returns `true` if the pusher is currently at the resting position.</returns>

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialRotator.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialRotator.cs
@@ -103,6 +103,15 @@ namespace VRTK.Controllables.ArtificialBased
         }
 
         /// <summary>
+        /// The SetValue method sets the current Angle of the rotator
+        /// </summary>
+        /// <param name="value">The new rotation value</param>
+        public override void SetValue(float value)
+        {
+            SetAngleTarget(value);
+        }
+
+        /// <summary>
         /// The GetContainer method returns the GameObject that is generated to hold the rotator control.
         /// </summary>
         /// <returns>The GameObject container of the rotator control.</returns>
@@ -202,6 +211,8 @@ namespace VRTK.Controllables.ArtificialBased
 
         protected override void OnEnable()
         {
+            SetValue(storedValue);
+
             ResetParentContainer();
             base.OnEnable();
             rotatorContainer = gameObject;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialSlider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Artificial/VRTK_ArtificialSlider.cs
@@ -96,6 +96,19 @@ namespace VRTK.Controllables.ArtificialBased
         }
 
         /// <summary>
+        /// The SetValue method sets the current position value of the slider
+        /// </summary>
+        /// <param name="value">The new position value</param>
+        public override void SetValue(float value)
+        {
+            Vector3 tempPos = new Vector3();
+            tempPos = transform.localPosition;
+            tempPos[(int)operateAxis] = value;
+
+            transform.localPosition = tempPos;
+        }
+
+        /// <summary>
         /// The GetStepValue method returns the current position of the slider based on the step value range.
         /// </summary>
         /// <param name="currentValue">The current position value of the slider to get the Step Value for.</param>
@@ -178,6 +191,9 @@ namespace VRTK.Controllables.ArtificialBased
         protected override void OnEnable()
         {
             base.OnEnable();
+
+            SetValue(storedValue);
+
             previousLocalPosition = Vector3.one * float.MaxValue;
             stillResting = false;
             SetupInteractableObject();

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsPusher.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsPusher.cs
@@ -69,6 +69,14 @@ namespace VRTK.Controllables.PhysicsBased
         }
 
         /// <summary>
+        /// The SetValue method is not implemented as the pusher resets automatically.
+        /// </summary>
+        /// <param name="value">Not used.</param>
+        public override void SetValue(float value)
+        {
+        }
+
+        /// <summary>
         /// The IsResting method returns whether the pusher is currently at it's resting position.
         /// </summary>
         /// <returns>Returns `true` if the pusher is currently at the resting position.</returns>

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsRotator.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsRotator.cs
@@ -127,6 +127,15 @@ namespace VRTK.Controllables.PhysicsBased
         }
 
         /// <summary>
+        /// The SetValue method sets the current Angle of the rotator
+        /// </summary>
+        /// <param name="value">The new rotation value</param>
+        public override void SetValue(float value)
+        {
+            UpdateToAngle(value);
+        }
+
+        /// <summary>
         /// The GetStepValue method returns the current angle of the rotator based on the step value range.
         /// </summary>
         /// <param name="currentValue">The current angle value of the rotator to get the Step Value for.</param>
@@ -223,11 +232,14 @@ namespace VRTK.Controllables.PhysicsBased
             SetupJoint();
             SetFrictions(releasedFriction);
             CheckLock();
-            UpdateToAngle(angleTarget);
+
+            SetValue(storedValue);
         }
 
         protected override void OnDisable()
         {
+            storedValue = GetValue();
+
             if (createControlJoint)
             {
                 Destroy(controlJoint);

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsSlider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsSlider.cs
@@ -97,6 +97,22 @@ namespace VRTK.Controllables.PhysicsBased
         }
 
         /// <summary>
+        /// The SetValue method sets the current position value of the slider
+        /// </summary>
+        /// <param name="value">The new position value</param>
+        public override void SetValue(float value)
+        {
+            Vector3 tempPos = new Vector3();
+            tempPos = transform.localPosition;
+            tempPos[(int)operateAxis] = value;
+
+            transform.localPosition = tempPos;
+
+            positionTarget = VRTK_SharedMethods.NormalizeValue(value, originalLocalPosition[(int)operateAxis], MaximumLength()[(int)operateAxis]);
+            SetPositionWithNormalizedValue(positionTarget);
+        }
+
+        /// <summary>
         /// The GetStepValue method returns the current position of the slider based on the step value range.
         /// </summary>
         /// <param name="currentValue">The current position value of the slider to get the Step Value for.</param>
@@ -182,11 +198,13 @@ namespace VRTK.Controllables.PhysicsBased
             previousLocalPosition = Vector3.one * float.MaxValue;
             previousPositionTarget = float.MaxValue;
             stillResting = false;
-            SetPositionWithNormalizedValue(positionTarget);
+
+            SetValue(storedValue);
         }
 
         protected override void OnDisable()
         {
+            storedValue = GetValue();
             if (createControlInteractableObject)
             {
                 ManageInteractableObjectListeners(false);

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/VRTK_BaseControllable.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/VRTK_BaseControllable.cs
@@ -100,6 +100,7 @@ namespace VRTK.Controllables
         protected Collider[] controlColliders = new Collider[0];
         protected bool createCustomCollider;
         protected Coroutine processAtEndOfFrame;
+        protected float storedValue;
 
         public virtual void OnValueChanged(ControllableEventArgs e)
         {
@@ -151,6 +152,7 @@ namespace VRTK.Controllables
 
         public abstract float GetValue();
         public abstract float GetNormalizedValue();
+        public abstract void SetValue(float value);
         public abstract bool IsResting();
 
         /// <summary>
@@ -222,6 +224,8 @@ namespace VRTK.Controllables
         {
             originalLocalPosition = transform.localPosition;
             originalLocalRotation = transform.localRotation;
+
+            storedValue = GetValue();
         }
 
         protected virtual void OnEnable()
@@ -234,6 +238,8 @@ namespace VRTK.Controllables
 
         protected virtual void OnDisable()
         {
+            storedValue = GetValue();
+
             if (processAtEndOfFrame != null)
             {
                 StopCoroutine(processAtEndOfFrame);


### PR DESCRIPTION
a SetValue function was added to the base class
all classes implement this
implemented for Sliders & Rotators
not for Pusher because resets anyway

fixes: #1696 