### PR TITLE
fix(Tooltips): Spelling mistake in touchpadtwo

### DIFF
--- a/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
+++ b/Assets/VRTK/Prefabs/ControllerTooltips/VRTK_ControllerTooltips.cs
@@ -400,7 +400,7 @@ namespace VRTK
                         tipText = touchpadText;
                         tipTransform = GetTransform(touchpad, SDK_BaseController.ControllerElements.Touchpad);
                         break;
-                    case "touchpadTwo":
+                    case "touchpadtwo":
                         tipText = touchpadTwoText;
                         tipTransform = GetTransform(touchpadTwo, SDK_BaseController.ControllerElements.TouchpadTwo);
                         break;


### PR DESCRIPTION
Fix spelling mistake in ControllerTooltips which caused TouchpadTwo to be ignored, due to prior ToLower()-conversion.
 