### PR TITLE
fix(Examples): automatically repair broken Oculus prefab instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /[Aa]ssets/[Ss]team[Vv][Rr].meta
 /[Aa]ssets/[Oo][Vv][Rr]/*
 /[Aa]ssets/[Oo][Vv][Rr].meta
+/[Aa]ssets/[Oo]culus/*
+/[Aa]ssets/[Oo]culus.meta
 /[Aa]ssets/[Oo]culus[Pp]latform/*
 /[Aa]ssets/[Oo]culus[Pp]latform.meta
 /[Aa]ssets/[Oo][Vv][Rr][Aa]vatar/*

--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/Editor.meta
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 064889a8bcb7911458e1be3b7d401cc4
+folderAsset: yes
+timeCreated: 1537913179
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/Editor/VRTKExample_FixSetupEditor.cs
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/Editor/VRTKExample_FixSetupEditor.cs
@@ -1,0 +1,20 @@
+﻿namespace VRTK.Examples.Utilities
+{
+    using UnityEditor;
+    using UnityEngine;
+
+    [CustomEditor(typeof(VRTKExample_FixSetup))]
+    public class VRTKExample_FixSetupEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            VRTKExample_FixSetup myScript = (VRTKExample_FixSetup)target;
+            if (GUILayout.Button("Fix SDK Setups"))
+            {
+                myScript.ApplyFixes();
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/Editor/VRTKExample_FixSetupEditor.cs.meta
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/Editor/VRTKExample_FixSetupEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9bb4819812fd8614aac8735b91224122
+timeCreated: 1537913206
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_FixSetup.cs
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_FixSetup.cs
@@ -1,0 +1,74 @@
+﻿#if UNITY_EDITOR
+namespace VRTK.Examples.Utilities
+{
+    using UnityEngine;
+    using UnityEditor;
+
+    [ExecuteInEditMode]
+    public class VRTKExample_FixSetup : MonoBehaviour
+    {
+        public virtual void ApplyFixes()
+        {
+            FixOculus();
+        }
+
+        protected virtual void Awake()
+        {
+            ApplyFixes();
+        }
+
+        protected virtual void FixOculus()
+        {
+#if VRTK_DEFINE_SDK_OCULUS
+            string oculusPath = "[VRTK_SDKManager]/[VRTK_SDKSetups]/Oculus";
+            GameObject oculusSDK = GameObject.Find(oculusPath);
+            GameObject currentRig = GameObject.Find(oculusPath + "/OVRCameraRig");
+            GameObject currentAvatar = GameObject.Find(oculusPath + "/LocalAvatar");
+            VRTK_SDKSetup oculusSetup = oculusSDK.GetComponent<VRTK_SDKSetup>();
+
+            if (currentRig != null)
+            {
+                DestroyImmediate(currentRig);
+            }
+            if (currentAvatar != null)
+            {
+                DestroyImmediate(currentAvatar);
+            }
+
+            GameObject ovrCameraRig = PrefabUtility.InstantiatePrefab((GameObject)AssetDatabase.LoadAssetAtPath("Assets/Oculus/VR/Prefabs/OVRCameraRig.prefab", typeof(GameObject))) as GameObject;
+            if (ovrCameraRig != null)
+            {
+                ovrCameraRig.transform.SetParent(oculusSDK.transform);
+                ovrCameraRig.SetActive(false);
+                oculusSetup.actualBoundaries = ovrCameraRig;
+                oculusSetup.actualHeadset = GameObject.Find(oculusPath + "/OVRCameraRig/TrackingSpace/CenterEyeAnchor");
+                oculusSetup.actualLeftController = GameObject.Find(oculusPath + "/OVRCameraRig/TrackingSpace/LeftHandAnchor");
+                oculusSetup.actualRightController = GameObject.Find(oculusPath + "/OVRCameraRig/TrackingSpace/RightHandAnchor");
+                OVRManager ovrManager = ovrCameraRig.GetComponent<OVRManager>();
+                ovrManager.trackingOriginType = OVRManager.TrackingOrigin.FloorLevel;
+                Debug.Log("Successfully repaired Oculus OVRCameraRig prefab");
+            }
+
+            GameObject ovrAvatar = PrefabUtility.InstantiatePrefab((GameObject)AssetDatabase.LoadAssetAtPath("Assets/Oculus/Avatar/Content/Prefabs/LocalAvatar.prefab", typeof(GameObject))) as GameObject;
+            if (ovrAvatar == null)
+            {
+                //legacy location
+                ovrAvatar = PrefabUtility.InstantiatePrefab((GameObject)AssetDatabase.LoadAssetAtPath("Assets/OvrAvatar/Content/Prefabs/LocalAvatar.prefab", typeof(GameObject))) as GameObject;
+            }
+            if (ovrAvatar != null)
+            {
+                ovrAvatar.transform.SetParent(oculusSDK.transform);
+                ovrAvatar.SetActive(false);
+                oculusSetup.modelAliasLeftController = GameObject.Find(oculusPath + "/LocalAvatar/controller_left");
+                oculusSetup.modelAliasRightController = GameObject.Find(oculusPath + "/LocalAvatar/controller_right");
+                GameObject.Find(oculusPath + "/LocalAvatar/hand_left").SetActive(false);
+                GameObject.Find(oculusPath + "/LocalAvatar/hand_right").SetActive(false);
+                VRTK_TransformFollow transformFollow = ovrAvatar.AddComponent<VRTK_TransformFollow>();
+                transformFollow.gameObjectToFollow = ovrCameraRig;
+                Debug.Log("Successfully repaired Oculus LocalAvatar prefab");
+            }
+#endif
+        }
+    }
+}
+#endif

--- a/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_FixSetup.cs.meta
+++ b/Assets/VRTK/Examples/ExampleResources/SharedResources/Scripts/VRTKExample_FixSetup.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: dbd363faecdfb6d4da2d9cdab9de34f8
+timeCreated: 1537913013
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Examples/[001 - Interactions] ControllerEvents.unity
+++ b/Assets/VRTK/Examples/[001 - Interactions] ControllerEvents.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -201,6 +201,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &45327575
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -442,6 +443,7 @@ GameObject:
   m_Component:
   - component: {fileID: 101641546}
   - component: {fileID: 101641545}
+  - component: {fileID: 101641547}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -491,6 +493,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &101641547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 101641544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &109582311
 GameObject:
   m_ObjectHideFlags: 0
@@ -1160,6 +1173,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &437062054
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1326,6 +1340,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &516690990
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1736,7 +1751,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22406496, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 22406496, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_SizeDelta.x
@@ -1744,7 +1759,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22406496, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 22435444, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_AnchorMin.y
@@ -1760,7 +1775,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22435444, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 22435444, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_SizeDelta.x
@@ -1768,7 +1783,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22435444, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 22435580, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_SizeDelta.x
@@ -1776,7 +1791,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 22435580, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 11440894, guid: 6b9dbb125b47726449ffe47a4110f342, type: 2}
       propertyPath: m_Size
@@ -2557,6 +2572,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &911137776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3278,6 +3294,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1101259493
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5661,6 +5678,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1703159951
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/[002 - Pointers] StraightPointer.unity
+++ b/Assets/VRTK/Examples/[002 - Pointers] StraightPointer.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -752,6 +752,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &243141330
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1129,6 +1130,7 @@ GameObject:
   m_Component:
   - component: {fileID: 315727735}
   - component: {fileID: 315727734}
+  - component: {fileID: 315727736}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -1178,6 +1180,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &315727736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 315727733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &324413262
 GameObject:
   m_ObjectHideFlags: 0
@@ -1762,6 +1775,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &615878202
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3940,6 +3954,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1208192149
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6224,6 +6239,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1939791525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6346,6 +6362,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1959794856
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6741,6 +6758,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &2044667786
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/[003 - Pointers] BezierPointer.unity
+++ b/Assets/VRTK/Examples/[003 - Pointers] BezierPointer.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -2257,6 +2257,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &732935642
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2565,6 +2566,7 @@ GameObject:
   m_Component:
   - component: {fileID: 805256616}
   - component: {fileID: 805256615}
+  - component: {fileID: 805256617}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -2614,6 +2616,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &805256617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 805256614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &854405436
 GameObject:
   m_ObjectHideFlags: 0
@@ -3995,6 +4008,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1179916367
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4155,6 +4169,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1254445747
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4984,6 +4999,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1392035835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6688,6 +6704,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1826246694
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6920,6 +6937,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1916925286
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/[004 - Locomotion] Teleporting.unity
+++ b/Assets/VRTK/Examples/[004 - Locomotion] Teleporting.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -1406,6 +1406,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &136028235
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3565,6 +3566,7 @@ GameObject:
   m_Component:
   - component: {fileID: 375406889}
   - component: {fileID: 375406888}
+  - component: {fileID: 375406890}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -3614,6 +3616,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &375406890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 375406887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &378297452
 GameObject:
   m_ObjectHideFlags: 0
@@ -6930,6 +6943,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &767856345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7867,6 +7881,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &855751250
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9506,6 +9521,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1012319336
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14285,6 +14301,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1554386877
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15558,6 +15575,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1723726419
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/[005 - Interactions] InteractableObjects.unity
+++ b/Assets/VRTK/Examples/[005 - Interactions] InteractableObjects.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -5364,6 +5364,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &263305724
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6778,6 +6780,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &319083183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8125,6 +8129,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &355656673
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8900,6 +8905,8 @@ SpringJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 1
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &382696245
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12453,6 +12460,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1 &505377495
 GameObject:
   m_ObjectHideFlags: 0
@@ -12988,6 +12997,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1001 &517438703
 Prefab:
   m_ObjectHideFlags: 0
@@ -14126,6 +14137,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &569811959
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14489,6 +14501,7 @@ GameObject:
   m_Component:
   - component: {fileID: 587475395}
   - component: {fileID: 587475394}
+  - component: {fileID: 587475396}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -14538,6 +14551,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &587475396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 587475393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &589812365
 Prefab:
   m_ObjectHideFlags: 0
@@ -15678,6 +15702,8 @@ SpringJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &637343859
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16023,6 +16049,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &642862913
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18940,6 +18968,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &795518318
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19240,6 +19269,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &799627613
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19525,6 +19556,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &799840269
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23473,6 +23506,8 @@ HingeJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 1
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!54 &958257946
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -27320,6 +27355,8 @@ SpringJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 1
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!136 &1078757862
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -27757,6 +27794,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1 &1085638134
 GameObject:
   m_ObjectHideFlags: 0
@@ -28807,7 +28846,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!199 &1105057152
 ParticleSystemRenderer:
-  serializedVersion: 3
+  serializedVersion: 4
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
@@ -28856,6 +28895,7 @@ ParticleSystemRenderer:
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MaskInteraction: 0
 --- !u!198 &1105057153
 ParticleSystem:
   m_ObjectHideFlags: 0
@@ -28868,7 +28908,9 @@ ParticleSystem:
   looping: 1
   prewarm: 0
   playOnAwake: 1
+  useUnscaledTime: 0
   autoRandomSeed: 1
+  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -29354,14 +29396,29 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
   ShapeModule:
-    serializedVersion: 4
+    serializedVersion: 5
     enabled: 1
     type: 4
     angle: 1
     length: 5
-    boxX: 1
-    boxY: 1
-    boxZ: 1
+    boxThickness: {x: 0, y: 0, z: 0}
+    radiusThickness: 1
+    donutRadius: 0.2
+    m_Position: {x: 0, y: 0, z: 0}
+    m_Rotation: {x: 0, y: 0, z: 0}
+    m_Scale: {x: 1, y: 1, z: 1}
+    placementMode: 0
+    m_Mesh: {fileID: 0}
+    m_MeshRenderer: {fileID: 0}
+    m_SkinnedMeshRenderer: {fileID: 0}
+    m_MeshMaterialIndex: 0
+    m_MeshNormalOffset: 0
+    m_UseMeshMaterialIndex: 0
+    m_UseMeshColors: 1
+    alignToDirection: 0
+    randomDirectionAmount: 0
+    sphericalDirectionAmount: 0
+    randomPositionAmount: 0
     radius:
       value: 0.01
       mode: 0
@@ -29452,18 +29509,6 @@ ParticleSystem:
           m_PreInfinity: 2
           m_PostInfinity: 2
           m_RotationOrder: 4
-    placementMode: 0
-    m_Mesh: {fileID: 0}
-    m_MeshRenderer: {fileID: 0}
-    m_SkinnedMeshRenderer: {fileID: 0}
-    m_MeshMaterialIndex: 0
-    m_MeshNormalOffset: 0
-    m_MeshScale: 1
-    m_UseMeshMaterialIndex: 0
-    m_UseMeshColors: 1
-    alignToDirection: 0
-    randomDirectionAmount: 0
-    sphericalDirectionAmount: 0
   EmissionModule:
     enabled: 1
     serializedVersion: 4
@@ -29870,6 +29915,7 @@ ParticleSystem:
         m_NumAlphaKeys: 2
   UVModule:
     enabled: 0
+    mode: 0
     frameOverTime:
       serializedVersion: 2
       minMaxState: 1
@@ -29961,6 +30007,8 @@ ParticleSystem:
     flipU: 0
     flipV: 0
     randomRow: 1
+    sprites:
+    - sprite: {fileID: 0}
   VelocityModule:
     enabled: 0
     x:
@@ -30727,6 +30775,129 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     remapEnabled: 0
+    positionAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 2
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        - serializedVersion: 2
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 2
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        - serializedVersion: 2
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    rotationAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 2
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        - serializedVersion: 2
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 2
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        - serializedVersion: 2
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    sizeAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 2
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        - serializedVersion: 2
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 2
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        - serializedVersion: 2
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
   SizeBySpeedModule:
     enabled: 0
     curve:
@@ -31052,6 +31223,10 @@ ParticleSystem:
     serializedVersion: 3
     type: 1
     collisionMode: 0
+    colliderForce: 0
+    multiplyColliderForceByParticleSize: 0
+    multiplyColliderForceByParticleSpeed: 0
+    multiplyColliderForceByCollisionAngle: 1
     plane0: {fileID: 0}
     plane1: {fileID: 0}
     plane2: {fileID: 0}
@@ -31355,6 +31530,7 @@ ParticleSystem:
     sizeAffectsWidth: 1
     sizeAffectsLifetime: 0
     inheritParticleColor: 1
+    generateLightingData: 0
     colorOverLifetime:
       serializedVersion: 2
       minMaxState: 0
@@ -32493,6 +32669,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1122566605
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32757,6 +32934,8 @@ SpringJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 1
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!136 &1125836185
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -35435,6 +35614,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1 &1207343382
 GameObject:
   m_ObjectHideFlags: 0
@@ -35745,6 +35926,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &1222748812
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -41578,6 +41761,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1392037288
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -43589,6 +43773,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1 &1461531314
 GameObject:
   m_ObjectHideFlags: 0
@@ -43737,6 +43923,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &1462467542
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -51668,6 +51856,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &1724225856
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -54181,6 +54371,8 @@ SpringJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 1
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!136 &1824762712
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -56443,6 +56635,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1870161006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -57071,6 +57264,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &1881677596
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -63231,6 +63426,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!114 &2073056601
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -64319,6 +64516,8 @@ CharacterJoint:
   m_BreakTorque: Infinity
   m_EnableCollision: 0
   m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
 --- !u!1001 &2131472692
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/[006 - Locomotion] MovementTypes.unity
+++ b/Assets/VRTK/Examples/[006 - Locomotion] MovementTypes.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -2082,6 +2082,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &129582516
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8086,6 +8087,7 @@ GameObject:
   m_Component:
   - component: {fileID: 537620530}
   - component: {fileID: 537620529}
+  - component: {fileID: 537620531}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -8135,6 +8137,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &537620531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 537620528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &537634619
 GameObject:
   m_ObjectHideFlags: 0
@@ -18771,6 +18784,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1248489809
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19709,6 +19723,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1306197546
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -22364,6 +22379,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1527128512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26138,6 +26154,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1759047937
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26225,6 +26242,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1767379244
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/[007 - Interactions] InteractionHelpers.unity
+++ b/Assets/VRTK/Examples/[007 - Interactions] InteractionHelpers.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -2143,6 +2143,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &139470412
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2468,6 +2469,7 @@ GameObject:
   m_Component:
   - component: {fileID: 176582145}
   - component: {fileID: 176582144}
+  - component: {fileID: 176582146}
   m_Layer: 0
   m_Name: '[VRTK_SDKManager]'
   m_TagString: Untagged
@@ -2517,6 +2519,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &176582146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 176582143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbd363faecdfb6d4da2d9cdab9de34f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &177835826
 GameObject:
   m_ObjectHideFlags: 0
@@ -2751,6 +2764,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &209523675
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2948,6 +2962,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &240109377
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14467,6 +14482,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1256242922
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15958,6 +15974,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1395157089
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17562,6 +17579,7 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!114 &1538826181
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The example scenes all have broken Oculus prefab instances unless the
specific version of the Oculus SDK is used. This fix uses a script to
attempt to repair the prefab by recreating the setup automatically.