### PR TITLE
fix(UnityXR): add vive pro controller names

### DIFF
--- a/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
+++ b/Assets/VRTK/Source/SDK/Unity/SDK_UnityController.cs
@@ -39,6 +39,7 @@ namespace VRTK
         {
             "OpenVR Controller - Right",
             "OpenVR Controller(Vive. Controller MV) - Right",
+            "OpenVR Controller(VIVE Controller Pro MV) - Right",
             "Oculus Touch - Right",
             "Oculus Remote"
         };
@@ -46,6 +47,7 @@ namespace VRTK
         {
             "OpenVR Controller - Left",
             "OpenVR Controller(Vive. Controller MV) - Left",
+            "OpenVR Controller(VIVE Controller Pro MV) - Left",
             "Oculus Touch - Left"
         };
 


### PR DESCRIPTION
Add the joystick names of the HTC Vive Pro controllers as reported
by Unity 2017.4.9f1.