### PR TITLE
fix(SharedMethods): don't search in unloaded scenes

### DIFF
--- a/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
+++ b/Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs
@@ -789,13 +789,13 @@ namespace VRTK
                 List<T> allSceneResults = new List<T>();
                 for (int sceneIndex = 0; sceneIndex < SceneManager.sceneCount; sceneIndex++)
                 {
-                    allSceneResults.AddRange(FindEventInactiveComponentsInScene<T>(SceneManager.GetSceneAt(sceneIndex), stopOnMatch));
+                    allSceneResults.AddRange(FindEvenInactiveComponentsInScene<T>(SceneManager.GetSceneAt(sceneIndex), stopOnMatch));
                 }
                 results = allSceneResults;
             }
             else
             {
-                results = FindEventInactiveComponentsInScene<T>(SceneManager.GetActiveScene(), stopOnMatch);
+                results = FindEvenInactiveComponentsInScene<T>(SceneManager.GetActiveScene(), stopOnMatch);
             }
 
             return results;
@@ -807,9 +807,14 @@ namespace VRTK
         /// <param name="scene">The scene to search. This scene must be valid, either loaded or loading.</param>
         /// <param name="stopOnMatch">If true, will stop searching objects as soon as a match is found.</param>
         /// <returns></returns>
-        private static IEnumerable<T> FindEventInactiveComponentsInScene<T>(Scene scene, bool stopOnMatch = false)
+        private static IEnumerable<T> FindEvenInactiveComponentsInScene<T>(Scene scene, bool stopOnMatch = false)
         {
             List<T> results = new List<T>();
+            if(!scene.isLoaded)
+            {
+                return results;
+            }
+
             foreach (GameObject rootObject in scene.GetRootGameObjects())
             {
                 if (stopOnMatch)


### PR DESCRIPTION
If a scene is open in the editor, but not loaded like this:  
![image](https://user-images.githubusercontent.com/1468331/45161346-f6274600-b1eb-11e8-8d40-773993189670.png)

Then every change in the hierarchy causes an exception like this one:
```
ArgumentException: The scene is not loaded.
UnityEngine.SceneManagement.Scene.GetRootGameObjects (System.Collections.Generic.List`1 rootGameObjects) (at C:/buildslave/unity/build/artifacts/generated/common/runtime/SceneBindings.gen.cs:61)
UnityEngine.SceneManagement.Scene.GetRootGameObjects () (at C:/buildslave/unity/build/artifacts/generated/common/runtime/SceneBindings.gen.cs:45)
VRTK.VRTK_SharedMethods.FindEventInactiveComponentsInScene[VRTK_SDKSetup] (Scene scene, Boolean stopOnMatch) (at Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs:813)
VRTK.VRTK_SharedMethods.FindEvenInactiveComponentsInValidScenes[VRTK_SDKSetup] (Boolean searchAllScenes, Boolean stopOnMatch) (at Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs:792)
VRTK.VRTK_SharedMethods.FindEvenInactiveComponents[VRTK_SDKSetup] (Boolean searchAllScenes) (at Assets/VRTK/Source/Scripts/Utilities/VRTK_SharedMethods.cs:290)
VRTK.VRTK_SDKSetup.AutoPopulateObjectReferences () (at Assets/VRTK/Source/Scripts/Utilities/SDK/VRTK_SDKSetup.cs:441)
UnityEditor.EditorApplication.Internal_CallHierarchyWindowHasChanged () (at C:/buildslave/unity/build/Editor/Mono/EditorApplication.cs:153)
```

This fix changes the scene searches to not look in scenes that are not loaded.
