### PR TITLE
fix(CameraRig): don't change the physics settings when XR is off

### DIFF
--- a/Prefabs/CameraRig/UnityXRCameraRig/SharedResources/Scripts/UnityXRConfigurator.cs
+++ b/Prefabs/CameraRig/UnityXRCameraRig/SharedResources/Scripts/UnityXRConfigurator.cs
@@ -78,7 +78,9 @@
         /// </summary>
         protected virtual void UpdateFixedDeltaTime()
         {
-            if (LockPhysicsUpdateRateToRenderFrequency && Time.timeScale > 0.0f)
+            if (LockPhysicsUpdateRateToRenderFrequency
+                && Time.timeScale > 0.0f
+                && !string.IsNullOrEmpty(XRSettings.loadedDeviceName))
             {
                 Time.fixedDeltaTime = Time.timeScale / XRDevice.refreshRate;
             }


### PR DESCRIPTION
When VR is off the existence of the Unity XR camera rig would set
the physics timestep to a really high value, which breaks any
physics usage altogether. The fix is to check whether XR is actually
used.