### PR TITLE
docs(UnityXR): Add touchpad y-axis information

### DIFF
--- a/Assets/VRTK/Source/SDK/Unity/README.md
+++ b/Assets/VRTK/Source/SDK/Unity/README.md
@@ -8,3 +8,4 @@
  * Increase the size of the `Axes` array to the number of required new axes (usually increase by 8, 2 for trigger, 2 for grip and 4 for touchpad [x,y] which is for both hands).
  * For each new axis created, enter a name for the axis that corresponds to the name specified on the `SDK_UnityControllerTrackerScript` which is found on `[UnityBase_CameraRig/<xxxx>HandAnchor]`.
  * The axis mapping information can be found in the [Unity3d Docs](https://docs.unity3d.com/Manual/OpenVRControllers.html).
+ * The touchpad y axis is reversed from other SDKs, so they should be inverted in the Input Manager in order for them to behave the same.


### PR DESCRIPTION
The touchpad y-axis in the Unity SDK is backwards from the SteamVR SDK. (Forward is negative instead of positive).

When setting up the inputs for the Unity SDK, it might prevent some confusion to know this ahead of time.