### PR TITLE
fix(ControllerToolTips): A wrong switch section in a Switch statement

### DIFF
--- a/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
@@ -400,7 +400,7 @@ namespace VRTK
                         tipText = touchpadText;
                         tipTransform = GetTransform(touchpad, SDK_BaseController.ControllerElements.Touchpad);
                         break;
-                    case "touchpadTwo":
+                    case "touchpadtwo":
                         tipText = touchpadTwoText;
                         tipTransform = GetTransform(touchpadTwo, SDK_BaseController.ControllerElements.TouchpadTwo);
                         break;

--- a/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
@@ -400,7 +400,7 @@ namespace VRTK
                         tipText = touchpadText;
                         tipTransform = GetTransform(touchpad, SDK_BaseController.ControllerElements.Touchpad);
                         break;
-                    case "touchpadtwo":
+                    case "touchpadTwo":
                         tipText = touchpadTwoText;
                         tipTransform = GetTransform(touchpadTwo, SDK_BaseController.ControllerElements.TouchpadTwo);
                         break;


### PR DESCRIPTION
Tooltip's name is in lowercase.It isn't equal to "touchpadTwo" which has a capital letter.