### PR TITLE
fix(UnityXR): Tag the camera rig's camera as MainCamera

### DIFF
--- a/Assets/VRTK/Source/SDK/Unity/[UnityBase_CameraRig].prefab
+++ b/Assets/VRTK/Source/SDK/Unity/[UnityBase_CameraRig].prefab
@@ -107,7 +107,7 @@ GameObject:
   - component: {fileID: 114012097166862850}
   m_Layer: 0
   m_Name: Head
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0


### PR DESCRIPTION
Tag the UnityXR camera rig's camera as MainCamera so that UI
interactions will work.