### PR TITLE
fix(Controller): work around crash in Unity 2018.2 #1852

### DIFF
--- a/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRController.cs
+++ b/Assets/VRTK/Source/SDK/HyperealVR/SDK_HyperealVRController.cs
@@ -79,7 +79,7 @@ namespace VRTK
                 case ControllerElements.Body:
                     return "Base/SM_Prop_HyFeel" + (hand == ControllerHand.Left ? "L" : "R") + "_02";
             }
-            return null;
+            return "";
         }
 
         /// <summary>

--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
@@ -153,7 +153,7 @@ namespace VRTK
                 switch (element)
                 {
                     case ControllerElements.AttachPoint:
-                        return null;
+                        return "";
                     case ControllerElements.Trigger:
                         return path + "trigger" + suffix;
                     case ControllerElements.GripLeft:
@@ -174,7 +174,7 @@ namespace VRTK
                         return parent;
                 }
             }
-            return null;
+            return "";
         }
 
         /// <summary>

--- a/Assets/VRTK/Source/SDK/Simulator/SDK_SimController.cs
+++ b/Assets/VRTK/Source/SDK/Simulator/SDK_SimController.cs
@@ -99,7 +99,7 @@ namespace VRTK
                 case ControllerElements.Body:
                     return "";
             }
-            return null;
+            return "";
         }
 
         /// <summary>

--- a/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
+++ b/Assets/VRTK/Source/SDK/SteamVR/SDK_SteamVRController.cs
@@ -164,7 +164,7 @@ namespace VRTK
                 case ControllerElements.Body:
                     return "body";
             }
-            return null;
+            return "";
         }
 
         /// <summary>

--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRController.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRController.cs
@@ -234,7 +234,7 @@ namespace VRTK
 
             return MotionControllerVisualizer.Instance.GetPathToButton(element, handedness);
 #else
-            return null;
+            return "";
 #endif
         }
 

--- a/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseController.cs
+++ b/Assets/VRTK/Source/SDK/Ximmerse/SDK_XimmerseController.cs
@@ -125,7 +125,7 @@ namespace VRTK
                 case ControllerElements.Body:
                     return path + "/object_1";
             }
-            return null;
+            return "";
         }
 
         /// <summary>


### PR DESCRIPTION
Fix NPE causing Unity to crash by returning `""` from
`GetControllerElementPath()` instead of `null`.