### PR TITLE
fix(physics): change collision detection mode for 2018.3

### DIFF
--- a/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Door.cs
+++ b/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Door.cs
@@ -407,7 +407,11 @@ namespace VRTK
                 doorRigidbody = actualDoor.AddComponent<Rigidbody>();
                 doorRigidbody.angularDrag = releasedFriction;
             }
+#if UNITY_2018_3_OR_NEWER
+            doorRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative; // otherwise door will not react to fast moving controller
+#else
             doorRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic; // otherwise door will not react to fast moving controller
+#endif
             doorRigidbody.isKinematic = false; // in case nested door as already created this
 
             doorHinge = actualDoor.GetComponent<HingeJoint>();

--- a/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Drawer.cs
+++ b/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Drawer.cs
@@ -202,7 +202,11 @@ namespace VRTK
             if (drawerRigidbody == null)
             {
                 drawerRigidbody = gameObject.AddComponent<Rigidbody>();
+#if UNITY_2018_3_OR_NEWER
+                drawerRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+#else
                 drawerRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+#endif
             }
             drawerRigidbody.isKinematic = false;
 

--- a/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Lever.cs
+++ b/Assets/VRTK/Source/Scripts/Controls/3D/VRTK_Lever.cs
@@ -126,7 +126,11 @@ namespace VRTK
             if (leverRigidbody == null)
             {
                 leverRigidbody = gameObject.AddComponent<Rigidbody>();
+#if UNITY_2018_3_OR_NEWER
+                leverRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+#else
                 leverRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+#endif
                 leverRigidbody.angularDrag = releasedFriction; // otherwise lever will continue to move too far on its own
             }
             leverRigidbody.isKinematic = false;

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsPusher.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsPusher.cs
@@ -148,7 +148,11 @@ namespace VRTK.Controllables.PhysicsBased
         protected override void ConfigueRigidbody()
         {
             SetRigidbodyGravity(false);
+#if UNITY_2018_3_OR_NEWER
+            SetRigidbodyCollisionDetectionMode(CollisionDetectionMode.ContinuousSpeculative);
+#else
             SetRigidbodyCollisionDetectionMode(CollisionDetectionMode.ContinuousDynamic);
+#endif
             SetRigidbodyConstraints(RigidbodyConstraints.FreezeRotation);
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsSlider.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactables/Controllables/Physics/VRTK_PhysicsSlider.cs
@@ -234,7 +234,11 @@ namespace VRTK.Controllables.PhysicsBased
         protected override void ConfigueRigidbody()
         {
             SetRigidbodyGravity(false);
+#if UNITY_2018_3_OR_NEWER
+            controlRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+#else
             controlRigidbody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+#endif
             controlRigidbody.constraints = RigidbodyConstraints.FreezeRotation;
         }
 

--- a/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Interactors/VRTK_InteractTouch.cs
@@ -534,7 +534,11 @@ namespace VRTK
             touchRigidBody.isKinematic = true;
             touchRigidBody.useGravity = false;
             touchRigidBody.constraints = RigidbodyConstraints.FreezeAll;
+#if UNITY_2018_3_OR_NEWER
+            touchRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+#else
             touchRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+#endif
         }
 
         protected virtual void EmitControllerRigidbodyEvent(bool state)

--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -594,7 +594,11 @@ namespace VRTK
                 Rigidbody objectInteratorRigidBody = objectInteractorAttachPoint.AddComponent<Rigidbody>();
                 objectInteratorRigidBody.isKinematic = true;
                 objectInteratorRigidBody.freezeRotation = true;
+#if UNITY_2018_3_OR_NEWER
+                objectInteratorRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+#else
                 objectInteratorRigidBody.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+#endif
                 VRTK_PlayerObject.SetPlayerObject(objectInteractorAttachPoint, VRTK_PlayerObject.ObjectTypes.Pointer);
             }
 


### PR DESCRIPTION
Unity 2018.3 seems to have a bug where it does not support continuous
dynamic for the rigidbody collision detection, instead it uses a newly
introduced mode called collision speculative.

This fix wraps all of the places where continuous dynamic is used with
ifdefs to check if the version is Unity 2018.3 or higher and if it is
then it will use the continuous speculative mode instead.