### PR TITLE
fix(SDK): handle touch and classic controller plugged in - fixes #1866

### DIFF
--- a/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
+++ b/Assets/VRTK/Source/SDK/Oculus/SDK_OculusController.cs
@@ -822,6 +822,7 @@ namespace VRTK
 
             switch (activeControllerType)
             {
+                case OVRInput.Controller.Gamepad | OVRInput.Controller.RTouch | OVRInput.Controller.LTouch:
                 case OVRInput.Controller.Touch:
                     return (index == 0 ? OVRInput.Controller.LTouch : (index == 1 ? OVRInput.Controller.RTouch : OVRInput.Controller.None));
                 case OVRInput.Controller.LTouch:


### PR DESCRIPTION
Added the missing switch case to handle the value returned by OVRInput.GetConnectedControllers when touch controllers
and a classic controller are active in the same time.