### PR TITLE
fix(SDK): use new hierarcyChanged event introduced in 2018.1

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKManager.cs
@@ -819,8 +819,14 @@ namespace VRTK
             PopulateAvailableAndInstalledSDKInfos();
 
 #if UNITY_EDITOR
+
             //call AutoManageScriptingDefineSymbolsAndManageVRSettings when the currently active scene changes
+#if UNITY_2018_1_OR_NEWER
+            EditorApplication.hierarchyChanged += AutoManageScriptingDefineSymbolsAndManageVRSettings;
+#else
             EditorApplication.hierarchyWindowChanged += AutoManageScriptingDefineSymbolsAndManageVRSettings;
+#endif
+
 #endif
         }
 

--- a/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs
@@ -423,7 +423,11 @@ namespace VRTK
         static VRTK_SDKSetup()
         {
             //call AutoPopulateObjectReferences when the currently active scene changes
+#if UNITY_2018_1_OR_NEWER
+            EditorApplication.hierarchyChanged += AutoPopulateObjectReferences;
+#else
             EditorApplication.hierarchyWindowChanged += AutoPopulateObjectReferences;
+#endif
         }
 
         [DidReloadScripts(2)]


### PR DESCRIPTION
Unity 2018.1 deprecated the `hierarchyWindowChanged` event and is now
called `hierarchyChanged` so the fix is to do a script define to use
the correct event based on the version.