### PR TITLE
VRTK_RotateTransformGrabAttach can now also work when parent is moving

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/GrabAttachMechanics/VRTK_CustomJointGrabAttach.cs
@@ -50,7 +50,7 @@ namespace VRTK.GrabAttachMechanics
 
         protected override void DestroyJoint(bool withDestroyImmediate, bool applyGrabbingObjectVelocity)
         {
-            base.DestroyJoint(true, true);
+            base.DestroyJoint(withDestroyImmediate, true);
         }
 
         protected virtual void CopyCustomJoint()

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -534,7 +534,7 @@ namespace VRTK
             touchRigidBody.isKinematic = true;
             touchRigidBody.useGravity = false;
             touchRigidBody.constraints = RigidbodyConstraints.FreezeAll;
-            touchRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+            touchRigidBody.collisionDetectionMode = CollisionDetectionMode.Discrete;
         }
 
         protected virtual void EmitControllerRigidbodyEvent(bool state)


### PR DESCRIPTION
VRTK_RotateTransformGrabAttach had a bug where it used world positioning in a way that would mess up angle calculation if parent moved between frames. Now uses local position instead so we can use levers and stuff on e.g. moving platforms