### PR TITLE
chore(Helpers): remove unused using statement

### DIFF
--- a/Prefabs/Helpers/Tooltip/SharedResources/Scripts/TooltipInternalSetup.cs
+++ b/Prefabs/Helpers/Tooltip/SharedResources/Scripts/TooltipInternalSetup.cs
@@ -1,7 +1,6 @@
 ﻿namespace VRTK.Prefabs.Helpers.Tooltip
 {
     using UnityEngine;
-    using UnityEngine.UI;
     using Zinnia.Process;
     using Zinnia.Data.Attribute;
 


### PR DESCRIPTION
A using statement that is no longer used has been removed to clean
up the codebase.